### PR TITLE
fix: update npm metadata for all @centient/* packages

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,13 +1,17 @@
 # @centient/logger
 
-Shared structured logging infrastructure for Engram packages. Provides structured logging with transport abstraction, context management, path/data sanitization, and audit event logging.
+Structured logging infrastructure for Centient packages. Provides structured logging with transport abstraction, context management, path/data sanitization, and audit event logging.
 
 ## Installation
 
-This is a private monorepo package. Add it as a workspace dependency:
+```bash
+npm install @centient/logger
+```
+
+Or with pnpm:
 
 ```bash
-pnpm add @centient/logger --workspace
+pnpm add @centient/logger
 ```
 
 ## Quick Start
@@ -378,4 +382,4 @@ interface LogEntry {
 
 ## License
 
-UNLICENSED - Private package
+MIT

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@centient/logger",
   "version": "0.16.0",
-  "description": "Shared structured logging infrastructure for Engram packages",
+  "description": "Structured logging infrastructure for Centient packages",
   "repository": {
     "type": "git",
-    "url": "https://github.com/centient-labs/engram-sdk",
+    "url": "git+https://github.com/centient-labs/centient-sdk.git",
     "directory": "packages/logger"
   },
+  "bugs": {
+    "url": "https://github.com/centient-labs/centient-sdk/issues"
+  },
+  "homepage": "https://github.com/centient-labs/centient-sdk/tree/main/packages/logger#readme",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,12 +30,11 @@
     "clean": "rm -rf dist"
   },
   "keywords": [
+    "centient",
     "logging",
-    "structured-logging",
-    "audit",
-    "engram"
+    "structured-logging"
   ],
-  "author": "Stephen Szermer",
+  "author": "Owen Johnson",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,68 @@
+# @centient/sdk
+
+TypeScript SDK for Centient -- AI agent memory and context engineering infrastructure.
+
+## Installation
+
+```bash
+npm install @centient/sdk
+```
+
+Or with pnpm:
+
+```bash
+pnpm add @centient/sdk
+```
+
+## Quick Start
+
+```typescript
+import { EngramClient, createEngramClient } from "@centient/sdk";
+
+// Create client from environment variables
+const client = createEngramClient();
+
+// Or with explicit config
+const client = new EngramClient({
+  baseUrl: "http://localhost:3100",
+  apiKey: "your-api-key",
+});
+
+// Create a session
+const session = await client.createSession({
+  sessionId: "2026-01-17-feature-work",
+  projectPath: "/path/to/project",
+  embeddingPreset: "balanced",
+});
+
+// Save notes
+await client.createNote(session.id, {
+  type: "decision",
+  content: "Using PostgreSQL with RLS for multi-tenant data isolation",
+});
+
+// Search session memory
+const results = await client.search(session.id, {
+  query: "database security",
+  limit: 5,
+});
+```
+
+## Features
+
+- 13+ resource classes covering sessions, notes, crystals, entities, search, and more
+- 95+ fully typed request/response interfaces
+- Factory function `createEngramClient()` for quick setup
+- Session coordination (constraints, decision points, branches)
+- Knowledge crystal management with hierarchy and versioning
+- Entity extraction and graph queries
+- Real-time event streaming
+- Export/import with conflict resolution
+
+## Documentation
+
+See the [centient-sdk monorepo](https://github.com/centient-labs/centient-sdk) for full documentation.
+
+## License
+
+MIT

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@centient/sdk",
   "version": "1.3.0",
-  "description": "TypeScript SDK for Engram Memory Server",
+  "description": "TypeScript SDK for Centient — AI agent memory and context engineering infrastructure",
   "repository": {
     "type": "git",
-    "url": "https://github.com/centient-labs/engram-sdk",
+    "url": "git+https://github.com/centient-labs/centient-sdk.git",
     "directory": "packages/sdk"
   },
+  "bugs": {
+    "url": "https://github.com/centient-labs/centient-sdk/issues"
+  },
+  "homepage": "https://github.com/centient-labs/centient-sdk/tree/main/packages/sdk#readme",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,13 +35,12 @@
     "clean": "rm -rf dist"
   },
   "keywords": [
-    "engram",
+    "centient",
     "sdk",
     "typescript",
     "memory",
     "ai-agents",
-    "qdrant",
-    "embeddings"
+    "mcp"
   ],
   "author": "Owen Johnson",
   "license": "MIT",

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -1,0 +1,70 @@
+# @centient/secrets
+
+Cross-platform secrets vault with AES-256-GCM encryption and platform-native key storage.
+
+## Installation
+
+```bash
+npm install @centient/secrets
+```
+
+Or with pnpm:
+
+```bash
+pnpm add @centient/secrets
+```
+
+## Features
+
+- AES-256-GCM authenticated encryption for secrets at rest
+- Platform-native key storage (macOS Keychain, Linux secret-service)
+- Pluggable key providers (Keychain, 1Password)
+- Credential vault with session management
+- Environment detection (CI, Docker, SSH, headless, agent)
+- Built-in CLI for interactive secret management
+
+## Quick Start
+
+```typescript
+import { storeCredential, getCredential, deleteCredential } from "@centient/secrets";
+
+// Store a credential
+await storeCredential("my-service", "api-key", "sk-abc123");
+
+// Retrieve it
+const value = await getCredential("my-service", "api-key");
+
+// Delete when no longer needed
+await deleteCredential("my-service", "api-key");
+```
+
+### Encryption Utilities
+
+```typescript
+import { encrypt, decrypt } from "@centient/secrets";
+
+const key = crypto.randomBytes(32);
+const encrypted = encrypt("sensitive data", key);
+const decrypted = decrypt(encrypted, key);
+```
+
+### Platform Detection
+
+```typescript
+import { isCIEnvironment, isDockerContainer, isAgentEnvironment } from "@centient/secrets";
+
+if (isCIEnvironment()) {
+  // Use environment variable fallback
+}
+```
+
+## Key Providers
+
+| Provider | Platform | Description |
+|----------|----------|-------------|
+| `KeychainProvider` | macOS/Linux | Uses OS keychain (Keychain Access / secret-service) |
+| `OnePasswordProvider` | Any | Uses 1Password CLI for team secret sharing |
+
+## License
+
+MIT

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -2,6 +2,24 @@
   "name": "@centient/secrets",
   "version": "0.3.0",
   "description": "Cross-platform secrets vault with AES-256-GCM encryption and platform-native key storage",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/centient-labs/centient-sdk.git",
+    "directory": "packages/secrets"
+  },
+  "bugs": {
+    "url": "https://github.com/centient-labs/centient-sdk/issues"
+  },
+  "homepage": "https://github.com/centient-labs/centient-sdk/tree/main/packages/secrets#readme",
+  "author": "Owen Johnson",
+  "keywords": [
+    "centient",
+    "secrets",
+    "vault",
+    "encryption",
+    "aes-256-gcm",
+    "keychain"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,7 +46,8 @@
     "vitest": "^4.0.17"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "engines": {
     "node": ">=18.0.0"

--- a/packages/wal/package.json
+++ b/packages/wal/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@centient/wal",
   "version": "0.3.0",
-  "description": "Shared Write-Ahead Log (WAL) for crash recovery across Engram packages",
+  "description": "Write-Ahead Log (WAL) for crash recovery across Centient packages",
   "repository": {
     "type": "git",
-    "url": "https://github.com/centient-labs/engram-sdk",
+    "url": "git+https://github.com/centient-labs/centient-sdk.git",
     "directory": "packages/wal"
   },
+  "bugs": {
+    "url": "https://github.com/centient-labs/centient-sdk/issues"
+  },
+  "homepage": "https://github.com/centient-labs/centient-sdk/tree/main/packages/wal#readme",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,12 +30,12 @@
     "clean": "rm -rf dist"
   },
   "keywords": [
+    "centient",
     "wal",
     "write-ahead-log",
-    "crash-recovery",
-    "engram"
+    "crash-recovery"
   ],
-  "author": "Stephen Szermer",
+  "author": "Owen Johnson",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes empty npm pages and stale metadata. Updates descriptions, adds repository/bugs/homepage URLs, fixes logger README install instructions, adds keywords to secrets.