### PR TITLE
chore: add session management protocol

### DIFF
--- a/.agent/procedures/session-management.md
+++ b/.agent/procedures/session-management.md
@@ -1,0 +1,60 @@
+# Session & Knowledge Management
+
+Protocol for using the centient knowledge management system. The centient MCP server (`mcp__centient__*`) provides session memory and a cross-project knowledge graph. Consistent use prevents duplicate work, preserves context, and enables cross-project learning.
+
+## Tool Reference
+
+### Session Lifecycle
+
+| Tool | When | Purpose |
+|------|------|---------|
+| `start_session_coordination` | Session start | Initialize session memory, optionally seed with related knowledge |
+| `save_session_note` | During work | Record decisions, findings, blockers, hypotheses |
+| `finalize_session_coordination` | Session end | Persist session artifacts to knowledge graph |
+
+### Knowledge Search
+
+| Tool | When | Purpose |
+|------|------|---------|
+| `search_crystals` | Before starting work | Find prior decisions, patterns, and related work |
+| `check_duplicate_work` | Before implementing | Detect if similar work was done in another session |
+| `search_artifacts` | When looking for specific outputs | Find code, docs, or other artifacts from past sessions |
+
+### Context Monitoring
+
+| Tool | When | Purpose |
+|------|------|---------|
+| `get_context_health` | Periodically | Check context window capacity |
+| `get_session_summary` | Mid-session | Review what's been captured so far |
+| `get_session_drift` | When focus shifts | Detect topic drift from original session goal |
+
+## Parameters
+
+### start_session_coordination
+
+```
+sessionId:    "YYYY-MM-DD-topic" (e.g., "2026-04-07-auth-refactor")
+projectPath:  Absolute path to project directory
+seedTopic:    Optional keyword to pre-load related knowledge
+```
+
+### save_session_note
+
+```
+note:   Free-text description of the decision, finding, or blocker
+tags:   Array of keywords for future searchability
+```
+
+### search_crystals
+
+```
+query:  Natural language description of what you're looking for
+mode:   "hybrid" (default), "semantic", or "keyword"
+limit:  Number of results (default: 10)
+```
+
+## When NOT to Use
+
+- **Trivial tasks**: Quick typo fixes, single-line changes — no session needed
+- **Tools unavailable**: If `mcp__centient__*` tools aren't in the tool list, skip silently
+- **Read-only exploration**: Browsing code without making changes — search is still useful, but session lifecycle is optional

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,17 @@ See `.agent/DESIGN-PHILOSOPHY.md` for the 14 principles (3 tiers) that guide all
 
 - See `.agent/procedures/commits.md` for full commit workflow.
 
+## Session & Knowledge Management
+
+This project participates in the centient knowledge management system. When `mcp__centient__*` tools are available, **always initialize a session at the start of every conversation** and use knowledge tools throughout:
+
+1. **Always start a session** — Call `start_session_coordination` with `sessionId` (format: `YYYY-MM-DD-topic`) and `projectPath` before doing any work
+2. **Search first** — Call `search_crystals` with your task topic to find prior work and decisions
+3. **Check duplicates** — Call `check_duplicate_work` before implementing non-trivial changes
+4. **Save knowledge** — Call `save_session_note` for important decisions, findings, and blockers
+5. **End** — Call `finalize_session_coordination` to persist session artifacts
+
+See `.agent/procedures/session-management.md` for tool parameters and additional tools.
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.agent/procedures/session-management.md` with centient knowledge system protocol
- Add "Session & Knowledge Management" section to CLAUDE.md instructing agents to always initialize a session

This ensures agents automatically use the centient MCP tools (`start_session_coordination`, `search_crystals`, `save_session_note`, etc.) for cross-session knowledge management.

Canonical source: `support/standards/session-management.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)