### PR TITLE
chore: add build summary to make check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/release-toolkit"]
+	path = scripts/release-toolkit
+	url = https://github.com/centient-labs/release-toolkit.git

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+TOOLKIT := scripts/release-toolkit/lib
+SUMMARY := . $(TOOLKIT)/common.sh && . $(TOOLKIT)/summary.sh
+
 .DEFAULT_GOAL := help
 
 .PHONY: help install build lint test check clean publish
@@ -6,20 +9,21 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install dependencies
-	pnpm install --frozen-lockfile
+	@$(SUMMARY) && run_summarized generic "pnpm install --frozen-lockfile" .logs/install.log
 
 build: ## Build all packages
-	pnpm run build
+	@$(SUMMARY) && run_summarized tsc "pnpm run build" .logs/build.log
 
 lint: ## Lint and typecheck
-	pnpm run lint
+	@$(SUMMARY) && run_summarized tsc "pnpm run lint" .logs/lint.log
 
 test: ## Run tests
-	pnpm run test
+	@$(SUMMARY) && run_summarized vitest "pnpm run test" .logs/test.log
 
 check: lint test ## Run full CI gate (lint + test)
 
 clean: ## Remove build artifacts
+	@rm -rf .logs
 	pnpm run clean
 
 publish: build check ## Publish to npm via changesets
@@ -27,3 +31,6 @@ publish: build check ## Publish to npm via changesets
 	git add -A && git commit -m "chore: version packages"
 	pnpm changeset publish
 	git push origin main --tags
+
+# Changelog
+# 2026-04-04  Add build summary (run_summarized via release-toolkit)


### PR DESCRIPTION
## Summary
- Add release-toolkit as git submodule
- Wrap build/lint/test in `run_summarized` for clean `make check` output
- Add `.logs/` to `.gitignore`
- Add Makefile changelog

## Test plan
- [ ] `make check` produces clean summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)