### PR TITLE
chore: add changeset for @centient/wal v0.3.0

### DIFF
--- a/.changeset/wal-v0.3.0-improvements.md
+++ b/.changeset/wal-v0.3.0-improvements.md
@@ -1,0 +1,14 @@
+---
+"@centient/wal": minor
+---
+
+Add mutex serialization, atomic writes, dead-letter support, and auto-confirm
+
+- Per-path mutex serialization for confirmEntry and compactWal to prevent TOCTOU races
+- Atomic file writes via temp-file-then-rename for crash safety
+- Dead-letter support with configurable maxRetries and WAL_MAX_RETRIES env var
+- Auto-confirm option on appendEntry for fire-and-forget entries
+- cleanupOrphanedTempFiles() for startup cleanup with symlink protection
+- Structured logging throughout replay.ts
+- 63 tests covering all features, error paths, and edge cases
+- README.md with full API documentation


### PR DESCRIPTION
## Summary

- Adds a changeset for the `@centient/wal` minor bump (0.2.0 → 0.3.0)
- Covers all improvements merged in #3: mutex, atomic writes, dead-letter, auto-confirm

## What happens next

1. Merge this PR
2. Release CI runs `changesets version` → opens a "Version Packages" PR bumping `package.json` to 0.3.0 and writing `CHANGELOG.md`
3. Merge that PR → release CI runs `changesets publish` → `@centient/wal@0.3.0` published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)