### PR TITLE
feat(sdk): engram-server v0.22.4 parity

### DIFF
--- a/.agent/procedures/session-management.md
+++ b/.agent/procedures/session-management.md
@@ -1,0 +1,60 @@
+# Session & Knowledge Management
+
+Protocol for using the centient knowledge management system. The centient MCP server (`mcp__centient__*`) provides session memory and a cross-project knowledge graph. Consistent use prevents duplicate work, preserves context, and enables cross-project learning.
+
+## Tool Reference
+
+### Session Lifecycle
+
+| Tool | When | Purpose |
+|------|------|---------|
+| `start_session_coordination` | Session start | Initialize session memory, optionally seed with related knowledge |
+| `save_session_note` | During work | Record decisions, findings, blockers, hypotheses |
+| `finalize_session_coordination` | Session end | Persist session artifacts to knowledge graph |
+
+### Knowledge Search
+
+| Tool | When | Purpose |
+|------|------|---------|
+| `search_crystals` | Before starting work | Find prior decisions, patterns, and related work |
+| `check_duplicate_work` | Before implementing | Detect if similar work was done in another session |
+| `search_artifacts` | When looking for specific outputs | Find code, docs, or other artifacts from past sessions |
+
+### Context Monitoring
+
+| Tool | When | Purpose |
+|------|------|---------|
+| `get_context_health` | Periodically | Check context window capacity |
+| `get_session_summary` | Mid-session | Review what's been captured so far |
+| `get_session_drift` | When focus shifts | Detect topic drift from original session goal |
+
+## Parameters
+
+### start_session_coordination
+
+```
+sessionId:    "YYYY-MM-DD-topic" (e.g., "2026-04-07-auth-refactor")
+projectPath:  Absolute path to project directory
+seedTopic:    Optional keyword to pre-load related knowledge
+```
+
+### save_session_note
+
+```
+note:   Free-text description of the decision, finding, or blocker
+tags:   Array of keywords for future searchability
+```
+
+### search_crystals
+
+```
+query:  Natural language description of what you're looking for
+mode:   "hybrid" (default), "semantic", or "keyword"
+limit:  Number of results (default: 10)
+```
+
+## When NOT to Use
+
+- **Trivial tasks**: Quick typo fixes, single-line changes — no session needed
+- **Tools unavailable**: If `mcp__centient__*` tools aren't in the tool list, skip silently
+- **Read-only exploration**: Browsing code without making changes — search is still useful, but session lifecycle is optional

--- a/.changeset/sdk-v2-server-parity.md
+++ b/.changeset/sdk-v2-server-parity.md
@@ -1,0 +1,35 @@
+---
+"@centient/sdk": minor
+---
+
+**Breaking changes:**
+- `SyncStatus` type export renamed to `TerrafirmaSyncStatus` (from terrafirma module) to avoid collision with new `SyncStatus` type from the sync module. Update imports: `import type { TerrafirmaSyncStatus } from "@centient/sdk"`
+- `NodeType` union expanded with `"system"` and `"memory_space"` — exhaustive switch statements will need updating
+- `KnowledgeCrystal` interface has 6 new required fields (`lifecycleStatus`, `lastAccessedAt`, `accessCount`, `relevanceScore`, `archivedAt`, `deletedAt`)
+- `KnowledgeCrystalEdge` interface has 3 new required fields (`weight`, `updatedAt`, `deletedAt`)
+
+Full parity with engram-server v0.22.4.
+
+**New resources:** Facts, MemorySpaces, Users, Audit, Sync (with Peers sub-resource), GC, Maintenance — 7 new resource classes bringing the total to 20.
+
+**Type expansions:**
+- NodeType: added `system` and `memory_space` (12 → 14 values)
+- KnowledgeCrystal: added `lifecycleStatus`, `lastAccessedAt`, `accessCount`, `relevanceScore`, `archivedAt`, `deletedAt`
+- KnowledgeCrystalEdge: added `supports` relationship, `weight`, `updatedAt`, `deletedAt` fields
+- MembershipAddedBy: added `terrafirma`, `consolidation`
+- Session note edge relationships: added `supports`, `contradicts`, `extends`
+- SearchKnowledgeCrystalsParams: added `fulltext` search mode
+
+**Create/Update params:**
+- CreateKnowledgeCrystalParams: added `id`, `contentRef` (ContentRef object), `coherenceMode`
+- UpdateKnowledgeCrystalParams: added `contentRef`
+- ListKnowledgeCrystalsParams: added `sourceSessionId` filter
+
+**New methods on existing resources:**
+- `crystals.items(id).bulkAdd()` and `reorder()`
+- `sessions.getLifecycleStats()`
+- `entities.graph()` for multi-hop traversal
+
+**Server compatibility:**
+- Added `MIN_SERVER_VERSION` constant (`0.22.0`)
+- Added `client.checkCompatibility()` method

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ See `.agent/DESIGN-PHILOSOPHY.md` for the 14 principles (3 tiers) that guide all
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| `@centient/sdk` | 1.3.0 | TypeScript SDK for Engram Memory Server REST API. 13 resource classes, 95+ types. Factory: `createEngramClient()` |
+| `@centient/sdk` | 1.4.0 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types. Factory: `createEngramClient()`. Requires engram-server >= 0.22.4 |
 | `@centient/logger` | 0.16.0 | Structured logging with transport abstraction. 6 levels, Console/File/Null transports, audit events, data redaction. Factory: `createLogger()`, `createAuditWriter()` |
 | `@centient/wal` | 0.2.0 | Write-ahead log for crash recovery. `appendEntry`, `confirmEntry`, `replayUnconfirmed`, `compactWal` |
 | `sdk-python` | - | Python SDK client with Pydantic v2 (async + sync) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,17 @@ See `.agent/DESIGN-PHILOSOPHY.md` for the 14 principles (3 tiers) that guide all
 
 - See `.agent/procedures/commits.md` for full commit workflow.
 
+## Session & Knowledge Management
+
+This project participates in the centient knowledge management system. When `mcp__centient__*` tools are available, **always initialize a session at the start of every conversation** and use knowledge tools throughout:
+
+1. **Always start a session** — Call `start_session_coordination` with `sessionId` (format: `YYYY-MM-DD-topic`) and `projectPath` before doing any work
+2. **Search first** — Call `search_crystals` with your task topic to find prior work and decisions
+3. **Check duplicates** — Call `check_duplicate_work` before implementing non-trivial changes
+4. **Save knowledge** — Call `save_session_note` for important decisions, findings, and blockers
+5. **End** — Call `finalize_session_coordination` to persist session artifacts
+
+See `.agent/procedures/session-management.md` for tool parameters and additional tools.
 ## Common Commands
 
 ```bash

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -10,7 +10,7 @@ import {
   TimeoutError,
   parseApiError,
 } from "./errors.js";
-import { SessionsResource, NotesResource, EdgesResource, SessionLinksResource, CrystalsResource, TerrafirmaResource, ExportImportResource, EntitiesResource, ExtractionResource, EventsResource, AgentsResource, AmbientContextResource } from "./resources/index.js";
+import { SessionsResource, NotesResource, EdgesResource, SessionLinksResource, CrystalsResource, TerrafirmaResource, ExportImportResource, EntitiesResource, ExtractionResource, EventsResource, AgentsResource, AmbientContextResource, FactsResource, MemorySpacesResource, UsersResource, AuditResource, SyncResource, GcResource, MaintenanceResource } from "./resources/index.js";
 import type {
   AddRelationshipRequest,
   AddRelationshipResponse,
@@ -174,6 +174,12 @@ const DEFAULT_RETRIES = 3;
 const DEFAULT_RETRY_DELAY = 1000;
 
 /**
+ * Minimum engram-server version required by this SDK.
+ * Use `client.checkCompatibility()` to verify at runtime.
+ */
+export const MIN_SERVER_VERSION = "0.22.4";
+
+/**
  * Engram Memory Server Client
  *
  * @example
@@ -277,6 +283,41 @@ export class EngramClient {
    */
   public readonly ambientContext: AmbientContextResource;
 
+  /**
+   * Resource-based access to bi-temporal facts.
+   */
+  public readonly facts: FactsResource;
+
+  /**
+   * Resource-based access to multi-agent shared memory spaces (P17).
+   */
+  public readonly memorySpaces: MemorySpacesResource;
+
+  /**
+   * Resource-based access to user management.
+   */
+  public readonly users: UsersResource;
+
+  /**
+   * Resource-based access to audit event ingestion and querying.
+   */
+  public readonly audit: AuditResource;
+
+  /**
+   * Resource-based access to instance-to-instance sync (ADR-011).
+   */
+  public readonly sync: SyncResource;
+
+  /**
+   * Resource-based access to garbage collection.
+   */
+  public readonly gc: GcResource;
+
+  /**
+   * Resource-based access to database maintenance operations.
+   */
+  public readonly maintenance: MaintenanceResource;
+
   constructor(config: EngramClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, ""); // Remove trailing slash
     this.apiKey = config.apiKey;
@@ -298,6 +339,40 @@ export class EngramClient {
     this.events = new EventsResource(this);
     this.agents = new AgentsResource(this);
     this.ambientContext = new AmbientContextResource(this);
+    this.facts = new FactsResource(this);
+    this.memorySpaces = new MemorySpacesResource(this);
+    this.users = new UsersResource(this);
+    this.audit = new AuditResource(this);
+    this.sync = new SyncResource(this);
+    this.gc = new GcResource(this);
+    this.maintenance = new MaintenanceResource(this);
+  }
+
+  /**
+   * Check if the connected server meets the minimum version requirement.
+   * Calls /health and compares the returned version against MIN_SERVER_VERSION.
+   */
+  async checkCompatibility(): Promise<{
+    compatible: boolean;
+    serverVersion: string;
+    minRequired: string;
+  }> {
+    const health = await this.request<{ version?: string }>("GET", "/health");
+    const serverVersion = health.version ?? "unknown";
+    const compatible =
+      serverVersion !== "unknown" &&
+      this.isVersionGte(serverVersion, MIN_SERVER_VERSION);
+    return { compatible, serverVersion, minRequired: MIN_SERVER_VERSION };
+  }
+
+  private isVersionGte(actual: string, required: string): boolean {
+    const parse = (v: string) => v.split(".").map(s => parseInt(s, 10));
+    const [aMaj = 0, aMin = 0, aPat = 0] = parse(actual);
+    const [rMaj = 0, rMin = 0, rPat = 0] = parse(required);
+    if ([aMaj, aMin, aPat].some(isNaN)) return false;
+    if (aMaj !== rMaj) return aMaj > rMaj;
+    if (aMin !== rMin) return aMin > rMin;
+    return aPat >= rPat;
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -136,7 +136,7 @@ export {
   TerrafirmaMigrationsResource,
   type TerrafirmaMode,
   type ProcessStatus,
-  type SyncStatus,
+  type TerrafirmaSyncStatus,
   type MigrationStatus,
   type SyncScope,
   type TerrafirmaWatcherStatus,
@@ -180,7 +180,62 @@ export {
   type ExtractionConfig,
   type ListEntitiesParams,
   type ExtractParams,
+  // Facts resource (bi-temporal facts)
+  FactsResource,
+  type Fact,
+  type CreateFactParams,
+  type UpdateFactParams,
+  type FactHistoryParams,
+  // Memory spaces resource (P17 multi-agent shared memory)
+  MemorySpacesResource,
+  type MemorySpacePermission,
+  type MemorySpace,
+  type MemorySpaceWithMembers,
+  type MemorySpaceMember,
+  type CreateMemorySpaceParams,
+  type ListMemorySpacesParams,
+  type JoinMemorySpaceParams,
+  // Users resource
+  UsersResource,
+  type User,
+  type ApiKey,
+  type CreateUserParams,
+  // Audit resource
+  AuditResource,
+  type AuditLevel,
+  type AuditOutcome,
+  type AuditEventType,
+  type AuditEvent,
+  type IngestEventParams,
+  type ListAuditEventsParams,
+  type AuditStats,
+  // Sync resource (ADR-011 instance-to-instance sync)
+  SyncResource,
+  SyncPeersResource,
+  type SyncPeer,
+  type SyncConflict,
+  type SyncStatus,
+  type CreatePeerParams,
+  type SyncPullParams,
+  type SyncPushResult,
+  type ListConflictsParams,
+  type SyncChange,
+  // GC resource
+  GcResource,
+  type GcCandidate,
+  type GcAuditEntry,
+  type GcRunResult,
+  type ListGcCandidatesParams,
+  type ListGcAuditParams,
+  // Maintenance resource
+  MaintenanceResource,
+  type MaintenanceParams,
+  type TombstoneCleanupResult,
+  type ChangelogCompactResult,
 } from "./resources/index.js";
+
+// Server version compatibility
+export { MIN_SERVER_VERSION } from "./client.js";
 
 // Unified Knowledge Crystal Types (ADR-055 — primary)
 export type {

--- a/packages/sdk/src/resources/audit.ts
+++ b/packages/sdk/src/resources/audit.ts
@@ -1,0 +1,254 @@
+/**
+ * Audit Resource
+ *
+ * Resource-based SDK interface for audit event ingestion, querying, and management.
+ * Designed for engram Knowledge API.
+ */
+
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type AuditLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+export type AuditOutcome = "success" | "failure" | "partial";
+export type AuditEventType =
+  | "pattern_search"
+  | "pattern_load"
+  | "pattern_find"
+  | "pattern_sign"
+  | "skill_execute"
+  | "pattern_index"
+  | "pattern_version_create"
+  | "pattern_version_deprecate"
+  | "artifact_search"
+  | "artifact_load"
+  | "artifact_code_extract"
+  | "session_start"
+  | "session_note"
+  | "session_search"
+  | "session_finalize"
+  | "research_plan"
+  | "consultation"
+  | "branch_create"
+  | "branch_close"
+  | "tool_call";
+
+export interface AuditEvent {
+  id: string;
+  timestamp: string;
+  level: AuditLevel;
+  component: string;
+  message: string;
+  service?: string;
+  version?: string;
+  pid?: number;
+  hostname?: string;
+  eventType?: AuditEventType;
+  tool?: string;
+  outcome?: AuditOutcome;
+  durationMs?: number;
+  projectPath?: string;
+  sessionId?: string;
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IngestEventParams {
+  timestamp?: string;
+  level: AuditLevel;
+  component: string;
+  message: string;
+  service?: string;
+  version?: string;
+  pid?: number;
+  hostname?: string;
+  eventType?: AuditEventType;
+  tool?: string;
+  outcome?: AuditOutcome;
+  durationMs?: number;
+  projectPath?: string;
+  sessionId?: string;
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ListAuditEventsParams {
+  level?: AuditLevel | AuditLevel[];
+  component?: string;
+  eventType?: AuditEventType | AuditEventType[];
+  tool?: string;
+  outcome?: AuditOutcome;
+  projectPath?: string;
+  sessionId?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditStats {
+  totalEvents: number;
+  eventsByType: Record<string, number>;
+  eventsByLevel: Record<string, number>;
+  recentActivity: Array<{ date: string; count: number }>;
+}
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// Audit Resource
+// ============================================================================
+
+/**
+ * Audit Resource - ingestion, querying, and management of audit events
+ */
+export class AuditResource extends BaseResource {
+  /**
+   * Ingest a single audit event
+   */
+  async ingest(event: IngestEventParams): Promise<{ accepted: true }> {
+    const response = await this.request<ApiSuccessResponse<{ accepted: true }>>(
+      "POST",
+      "/v1/audit/ingest",
+      event
+    );
+    return response.data;
+  }
+
+  /**
+   * Ingest a batch of audit events
+   */
+  async ingestBatch(events: IngestEventParams[]): Promise<{ accepted: number }> {
+    const response = await this.request<ApiSuccessResponse<{ accepted: number }>>(
+      "POST",
+      "/v1/audit/ingest/batch",
+      { events }
+    );
+    return response.data;
+  }
+
+  /**
+   * Flush buffered audit events to persistent storage
+   */
+  async flush(): Promise<{ flushed: true }> {
+    const response = await this.request<ApiSuccessResponse<{ flushed: true }>>(
+      "POST",
+      "/v1/audit/flush"
+    );
+    return response.data;
+  }
+
+  /**
+   * List audit events with optional filters
+   */
+  async listEvents(params?: ListAuditEventsParams): Promise<{
+    events: AuditEvent[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const query = new URLSearchParams();
+
+    if (params?.level) {
+      const levels = Array.isArray(params.level)
+        ? params.level.join(",")
+        : params.level;
+      query.set("level", levels);
+    }
+    if (params?.component) query.set("component", params.component);
+    if (params?.eventType) {
+      const eventTypes = Array.isArray(params.eventType)
+        ? params.eventType.join(",")
+        : params.eventType;
+      query.set("eventType", eventTypes);
+    }
+    if (params?.tool) query.set("tool", params.tool);
+    if (params?.outcome) query.set("outcome", params.outcome);
+    if (params?.projectPath) query.set("projectPath", params.projectPath);
+    if (params?.sessionId) query.set("sessionId", params.sessionId);
+    if (params?.since) query.set("since", params.since);
+    if (params?.until) query.set("until", params.until);
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+
+    const queryString = query.toString();
+    const path = `/v1/audit/events${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<AuditEvent[]>>(
+      "GET",
+      path
+    );
+
+    return {
+      events: response.data,
+      total: response.meta?.pagination?.total ?? response.data.length,
+      hasMore: response.meta?.pagination?.hasMore ?? false,
+    };
+  }
+
+  /**
+   * Get a single audit event by ID
+   */
+  async getEvent(id: string): Promise<AuditEvent> {
+    const response = await this.request<ApiSuccessResponse<AuditEvent>>(
+      "GET",
+      `/v1/audit/events/${encodeURIComponent(id)}`
+    );
+    return response.data;
+  }
+
+  /**
+   * Get aggregate audit statistics
+   */
+  async getStats(params?: { since?: string; until?: string }): Promise<AuditStats> {
+    const query = new URLSearchParams();
+
+    if (params?.since) query.set("since", params.since);
+    if (params?.until) query.set("until", params.until);
+
+    const queryString = query.toString();
+    const path = `/v1/audit/stats${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<AuditStats>>(
+      "GET",
+      path
+    );
+    return response.data;
+  }
+
+  /**
+   * Prune audit events older than the specified number of days
+   */
+  async prune(olderThanDays: number): Promise<{ deleted: number }> {
+    const query = new URLSearchParams();
+    query.set("olderThanDays", String(olderThanDays));
+
+    const qs = query.toString();
+    const path = `/v1/audit/prune${qs ? `?${qs}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<{ deleted: number }>>(
+      "DELETE",
+      path
+    );
+    return response.data;
+  }
+}

--- a/packages/sdk/src/resources/crystals.ts
+++ b/packages/sdk/src/resources/crystals.ts
@@ -118,6 +118,29 @@ export class CrystalItemsResource extends BaseResource {
       `/v1/crystals/${encodeURIComponent(this.crystalId)}/items/${encodeURIComponent(itemId)}`
     );
   }
+
+  /**
+   * Bulk add items to the crystal
+   */
+  async bulkAdd(items: Array<{ itemId: string; position?: number }>): Promise<{ added: number }> {
+    const response = await this.request<ApiSuccessResponse<{ added: number }>>(
+      "POST",
+      `/v1/crystals/${encodeURIComponent(this.crystalId)}/items/bulk`,
+      { items }
+    );
+    return response.data;
+  }
+
+  /**
+   * Reorder items in the crystal
+   */
+  async reorder(itemIds: string[]): Promise<void> {
+    await this.request<ApiSuccessResponse<void>>(
+      "POST",
+      `/v1/crystals/${encodeURIComponent(this.crystalId)}/items/reorder`,
+      { itemIds }
+    );
+  }
 }
 
 // ============================================================================
@@ -392,9 +415,11 @@ export class CrystalsResource extends BaseResource {
    * Create a new knowledge crystal node
    */
   async create(params: CreateKnowledgeCrystalParams): Promise<KnowledgeCrystal> {
-    // Map camelCase nodeType to snake_case node_type expected by the server
-    const { nodeType, ...rest } = params;
-    const body = { ...rest, node_type: nodeType };
+    // Map camelCase fields to snake_case expected by the server
+    const { nodeType, contentRef, coherenceMode, ...rest } = params;
+    const body: Record<string, unknown> = { ...rest, node_type: nodeType };
+    if (contentRef !== undefined) body.content_ref = contentRef;
+    if (coherenceMode !== undefined) body.coherence_mode = coherenceMode;
     const response = await this.request<ApiSuccessResponse<KnowledgeCrystal>>(
       "POST",
       "/v1/crystals",
@@ -442,6 +467,9 @@ export class CrystalsResource extends BaseResource {
     if (params?.verified !== undefined) {
       query.set("verified", String(params.verified));
     }
+    if (params?.sourceSessionId) {
+      query.set("source_session_id", params.sourceSessionId);
+    }
     if (params?.sourceProject) {
       query.set("source_project", params.sourceProject);
     }
@@ -474,10 +502,14 @@ export class CrystalsResource extends BaseResource {
    * Update a knowledge crystal node
    */
   async update(id: string, params: UpdateKnowledgeCrystalParams): Promise<KnowledgeCrystal> {
+    // Map camelCase fields to snake_case expected by the server
+    const { contentRef, ...rest } = params;
+    const body: Record<string, unknown> = { ...rest };
+    if (contentRef !== undefined) body.content_ref = contentRef;
     const response = await this.request<ApiSuccessResponse<KnowledgeCrystal>>(
       "PATCH",
       `/v1/crystals/${encodeURIComponent(id)}`,
-      params
+      body
     );
     return response.data;
   }

--- a/packages/sdk/src/resources/entities.ts
+++ b/packages/sdk/src/resources/entities.ts
@@ -255,6 +255,42 @@ export class EntitiesResource extends BaseResource {
   }
 
   /**
+   * Multi-hop graph traversal from an entity node.
+   */
+  async graph(
+    id: string,
+    params?: { depth?: number; filterClass?: string; filterVerified?: boolean; minConfidence?: number }
+  ): Promise<{
+    data: {
+      root: EntityCard;
+      nodes: EntityCard[];
+      edges: Array<{ sourceId: string; targetId: string; edgeType: string; metadata: Record<string, unknown> }>;
+      totalNodes: number;
+      depth: number;
+      truncated: boolean;
+    };
+  }> {
+    const query = new URLSearchParams();
+    if (params?.depth !== undefined) query.set("depth", String(params.depth));
+    if (params?.filterClass) query.set("filter_class", params.filterClass);
+    if (params?.filterVerified !== undefined) query.set("filter_verified", String(params.filterVerified));
+    if (params?.minConfidence !== undefined) query.set("min_confidence", String(params.minConfidence));
+    const qs = query.toString();
+    const response = await this.request<ApiSuccessResponse<{
+      root: EntityCard;
+      nodes: EntityCard[];
+      edges: Array<{ sourceId: string; targetId: string; edgeType: string; metadata: Record<string, unknown> }>;
+      totalNodes: number;
+      depth: number;
+      truncated: boolean;
+    }>>(
+      "GET",
+      `/v1/entities/${encodeURIComponent(id)}/graph${qs ? `?${qs}` : ""}`
+    );
+    return { data: response.data };
+  }
+
+  /**
    * Submit a review action for an entity (merge, create new, or dismiss).
    */
   async review(

--- a/packages/sdk/src/resources/facts.ts
+++ b/packages/sdk/src/resources/facts.ts
@@ -1,0 +1,170 @@
+/**
+ * Facts Resource
+ *
+ * Resource-based SDK interface for bi-temporal fact management.
+ * Provides access to versioned facts with point-in-time queries
+ * and full version history.
+ */
+
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface Fact {
+  id: string;
+  key: string;
+  value: Record<string, unknown>;
+  validFrom: string;
+  validTo: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateFactParams {
+  key: string;
+  value: Record<string, unknown>;
+  validAt?: string;
+}
+
+export interface UpdateFactParams {
+  value: Record<string, unknown>;
+  validAt?: string;
+}
+
+export interface FactHistoryParams {
+  validFrom?: string;
+  validTo?: string;
+  limit?: number;
+  offset?: number;
+}
+
+// ============================================================================
+// API Response Types (internal)
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// Facts Resource
+// ============================================================================
+
+/**
+ * Facts Resource — manages bi-temporal facts with versioned history.
+ *
+ * @example
+ * ```typescript
+ * // Create a new fact
+ * const fact = await client.facts.create({
+ *   key: "user.preferences.theme",
+ *   value: { mode: "dark" },
+ * });
+ *
+ * // Get a fact by key
+ * const current = await client.facts.getByKey("user.preferences.theme");
+ *
+ * // Get a fact as it was at a specific point in time
+ * const historical = await client.facts.get(fact.id, {
+ *   asOf: "2025-01-15T00:00:00Z",
+ * });
+ *
+ * // Update a fact
+ * const updated = await client.facts.update(fact.id, {
+ *   value: { mode: "light" },
+ * });
+ *
+ * // Browse version history
+ * const history = await client.facts.getHistory(fact.id, { limit: 10 });
+ * ```
+ */
+export class FactsResource extends BaseResource {
+  /**
+   * Create a new fact.
+   */
+  async create(params: CreateFactParams): Promise<Fact> {
+    const response = await this.request<ApiSuccessResponse<Fact>>(
+      "POST",
+      "/v1/facts",
+      params
+    );
+    return response.data;
+  }
+
+  /**
+   * Get a fact by ID, optionally as of a specific point in time.
+   */
+  async get(id: string, options?: { asOf?: string }): Promise<Fact> {
+    const query = new URLSearchParams();
+    if (options?.asOf) query.set("asOf", options.asOf);
+
+    const queryString = query.toString();
+    const path = `/v1/facts/${encodeURIComponent(id)}${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<Fact>>("GET", path);
+    return response.data;
+  }
+
+  /**
+   * Get a fact by its key.
+   */
+  async getByKey(key: string): Promise<Fact> {
+    const query = new URLSearchParams();
+    query.set("key", key);
+
+    const path = `/v1/facts?${query.toString()}`;
+
+    const response = await this.request<ApiSuccessResponse<Fact>>("GET", path);
+    return response.data;
+  }
+
+  /**
+   * Update an existing fact.
+   */
+  async update(id: string, params: UpdateFactParams): Promise<Fact> {
+    const response = await this.request<ApiSuccessResponse<Fact>>(
+      "PATCH",
+      `/v1/facts/${encodeURIComponent(id)}`,
+      params
+    );
+    return response.data;
+  }
+
+  /**
+   * Get the version history of a fact.
+   */
+  async getHistory(
+    id: string,
+    params?: FactHistoryParams
+  ): Promise<{ versions: Fact[]; total: number; hasMore: boolean }> {
+    const query = new URLSearchParams();
+    if (params?.validFrom) query.set("validFrom", params.validFrom);
+    if (params?.validTo) query.set("validTo", params.validTo);
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+
+    const queryString = query.toString();
+    const path = `/v1/facts/${encodeURIComponent(id)}/history${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<Fact[]>>(
+      "GET",
+      path
+    );
+
+    return {
+      versions: response.data,
+      total: response.meta?.pagination?.total ?? response.data.length,
+      hasMore: response.meta?.pagination?.hasMore ?? false,
+    };
+  }
+}

--- a/packages/sdk/src/resources/gc.ts
+++ b/packages/sdk/src/resources/gc.ts
@@ -1,0 +1,152 @@
+/**
+ * GC (Garbage Collection) Resource
+ *
+ * Resource-based SDK interface for knowledge garbage collection operations.
+ * Designed for engram Knowledge API.
+ */
+
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface GcCandidate {
+  id: string;
+  title: string;
+  nodeType: string;
+  relevanceScore: number;
+  accessCount: number;
+  lastAccessedAt: string | null;
+  createdAt: string;
+  verified: boolean;
+  lifecycleStatus: string;
+}
+
+export interface GcAuditEntry {
+  id: string;
+  runAt: string;
+  decayCurve: string;
+  threshold: number;
+  scannedCrystals: number;
+  archivedCrystals: number;
+  scannedNotes: number;
+  archivedNotes: number;
+  dryRun: boolean;
+  details: Record<string, unknown>;
+}
+
+export interface GcRunResult {
+  scannedCrystals: number;
+  archivedCrystals: number;
+  scannedNotes: number;
+  archivedNotes: number;
+  dryRun: boolean;
+}
+
+export interface ListGcCandidatesParams {
+  threshold?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListGcAuditParams {
+  limit?: number;
+  offset?: number;
+}
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// GC Resource
+// ============================================================================
+
+/** GC Resource — garbage collection candidates, audit log, and manual run trigger. */
+export class GcResource extends BaseResource {
+  /**
+   * List garbage collection candidates ranked by relevance score
+   */
+  async getCandidates(params?: ListGcCandidatesParams): Promise<{
+    candidates: GcCandidate[];
+    threshold: number;
+    total: number;
+    hasMore: boolean;
+  }> {
+    const query = new URLSearchParams();
+
+    if (params?.threshold !== undefined) query.set("threshold", String(params.threshold));
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+
+    const queryString = query.toString();
+    const path = `/v1/gc/candidates${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<{
+      candidates: GcCandidate[];
+      threshold: number;
+      total: number;
+    }>>(
+      "GET",
+      path
+    );
+    return {
+      ...response.data,
+      hasMore: response.meta?.pagination?.hasMore ?? false,
+    };
+  }
+
+  /**
+   * Get the GC audit log of previous runs
+   */
+  async getAuditLog(params?: ListGcAuditParams): Promise<{
+    entries: GcAuditEntry[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const query = new URLSearchParams();
+
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+
+    const queryString = query.toString();
+    const path = `/v1/gc/audit${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<{
+      entries: GcAuditEntry[];
+      total: number;
+    }>>(
+      "GET",
+      path
+    );
+    return {
+      ...response.data,
+      hasMore: response.meta?.pagination?.hasMore ?? false,
+    };
+  }
+
+  /**
+   * Run garbage collection, optionally as a dry run
+   */
+  async run(options?: { dryRun?: boolean }): Promise<GcRunResult> {
+    const response = await this.request<ApiSuccessResponse<GcRunResult>>(
+      "POST",
+      "/v1/gc/run",
+      options
+    );
+    return response.data;
+  }
+}

--- a/packages/sdk/src/resources/index.ts
+++ b/packages/sdk/src/resources/index.ts
@@ -139,7 +139,7 @@ export {
   TerrafirmaMigrationsResource,
   type TerrafirmaMode,
   type ProcessStatus,
-  type SyncStatus,
+  type SyncStatus as TerrafirmaSyncStatus,
   type MigrationStatus,
   type SyncScope,
   type TerrafirmaWatcherStatus,
@@ -161,3 +161,76 @@ export {
   type TriggerSyncOptions,
   type SyncResult,
 } from "./terrafirma.js";
+
+// Facts resource (bi-temporal facts)
+export {
+  FactsResource,
+  type Fact,
+  type CreateFactParams,
+  type UpdateFactParams,
+  type FactHistoryParams,
+} from "./facts.js";
+
+// Memory spaces resource (P17 multi-agent shared memory)
+export {
+  MemorySpacesResource,
+  type MemorySpacePermission,
+  type MemorySpace,
+  type MemorySpaceWithMembers,
+  type MemorySpaceMember,
+  type CreateMemorySpaceParams,
+  type ListMemorySpacesParams,
+  type JoinMemorySpaceParams,
+} from "./memory-spaces.js";
+
+// Users resource
+export {
+  UsersResource,
+  type User,
+  type ApiKey,
+  type CreateUserParams,
+} from "./users.js";
+
+// Audit resource
+export {
+  AuditResource,
+  type AuditLevel,
+  type AuditOutcome,
+  type AuditEventType,
+  type AuditEvent,
+  type IngestEventParams,
+  type ListAuditEventsParams,
+  type AuditStats,
+} from "./audit.js";
+
+// Sync resource (ADR-011 instance-to-instance sync)
+export {
+  SyncResource,
+  SyncPeersResource,
+  type SyncPeer,
+  type SyncConflict,
+  type SyncStatus,
+  type CreatePeerParams,
+  type SyncPullParams,
+  type SyncPushResult,
+  type ListConflictsParams,
+  type SyncChange,
+} from "./sync.js";
+
+// GC resource
+export {
+  GcResource,
+  type GcCandidate,
+  type GcAuditEntry,
+  type GcRunResult,
+  type ListGcCandidatesParams,
+  type ListGcAuditParams,
+} from "./gc.js";
+
+// Maintenance resource
+export {
+  MaintenanceResource,
+  type MaintenanceParams,
+  type TombstoneCleanupResult,
+  type ChangelogCompactResult,
+} from "./maintenance.js";

--- a/packages/sdk/src/resources/maintenance.ts
+++ b/packages/sdk/src/resources/maintenance.ts
@@ -1,0 +1,92 @@
+/**
+ * Maintenance Resource
+ *
+ * Resource-based SDK interface for server maintenance operations.
+ * Provides access to tombstone cleanup and changelog compaction
+ * with dry-run support.
+ */
+
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MaintenanceParams {
+  days?: number;
+  dryRun?: boolean;
+}
+
+export interface TombstoneCleanupResult {
+  deleted: number;
+  warnings: string[];
+  dryRun: boolean;
+}
+
+export interface ChangelogCompactResult {
+  deleted: number;
+  belowSeq: string | null;
+  dryRun: boolean;
+  reason?: string;
+}
+
+// ============================================================================
+// API Response Types (internal)
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// Maintenance Resource
+// ============================================================================
+
+/**
+ * Maintenance Resource — server maintenance and cleanup operations.
+ *
+ * @example
+ * ```typescript
+ * // Dry-run tombstone cleanup
+ * const preview = await client.maintenance.tombstoneCleanup({
+ *   days: 30,
+ *   dryRun: true,
+ * });
+ *
+ * // Run changelog compaction
+ * const result = await client.maintenance.changelogCompact({ days: 90 });
+ * ```
+ */
+export class MaintenanceResource extends BaseResource {
+  /**
+   * Clean up soft-deleted (tombstoned) records older than the specified number of days.
+   */
+  async tombstoneCleanup(params?: MaintenanceParams): Promise<TombstoneCleanupResult> {
+    const response = await this.request<ApiSuccessResponse<TombstoneCleanupResult>>(
+      "POST",
+      "/v1/maintenance/tombstone-cleanup",
+      params
+    );
+    return response.data;
+  }
+
+  /**
+   * Compact the changelog by removing entries older than the specified number of days.
+   */
+  async changelogCompact(params?: MaintenanceParams): Promise<ChangelogCompactResult> {
+    const response = await this.request<ApiSuccessResponse<ChangelogCompactResult>>(
+      "POST",
+      "/v1/maintenance/changelog-compact",
+      params
+    );
+    return response.data;
+  }
+}

--- a/packages/sdk/src/resources/memory-spaces.ts
+++ b/packages/sdk/src/resources/memory-spaces.ts
@@ -1,0 +1,143 @@
+/**
+ * Memory Spaces Resource
+ *
+ * Resource-based SDK interface for shared memory space management.
+ * Memory spaces allow agents to collaborate within shared knowledge containers.
+ */
+
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type MemorySpacePermission = "read" | "write" | "admin";
+
+export interface MemorySpace {
+  id: string;
+  title: string;
+  description: string | null;
+  visibility: "private" | "shared";
+  nodeType: "memory_space";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MemorySpaceWithMembers extends MemorySpace {
+  members: MemorySpaceMember[];
+}
+
+export interface MemorySpaceMember {
+  agentId: string;
+  permission: MemorySpacePermission;
+  joinedAt: string;
+}
+
+export interface CreateMemorySpaceParams {
+  title: string;
+  description?: string;
+  visibility?: "private" | "shared";
+  initialMembers?: Array<{ agentId: string; permission: MemorySpacePermission }>;
+}
+
+export interface ListMemorySpacesParams {
+  agentId?: string;
+}
+
+export interface JoinMemorySpaceParams {
+  agentId: string;
+  permission: MemorySpacePermission;
+}
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// Memory Spaces Resource
+// ============================================================================
+
+/**
+ * Memory Spaces Resource - manages shared memory spaces for multi-agent collaboration.
+ */
+export class MemorySpacesResource extends BaseResource {
+  /**
+   * List memory spaces, optionally filtered by agent membership.
+   */
+  async list(params?: ListMemorySpacesParams): Promise<MemorySpace[]> {
+    const query = new URLSearchParams();
+    if (params?.agentId) {
+      query.set("agentId", params.agentId);
+    }
+
+    const queryString = query.toString();
+    const path = `/v1/memory-spaces${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<{ spaces: MemorySpace[] }>>(
+      "GET",
+      path
+    );
+    return response.data.spaces;
+  }
+
+  /**
+   * Create a new memory space.
+   */
+  async create(params: CreateMemorySpaceParams): Promise<MemorySpace> {
+    const response = await this.request<ApiSuccessResponse<{ space: MemorySpace }>>(
+      "POST",
+      "/v1/memory-spaces",
+      params
+    );
+    return response.data.space;
+  }
+
+  /**
+   * Get a memory space by ID, including its members.
+   */
+  async get(spaceId: string): Promise<MemorySpaceWithMembers> {
+    const response = await this.request<ApiSuccessResponse<{ space: MemorySpaceWithMembers }>>(
+      "GET",
+      `/v1/memory-spaces/${encodeURIComponent(spaceId)}`
+    );
+    return response.data.space;
+  }
+
+  /**
+   * Join a memory space as an agent with a given permission level.
+   */
+  async join(spaceId: string, params: JoinMemorySpaceParams): Promise<MemorySpaceMember> {
+    const response = await this.request<ApiSuccessResponse<{ member: MemorySpaceMember }>>(
+      "POST",
+      `/v1/memory-spaces/${encodeURIComponent(spaceId)}/join`,
+      params
+    );
+    return response.data.member;
+  }
+
+  /**
+   * Leave a memory space (remove an agent from the space).
+   */
+  async leave(spaceId: string, agentId: string): Promise<{ removed: true }> {
+    const query = new URLSearchParams();
+    query.set("agentId", agentId);
+    const qs = query.toString();
+    const response = await this.request<ApiSuccessResponse<{ removed: true }>>(
+      "DELETE",
+      `/v1/memory-spaces/${encodeURIComponent(spaceId)}/leave${qs ? `?${qs}` : ""}`
+    );
+    return response.data;
+  }
+}

--- a/packages/sdk/src/resources/session-coordination.ts
+++ b/packages/sdk/src/resources/session-coordination.ts
@@ -112,7 +112,7 @@ export interface SessionNoteEdge {
   sessionId: string;
   sourceNoteId: string;
   targetNoteId: string;
-  relationship: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to";
+  relationship: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to" | "supports" | "contradicts" | "extends";
   evidence: string | null;
   metadata: Record<string, unknown>;
   createdAt: string;
@@ -240,7 +240,7 @@ export interface ListBranchesParams {
 export interface CreateNoteEdgeParams {
   sourceNoteId: string;
   targetNoteId: string;
-  relationship: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to";
+  relationship: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to" | "supports" | "contradicts" | "extends";
   evidence?: string;
   metadata?: Record<string, unknown>;
 }
@@ -248,14 +248,14 @@ export interface CreateNoteEdgeParams {
 export interface ListNoteEdgesParams {
   sourceNoteId?: string;
   targetNoteId?: string;
-  relationship?: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to";
+  relationship?: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to" | "supports" | "contradicts" | "extends";
   limit?: number;
   offset?: number;
 }
 
 export interface TraverseNotesParams {
   startNoteId: string;
-  relationship?: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to";
+  relationship?: "preceded_by" | "caused_by" | "validated_by" | "superseded_by" | "related_to" | "supports" | "contradicts" | "extends";
   maxDepth?: number;
 }
 

--- a/packages/sdk/src/resources/sessions.ts
+++ b/packages/sdk/src/resources/sessions.ts
@@ -688,4 +688,29 @@ export class SessionsResource extends BaseResource {
     );
     return response.data;
   }
+
+  /**
+   * Get lifecycle statistics for a session
+   */
+  async getLifecycleStats(sessionId: string): Promise<{
+    noteCount: number;
+    decisionCount: number;
+    constraintCount: number;
+    branchCount: number;
+    stuckDetectionCount: number;
+    durationMinutes: number | null;
+  }> {
+    const response = await this.request<ApiSuccessResponse<{
+      noteCount: number;
+      decisionCount: number;
+      constraintCount: number;
+      branchCount: number;
+      stuckDetectionCount: number;
+      durationMinutes: number | null;
+    }>>(
+      "GET",
+      `/v1/sessions/${encodeURIComponent(sessionId)}/lifecycle-stats`
+    );
+    return response.data;
+  }
 }

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -1,0 +1,335 @@
+/**
+ * Sync Resource
+ *
+ * Resource-based SDK interface for multi-node synchronization.
+ * Provides push/pull replication, conflict resolution, and peer management.
+ */
+
+import type { EngramClient } from "../client.js";
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SyncPeer {
+  id: string;
+  name: string;
+  url: string;
+  lastPushAt: string | null;
+  lastPullAt: string | null;
+  lastPushSeq: string | null;
+  lastPullSeq: string | null;
+  linkEnabled: boolean;
+  linkIntervalSeconds: number;
+  linkLastSyncAt: string | null;
+  linkLastError: string | null;
+  linkPaused: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SyncConflict {
+  id: string;
+  entityType: string;
+  entityId: string;
+  fieldName: string;
+  localValue: unknown;
+  remoteValue: unknown;
+  localUpdatedAt: string | null;
+  remoteUpdatedAt: string | null;
+  winner: "local" | "remote";
+  resolution: "auto_lww" | "manual";
+  resolvedAt: string | null;
+  createdAt: string;
+}
+
+export interface SyncStatus {
+  schemaVersion: string;
+  lastPushSeq: string | null;
+  lastPullSeq: string | null;
+  pendingChanges: number;
+  conflictCount: number;
+}
+
+export interface CreatePeerParams {
+  name: string;
+  url: string;
+  apiKey?: string;
+}
+
+export interface SyncPullParams {
+  sinceSeq?: string;
+  entityTypes?: string[];
+}
+
+export interface SyncPushResult {
+  success: boolean;
+  counts: Record<string, number>;
+  conflicts: number;
+  duration: number;
+}
+
+export interface ListConflictsParams {
+  unresolved?: boolean;
+}
+
+/**
+ * A single change record in the sync changelog.
+ * Represents an operation on an entity that should be replicated.
+ */
+export interface SyncChange {
+  entityType: string;
+  entityId: string;
+  operation: "insert" | "update" | "delete";
+  seq?: string;
+  payload?: Record<string, unknown>;
+  timestamp?: string;
+}
+
+// ============================================================================
+// Sync Peers Resource (Sub-resource)
+// ============================================================================
+
+/**
+ * Sync Peers Resource - manages peer connections for replication.
+ */
+export class SyncPeersResource extends BaseResource {
+  /**
+   * Register a new sync peer.
+   */
+  async create(params: CreatePeerParams): Promise<SyncPeer> {
+    const response = await this.request<ApiSuccessResponse<SyncPeer>>(
+      "POST",
+      "/v1/sync/peers",
+      params
+    );
+    return response.data;
+  }
+
+  /**
+   * List all registered sync peers.
+   */
+  async list(): Promise<SyncPeer[]> {
+    const response = await this.request<ApiSuccessResponse<SyncPeer[]>>(
+      "GET",
+      "/v1/sync/peers"
+    );
+    return response.data;
+  }
+
+  /**
+   * Get a sync peer by name.
+   */
+  async get(name: string): Promise<SyncPeer> {
+    const response = await this.request<ApiSuccessResponse<SyncPeer>>(
+      "GET",
+      `/v1/sync/peers/${encodeURIComponent(name)}`
+    );
+    return response.data;
+  }
+
+  /**
+   * Delete a sync peer by name.
+   */
+  async delete(name: string): Promise<{ deleted: true }> {
+    const response = await this.request<ApiSuccessResponse<{ deleted: true }>>(
+      "DELETE",
+      `/v1/sync/peers/${encodeURIComponent(name)}`
+    );
+    return response.data;
+  }
+
+  /**
+   * Enable automatic sync link for a peer.
+   */
+  async link(name: string): Promise<void> {
+    await this.request<ApiSuccessResponse<void>>(
+      "POST",
+      `/v1/sync/peers/${encodeURIComponent(name)}/link`
+    );
+  }
+
+  /**
+   * Disable automatic sync link for a peer.
+   */
+  async unlink(name: string): Promise<void> {
+    await this.request<ApiSuccessResponse<void>>(
+      "DELETE",
+      `/v1/sync/peers/${encodeURIComponent(name)}/link`
+    );
+  }
+
+  /**
+   * Pause an active sync link for a peer.
+   */
+  async pause(name: string): Promise<void> {
+    await this.request<ApiSuccessResponse<void>>(
+      "POST",
+      `/v1/sync/peers/${encodeURIComponent(name)}/link/pause`
+    );
+  }
+
+  /**
+   * Resume a paused sync link for a peer.
+   */
+  async resume(name: string): Promise<void> {
+    await this.request<ApiSuccessResponse<void>>(
+      "POST",
+      `/v1/sync/peers/${encodeURIComponent(name)}/link/resume`
+    );
+  }
+}
+
+// ============================================================================
+// Sync Resource
+// ============================================================================
+
+/**
+ * Sync Resource - manages data synchronization between Engram nodes.
+ *
+ * Provides push/pull replication, conflict detection and resolution,
+ * and peer-to-peer sync orchestration.
+ */
+export class SyncResource extends BaseResource {
+  private _peers: SyncPeersResource;
+
+  constructor(client: EngramClient) {
+    super(client);
+    this._peers = new SyncPeersResource(client);
+  }
+
+  /**
+   * Access the peers sub-resource for managing sync peers.
+   */
+  get peers(): SyncPeersResource {
+    return this._peers;
+  }
+
+  /**
+   * Push local changes to the server.
+   */
+  async push(changes?: SyncChange[]): Promise<SyncPushResult> {
+    const response = await this.request<ApiSuccessResponse<SyncPushResult>>(
+      "POST",
+      "/v1/sync/push",
+      changes
+    );
+    return response.data;
+  }
+
+  /**
+   * Pull remote changes from the server.
+   */
+  async pull(params?: SyncPullParams): Promise<SyncChange[]> {
+    const response = await this.request<ApiSuccessResponse<SyncChange[]>>(
+      "POST",
+      "/v1/sync/pull",
+      params
+    );
+    return response.data;
+  }
+
+  /**
+   * Get the current sync status.
+   */
+  async getStatus(): Promise<SyncStatus> {
+    const response = await this.request<ApiSuccessResponse<SyncStatus>>(
+      "GET",
+      "/v1/sync/status"
+    );
+    return response.data;
+  }
+
+  /**
+   * Push local changes to a specific peer.
+   */
+  async pushTo(peer: string): Promise<SyncPushResult> {
+    const query = new URLSearchParams();
+    query.set("peer", peer);
+
+    const qs = query.toString();
+    const path = `/v1/sync/push-to${qs ? `?${qs}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<SyncPushResult>>(
+      "POST",
+      path
+    );
+    return response.data;
+  }
+
+  /**
+   * Pull changes from a specific peer.
+   */
+  async pullFrom(peer: string): Promise<SyncChange[]> {
+    const query = new URLSearchParams();
+    query.set("peer", peer);
+
+    const qs = query.toString();
+    const path = `/v1/sync/pull-from${qs ? `?${qs}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<SyncChange[]>>(
+      "POST",
+      path
+    );
+    return response.data;
+  }
+
+  /**
+   * List sync conflicts, optionally filtering to unresolved only.
+   */
+  async listConflicts(params?: ListConflictsParams): Promise<{
+    conflicts: SyncConflict[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const query = new URLSearchParams();
+    if (params?.unresolved !== undefined) {
+      query.set("unresolved", String(params.unresolved));
+    }
+
+    const queryString = query.toString();
+    const path = `/v1/sync/conflicts${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<ApiSuccessResponse<SyncConflict[]>>(
+      "GET",
+      path
+    );
+    return {
+      conflicts: response.data,
+      total: response.meta?.pagination?.total ?? response.data.length,
+      hasMore: response.meta?.pagination?.hasMore ?? false,
+    };
+  }
+
+  /**
+   * Resolve a sync conflict by ID.
+   */
+  async resolveConflict(
+    id: string,
+    params?: { resolution?: "local" | "remote"; rationale?: string }
+  ): Promise<SyncConflict> {
+    const response = await this.request<ApiSuccessResponse<SyncConflict>>(
+      "POST",
+      `/v1/sync/conflicts/${encodeURIComponent(id)}/resolve`,
+      params
+    );
+    return response.data;
+  }
+}

--- a/packages/sdk/src/resources/users.ts
+++ b/packages/sdk/src/resources/users.ts
@@ -1,0 +1,126 @@
+/**
+ * Users Resource
+ *
+ * Resource-based SDK interface for user management.
+ * Provides access to user creation, listing, lookup, and deletion
+ * with associated API key provisioning.
+ */
+
+import { BaseResource } from "./base.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface User {
+  id: string;
+  name: string;
+  displayName: string | null;
+  createdAt: string;
+}
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  value: string;
+}
+
+export interface CreateUserParams {
+  name: string;
+  displayName?: string;
+}
+
+// ============================================================================
+// API Response Types (internal)
+// ============================================================================
+
+interface ApiSuccessResponse<T> {
+  data: T;
+  meta?: {
+    pagination?: {
+      total: number;
+      limit: number;
+      offset?: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+// ============================================================================
+// Users Resource
+// ============================================================================
+
+/**
+ * Users Resource — manages user accounts and API key provisioning.
+ *
+ * @example
+ * ```typescript
+ * // Create a new user (returns user + initial API key)
+ * const { user, key } = await client.users.create({ name: "alice" });
+ *
+ * // List all users
+ * const users = await client.users.list();
+ *
+ * // Get a user by ID or name
+ * const user = await client.users.get("alice");
+ *
+ * // Delete a user and revoke their keys
+ * const result = await client.users.delete("alice", { revokeKeys: true });
+ * ```
+ */
+export class UsersResource extends BaseResource {
+  /**
+   * Create a new user. Returns the user and an initial API key.
+   */
+  async create(params: CreateUserParams): Promise<{ user: User; key: ApiKey }> {
+    const response = await this.request<
+      ApiSuccessResponse<{ user: User; key: ApiKey }>
+    >("POST", "/v1/users", params);
+    return response.data;
+  }
+
+  /**
+   * List all users.
+   */
+  async list(params?: { limit?: number; offset?: number }): Promise<User[]> {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+    const qs = query.toString();
+    const path = `/v1/users${qs ? `?${qs}` : ""}`;
+    const response = await this.request<
+      ApiSuccessResponse<{ users: User[] }>
+    >("GET", path);
+    return response.data.users;
+  }
+
+  /**
+   * Get a user by ID or name.
+   */
+  async get(idOrName: string): Promise<User> {
+    const response = await this.request<
+      ApiSuccessResponse<{ user: User }>
+    >("GET", `/v1/users/${encodeURIComponent(idOrName)}`);
+    return response.data.user;
+  }
+
+  /**
+   * Delete a user by ID or name, optionally revoking all their API keys.
+   */
+  async delete(
+    idOrName: string,
+    options?: { revokeKeys?: boolean }
+  ): Promise<{ deleted: true; revokedKeys: number }> {
+    const query = new URLSearchParams();
+    if (options?.revokeKeys) query.set("revokeKeys", "true");
+
+    const queryString = query.toString();
+    const path = `/v1/users/${encodeURIComponent(idOrName)}${queryString ? `?${queryString}` : ""}`;
+
+    const response = await this.request<
+      ApiSuccessResponse<{ deleted: true; revokedKeys: number }>
+    >("DELETE", path);
+    return response.data;
+  }
+}

--- a/packages/sdk/src/types/knowledge-crystal-edge.ts
+++ b/packages/sdk/src/types/knowledge-crystal-edge.ts
@@ -34,6 +34,7 @@ export type KnowledgeCrystalEdgeRelationship =
   | "derived_from"  // Versioning, extraction, refinement
   | "related_to"    // Semantic connection
   | "contradicts"   // Tension or conflict
+  | "supports"      // Evidence supporting a claim
   | "implements"    // Implements a pattern/decision
   | "depends_on";   // Requires another node
 
@@ -56,10 +57,16 @@ export interface KnowledgeCrystalEdge {
   relationship: KnowledgeCrystalEdgeRelationship;
   /** Additional metadata about the relationship */
   metadata: Record<string, unknown>;
+  /** Edge weight (default 1.0) */
+  weight: number;
   /** ISO timestamp of creation */
   createdAt: string;
+  /** ISO timestamp of last update */
+  updatedAt: string;
   /** Creator ID (optional) */
   createdBy?: string;
+  /** ISO timestamp of soft deletion, or null if active */
+  deletedAt: string | null;
 }
 
 // ============================================================================

--- a/packages/sdk/src/types/knowledge-crystal.ts
+++ b/packages/sdk/src/types/knowledge-crystal.ts
@@ -40,7 +40,9 @@ export type MembershipAddedBy =
   | "promotion"
   | "manual"
   | "import"
-  | "finalization";
+  | "finalization"
+  | "terrafirma"
+  | "consolidation";
 
 /**
  * Reference to content storage location.
@@ -142,6 +144,18 @@ export interface KnowledgeCrystal {
   typeMetadata: Record<string, unknown>;
   /** Filesystem path (Terrafirma file_ref and directory nodes) */
   path: string | null;
+  /** Lifecycle status (ADR-058) */
+  lifecycleStatus: "active" | "archived" | "merged";
+  /** ISO timestamp of last access (relevance tracking) */
+  lastAccessedAt: string | null;
+  /** Number of times this node has been accessed */
+  accessCount: number;
+  /** Computed relevance score (0-1, used by GC) */
+  relevanceScore: number | null;
+  /** ISO timestamp of when this node was archived */
+  archivedAt: string | null;
+  /** ISO timestamp of soft deletion, or null if active */
+  deletedAt: string | null;
   /** ISO timestamp of creation */
   createdAt: string;
   /** ISO timestamp of last update */
@@ -171,6 +185,8 @@ export interface TrashedCrystal {
  * Parameters for creating a knowledge crystal node.
  */
 export interface CreateKnowledgeCrystalParams {
+  /** Client-supplied UUID (optional, server generates if omitted) */
+  id?: string;
   /** Node type */
   nodeType: NodeType;
   /** Human-readable title */
@@ -183,6 +199,8 @@ export interface CreateKnowledgeCrystalParams {
   tags?: string[];
   /** URL-friendly slug */
   slug?: string;
+  /** Content reference (required for content-type nodes: pattern, learning, decision, note, finding, constraint) */
+  contentRef?: ContentRef;
   /** Inline content (content nodes) */
   contentInline?: string;
   /** Confidence score (0-1, content nodes) */
@@ -205,6 +223,8 @@ export interface CreateKnowledgeCrystalParams {
   sourceProject?: string;
   /** Filesystem path (file_ref, directory nodes) */
   path?: string;
+  /** Coherence mode for conflict handling during creation */
+  coherenceMode?: "blocking" | "advisory" | "bypass";
 }
 
 /**
@@ -221,6 +241,8 @@ export interface UpdateKnowledgeCrystalParams {
   slug?: string;
   /** Tags for categorization */
   tags?: string[];
+  /** Content reference */
+  contentRef?: ContentRef;
   /** Inline content (content nodes) */
   contentInline?: string;
   /** Confidence score (0-1, content nodes) */
@@ -261,6 +283,8 @@ export interface ListKnowledgeCrystalsParams {
   tags?: string[];
   /** Filter by verification status (content nodes) */
   verified?: boolean;
+  /** Filter by source session ID */
+  sourceSessionId?: string;
   /** Filter by source project */
   sourceProject?: string;
   /** Filter by owner IDs (comma-separated) */
@@ -286,7 +310,7 @@ export interface SearchKnowledgeCrystalsParams {
   /** Filter by verification status (content nodes) */
   verified?: boolean;
   /** Search mode */
-  mode?: "semantic" | "keyword" | "hybrid";
+  mode?: "semantic" | "keyword" | "fulltext" | "hybrid";
   /** Maximum results to return */
   limit?: number;
   /** Offset for pagination */

--- a/packages/sdk/src/types/node-type.ts
+++ b/packages/sdk/src/types/node-type.ts
@@ -1,11 +1,13 @@
 /**
  * NodeType — Unified Knowledge Crystal Node Type
  *
- * A 12-value string literal union that replaces the former
+ * A 14-value string literal union that replaces the former
  * separate `KnowledgeItemType` (6 content types) and `CrystalType`
- * (4 container types) enums. Terrafirma types are added in ADR-055.
+ * (4 container types) enums. Terrafirma and system types added in
+ * ADR-055/ADR-058.
  *
  * ADR-055: Unified Knowledge Crystal Model
+ * ADR-058: System & Collaboration Node Types
  */
 
 // ============================================================================
@@ -39,5 +41,8 @@ export type NodeType =
   | "domain"
   // Terrafirma types (ADR-049)
   | "file_ref"
-  | "directory";
+  | "directory"
+  // System types (ADR-058)
+  | "system"
+  | "memory_space";
 

--- a/packages/sdk/tests/client-compat.test.ts
+++ b/packages/sdk/tests/client-compat.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EngramClient, MIN_SERVER_VERSION } from "../src/client.js";
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers({ "content-type": "application/json" }),
+  });
+}
+
+describe("EngramClient.checkCompatibility", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("should return compatible: true for server >= MIN_SERVER_VERSION", async () => {
+    mockFetch = mockFetchResponse({ version: "0.22.4" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.checkCompatibility();
+    expect(result.compatible).toBe(true);
+    expect(result.serverVersion).toBe("0.22.4");
+    expect(result.minRequired).toBe(MIN_SERVER_VERSION);
+  });
+
+  it("should return compatible: false for older server", async () => {
+    mockFetch = mockFetchResponse({ version: "0.21.0" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.checkCompatibility();
+    expect(result.compatible).toBe(false);
+    expect(result.serverVersion).toBe("0.21.0");
+  });
+
+  it("should return compatible: false when version is missing", async () => {
+    mockFetch = mockFetchResponse({ status: "ok" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.checkCompatibility();
+    expect(result.compatible).toBe(false);
+    expect(result.serverVersion).toBe("unknown");
+  });
+
+  it("should compare patch versions correctly", async () => {
+    mockFetch = mockFetchResponse({ version: "0.22.3" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.checkCompatibility();
+    // 0.22.3 < 0.22.4 (MIN_SERVER_VERSION)
+    expect(result.compatible).toBe(false);
+  });
+
+  it("should return compatible: true for higher minor version", async () => {
+    mockFetch = mockFetchResponse({ version: "0.23.0" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.checkCompatibility();
+    expect(result.compatible).toBe(true);
+  });
+});
+
+describe("MIN_SERVER_VERSION", () => {
+  it("should be a valid semver string", () => {
+    expect(MIN_SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/packages/sdk/tests/resources/audit.test.ts
+++ b/packages/sdk/tests/resources/audit.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Audit Resource Tests
+ *
+ * Tests for the AuditResource SDK pattern (engram Knowledge API).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EngramClient } from "../../src/client.js";
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers({ "content-type": "application/json" }),
+  });
+}
+
+describe("AuditResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("audit.ingest", () => {
+    it("should POST to /v1/audit/ingest", async () => {
+      mockFetch = mockFetchResponse({ data: { accepted: true } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const event = {
+        level: "info" as const,
+        component: "test-component",
+        message: "Test audit event",
+        eventType: "tool_call" as const,
+      };
+
+      const result = await client.audit.ingest(event);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/ingest",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(event),
+        })
+      );
+
+      expect(result.accepted).toBe(true);
+    });
+  });
+
+  describe("audit.ingestBatch", () => {
+    it("should POST to /v1/audit/ingest/batch with events array", async () => {
+      mockFetch = mockFetchResponse({ data: { accepted: 2 } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const events = [
+        { level: "info" as const, component: "comp-a", message: "Event 1" },
+        { level: "warn" as const, component: "comp-b", message: "Event 2" },
+      ];
+
+      const result = await client.audit.ingestBatch(events);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/ingest/batch",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ events }),
+        })
+      );
+
+      expect(result.accepted).toBe(2);
+    });
+  });
+
+  describe("audit.flush", () => {
+    it("should POST to /v1/audit/flush", async () => {
+      mockFetch = mockFetchResponse({ data: { flushed: true } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.audit.flush();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/flush",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.flushed).toBe(true);
+    });
+  });
+
+  describe("audit.listEvents", () => {
+    it("should GET /v1/audit/events", async () => {
+      const mockEvents = [
+        { id: "evt-1", level: "info", component: "comp-a", message: "Event 1" },
+        { id: "evt-2", level: "warn", component: "comp-b", message: "Event 2" },
+      ];
+
+      mockFetch = mockFetchResponse({
+        data: mockEvents,
+        meta: { pagination: { total: 2, limit: 50, hasMore: false } },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.audit.listEvents();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/events",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.events).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("should pass query params including comma-joined arrays", async () => {
+      mockFetch = mockFetchResponse({
+        data: [],
+        meta: { pagination: { total: 0, limit: 10, hasMore: false } },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.audit.listEvents({
+        level: ["info", "warn"],
+        component: "test-comp",
+        eventType: ["tool_call", "session_start"],
+        since: "2026-01-01T00:00:00Z",
+        until: "2026-12-31T23:59:59Z",
+        limit: 10,
+        offset: 5,
+      });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v1/audit/events?");
+      expect(calledUrl).toContain("level=info%2Cwarn");
+      expect(calledUrl).toContain("component=test-comp");
+      expect(calledUrl).toContain("eventType=tool_call%2Csession_start");
+      expect(calledUrl).toContain("since=2026-01-01T00%3A00%3A00Z");
+      expect(calledUrl).toContain("until=2026-12-31T23%3A59%3A59Z");
+      expect(calledUrl).toContain("limit=10");
+      expect(calledUrl).toContain("offset=5");
+    });
+  });
+
+  describe("audit.getEvent", () => {
+    it("should GET /v1/audit/events/:id", async () => {
+      const mockEvent = {
+        id: "evt-123",
+        level: "info",
+        component: "test-comp",
+        message: "Test event",
+        timestamp: "2026-01-25T10:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: mockEvent });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const event = await client.audit.getEvent("evt-123");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/events/evt-123",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(event.id).toBe("evt-123");
+      expect(event.message).toBe("Test event");
+    });
+  });
+
+  describe("audit.getStats", () => {
+    it("should GET /v1/audit/stats", async () => {
+      const mockStats = {
+        totalEvents: 150,
+        eventsByType: { tool_call: 100, session_start: 50 },
+        eventsByLevel: { info: 120, warn: 30 },
+        recentActivity: [{ date: "2026-01-25", count: 42 }],
+      };
+
+      mockFetch = mockFetchResponse({ data: mockStats });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const stats = await client.audit.getStats();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/stats",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(stats.totalEvents).toBe(150);
+      expect(stats.eventsByType.tool_call).toBe(100);
+    });
+  });
+
+  describe("audit.prune", () => {
+    it("should DELETE /v1/audit/prune with olderThanDays param", async () => {
+      mockFetch = mockFetchResponse({ data: { deleted: 42 } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.audit.prune(30);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/audit/prune?olderThanDays=30",
+        expect.objectContaining({ method: "DELETE" })
+      );
+
+      expect(result.deleted).toBe(42);
+    });
+  });
+});

--- a/packages/sdk/tests/resources/crystals.test.ts
+++ b/packages/sdk/tests/resources/crystals.test.ts
@@ -1508,3 +1508,70 @@ describe("CrystalsResource Type Coverage", () => {
     });
   });
 });
+
+// ============================================================================
+// CrystalItemsResource — bulkAdd & reorder Tests
+// ============================================================================
+describe("CrystalItemsResource bulkAdd & reorder", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("crystals.items(id).bulkAdd", () => {
+    it("should POST to /v1/crystals/:id/items/bulk", async () => {
+      const mockData = { added: 3 };
+      mockFetch = mockFetchResponse({ data: mockData });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.crystals.items("crystal-1").bulkAdd([
+        { itemId: "item-1" },
+        { itemId: "item-2", position: 1 },
+        { itemId: "item-3", position: 2 },
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/crystals/crystal-1/items/bulk",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ items: [
+            { itemId: "item-1" },
+            { itemId: "item-2", position: 1 },
+            { itemId: "item-3", position: 2 },
+          ] }),
+        })
+      );
+      expect(result.added).toBe(3);
+    });
+  });
+
+  describe("crystals.items(id).reorder", () => {
+    it("should POST to /v1/crystals/:id/items/reorder", async () => {
+      mockFetch = mockFetchResponse({ data: undefined });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.crystals.items("crystal-1").reorder(["item-2", "item-1", "item-3"]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/crystals/crystal-1/items/reorder",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ itemIds: ["item-2", "item-1", "item-3"] }),
+        })
+      );
+    });
+  });
+});

--- a/packages/sdk/tests/resources/entities.test.ts
+++ b/packages/sdk/tests/resources/entities.test.ts
@@ -582,3 +582,43 @@ describe("Type correctness", () => {
     expect(typeof client.extraction.getStats).toBe("function");
   });
 });
+
+// ============================================================================
+// EntitiesResource.graph()
+// ============================================================================
+
+describe("client.entities.graph()", () => {
+  it("should GET /v1/entities/:id/graph", async () => {
+    const mockGraphData = {
+      root: { id: "entity-1", canonicalName: "Test", confidence: 0.9, mentionCount: 5, verified: true, entityClass: "concept", autoConstructed: false, corroboratingSources: 2, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+      nodes: [],
+      edges: [],
+      totalNodes: 1,
+      depth: 1,
+      truncated: false,
+    };
+    mockFetch = mockJsonResponse({ data: mockGraphData });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.entities.graph("entity-1");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:3100/v1/entities/entity-1/graph",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(result.data.totalNodes).toBe(1);
+    expect(result.data.truncated).toBe(false);
+  });
+
+  it("should pass query params for depth and filters", async () => {
+    mockFetch = mockJsonResponse({ data: { root: {}, nodes: [], edges: [], totalNodes: 0, depth: 2, truncated: false } });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await client.entities.graph("entity-1", { depth: 2, filterClass: "person", minConfidence: 0.8 });
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("depth=2");
+    expect(calledUrl).toContain("filter_class=person");
+    expect(calledUrl).toContain("min_confidence=0.8");
+  });
+});

--- a/packages/sdk/tests/resources/facts.test.ts
+++ b/packages/sdk/tests/resources/facts.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Facts Resource Tests
+ *
+ * Tests for the FactsResource SDK pattern.
+ * Facts are bi-temporal versioned key-value pairs with point-in-time queries
+ * and full version history.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EngramClient } from "../../src/client.js";
+import { EngramError } from "../../src/errors.js";
+import type { Fact } from "../../src/resources/facts.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const FACT_ID = "00000000-0000-4000-8000-000000000001";
+
+const mockFact: Fact = {
+  id: FACT_ID,
+  key: "user.preferences.theme",
+  value: { mode: "dark" },
+  validFrom: "2026-01-01T00:00:00Z",
+  validTo: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+describe("FactsResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // facts.create()
+  // ==========================================================================
+
+  describe("facts.create", () => {
+    it("should POST to /v1/facts", async () => {
+      mockFetch = mockFetchResponse({ data: mockFact }, 201);
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.create({
+        key: "user.preferences.theme",
+        value: { mode: "dark" },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/facts",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            key: "user.preferences.theme",
+            value: { mode: "dark" },
+          }),
+        })
+      );
+
+      expect(result.id).toBe(FACT_ID);
+      expect(result.key).toBe("user.preferences.theme");
+      expect(result.value).toEqual({ mode: "dark" });
+    });
+
+    it("throws EngramError on validation failure", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "VALIDATION_FAILED", message: "key is required" } },
+        400
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.facts.create({ key: "", value: {} })
+      ).rejects.toBeInstanceOf(EngramError);
+    });
+  });
+
+  // ==========================================================================
+  // facts.get()
+  // ==========================================================================
+
+  describe("facts.get", () => {
+    it("should GET /v1/facts/:id", async () => {
+      mockFetch = mockFetchResponse({ data: mockFact });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.get(FACT_ID);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:3100/v1/facts/${FACT_ID}`,
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.id).toBe(FACT_ID);
+      expect(result.key).toBe("user.preferences.theme");
+    });
+
+    it("should GET /v1/facts/:id?asOf=... with asOf query param", async () => {
+      const asOf = "2026-03-15T00:00:00Z";
+      const historicalFact: Fact = {
+        ...mockFact,
+        value: { mode: "light" },
+        validFrom: "2026-01-01T00:00:00Z",
+        validTo: "2026-02-01T00:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: historicalFact });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.get(FACT_ID, { asOf });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(`/v1/facts/${FACT_ID}`);
+      expect(calledUrl).toContain(`asOf=${encodeURIComponent(asOf)}`);
+
+      expect(result.value).toEqual({ mode: "light" });
+    });
+
+    it("throws EngramError on 404", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "NOT_FOUND", message: "Fact not found" } },
+        404
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.facts.get(FACT_ID)).rejects.toBeInstanceOf(
+        EngramError
+      );
+    });
+  });
+
+  // ==========================================================================
+  // facts.getByKey()
+  // ==========================================================================
+
+  describe("facts.getByKey", () => {
+    it("should GET /v1/facts?key=...", async () => {
+      mockFetch = mockFetchResponse({ data: mockFact });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.getByKey("user.preferences.theme");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v1/facts?");
+      expect(calledUrl).toContain("key=user.preferences.theme");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.key).toBe("user.preferences.theme");
+    });
+
+    it("throws EngramError on 404", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "NOT_FOUND", message: "Fact not found" } },
+        404
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.facts.getByKey("nonexistent.key")
+      ).rejects.toBeInstanceOf(EngramError);
+    });
+  });
+
+  // ==========================================================================
+  // facts.update()
+  // ==========================================================================
+
+  describe("facts.update", () => {
+    it("should PATCH /v1/facts/:id", async () => {
+      const updatedFact: Fact = {
+        ...mockFact,
+        value: { mode: "light" },
+        updatedAt: "2026-02-01T00:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: updatedFact });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.update(FACT_ID, {
+        value: { mode: "light" },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:3100/v1/facts/${FACT_ID}`,
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ value: { mode: "light" } }),
+        })
+      );
+
+      expect(result.value).toEqual({ mode: "light" });
+    });
+  });
+
+  // ==========================================================================
+  // facts.getHistory()
+  // ==========================================================================
+
+  describe("facts.getHistory", () => {
+    it("should GET /v1/facts/:id/history", async () => {
+      const versions: Fact[] = [
+        { ...mockFact, value: { mode: "dark" }, validFrom: "2026-02-01T00:00:00Z", validTo: null },
+        { ...mockFact, value: { mode: "light" }, validFrom: "2026-01-01T00:00:00Z", validTo: "2026-02-01T00:00:00Z" },
+      ];
+
+      mockFetch = mockFetchResponse({
+        data: versions,
+        meta: { pagination: { total: 2, limit: 50, offset: 0, hasMore: false } },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.getHistory(FACT_ID);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://localhost:3100/v1/facts/${FACT_ID}/history`,
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.versions).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("should pass validFrom, validTo, limit, and offset as query params", async () => {
+      mockFetch = mockFetchResponse({
+        data: [mockFact],
+        meta: { pagination: { total: 5, limit: 10, offset: 2, hasMore: true } },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.facts.getHistory(FACT_ID, {
+        validFrom: "2026-01-01T00:00:00Z",
+        validTo: "2026-03-01T00:00:00Z",
+        limit: 10,
+        offset: 2,
+      });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(`/v1/facts/${FACT_ID}/history?`);
+      expect(calledUrl).toContain("validFrom=2026-01-01T00%3A00%3A00Z");
+      expect(calledUrl).toContain("validTo=2026-03-01T00%3A00%3A00Z");
+      expect(calledUrl).toContain("limit=10");
+      expect(calledUrl).toContain("offset=2");
+
+      expect(result.versions).toHaveLength(1);
+      expect(result.total).toBe(5);
+      expect(result.hasMore).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/tests/resources/gc.test.ts
+++ b/packages/sdk/tests/resources/gc.test.ts
@@ -1,0 +1,175 @@
+/**
+ * GC (Garbage Collection) Resource Tests
+ *
+ * Tests for the GcResource SDK pattern (engram Knowledge API).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EngramClient } from "../../src/client.js";
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers({ "content-type": "application/json" }),
+  });
+}
+
+describe("GcResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("gc.getCandidates", () => {
+    it("should GET /v1/gc/candidates", async () => {
+      const mockCandidates = [
+        { id: "c-1", title: "Old Crystal", relevanceScore: 0.1, nodeType: "collection" },
+        { id: "c-2", title: "Stale Note", relevanceScore: 0.2, nodeType: "note" },
+      ];
+
+      mockFetch = mockFetchResponse({
+        data: { candidates: mockCandidates, threshold: 0.3, total: 5 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.gc.getCandidates();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/gc/candidates",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.candidates).toHaveLength(2);
+      expect(result.threshold).toBe(0.3);
+      expect(result.total).toBe(5);
+    });
+
+    it("should pass threshold and limit query params", async () => {
+      mockFetch = mockFetchResponse({
+        data: { candidates: [], threshold: 0.5, total: 0 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.gc.getCandidates({ threshold: 0.5, limit: 10 });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v1/gc/candidates?");
+      expect(calledUrl).toContain("threshold=0.5");
+      expect(calledUrl).toContain("limit=10");
+    });
+  });
+
+  describe("gc.getAuditLog", () => {
+    it("should GET /v1/gc/audit", async () => {
+      const mockEntries = [
+        {
+          id: "gc-run-1",
+          runAt: "2026-01-25T10:00:00Z",
+          decayCurve: "exponential",
+          threshold: 0.3,
+          scannedCrystals: 100,
+          archivedCrystals: 5,
+          scannedNotes: 200,
+          archivedNotes: 10,
+          dryRun: false,
+          details: {},
+        },
+        {
+          id: "gc-run-2",
+          runAt: "2026-01-24T10:00:00Z",
+          decayCurve: "exponential",
+          threshold: 0.3,
+          scannedCrystals: 90,
+          archivedCrystals: 3,
+          scannedNotes: 180,
+          archivedNotes: 7,
+          dryRun: true,
+          details: {},
+        },
+      ];
+
+      mockFetch = mockFetchResponse({
+        data: { entries: mockEntries, total: 2 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.gc.getAuditLog();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/gc/audit",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.entries).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+  });
+
+  describe("gc.run", () => {
+    it("should POST to /v1/gc/run", async () => {
+      const mockResult = {
+        scannedCrystals: 100,
+        archivedCrystals: 5,
+        scannedNotes: 200,
+        archivedNotes: 10,
+        dryRun: false,
+      };
+
+      mockFetch = mockFetchResponse({ data: mockResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.gc.run();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/gc/run",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.scannedCrystals).toBe(100);
+      expect(result.archivedCrystals).toBe(5);
+      expect(result.dryRun).toBe(false);
+    });
+
+    it("should pass dryRun as POST body when specified", async () => {
+      const mockResult = {
+        scannedCrystals: 100,
+        archivedCrystals: 5,
+        scannedNotes: 200,
+        archivedNotes: 10,
+        dryRun: true,
+      };
+
+      mockFetch = mockFetchResponse({ data: mockResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.gc.run({ dryRun: true });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/gc/run",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ dryRun: true }),
+        })
+      );
+
+      expect(result.dryRun).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/tests/resources/maintenance.test.ts
+++ b/packages/sdk/tests/resources/maintenance.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Maintenance Resource Tests
+ *
+ * Tests for the MaintenanceResource SDK pattern.
+ * Maintenance operations include tombstone cleanup and changelog compaction
+ * with dry-run support.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EngramClient } from "../../src/client.js";
+import { EngramError } from "../../src/errors.js";
+import type {
+  TombstoneCleanupResult,
+  ChangelogCompactResult,
+} from "../../src/resources/maintenance.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const mockTombstoneResult: TombstoneCleanupResult = {
+  deleted: 42,
+  warnings: [],
+  dryRun: false,
+};
+
+const mockChangelogResult: ChangelogCompactResult = {
+  deleted: 100,
+  belowSeq: "seq-500",
+  dryRun: false,
+};
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+describe("MaintenanceResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // maintenance.tombstoneCleanup()
+  // ==========================================================================
+
+  describe("maintenance.tombstoneCleanup", () => {
+    it("should POST to /v1/maintenance/tombstone-cleanup", async () => {
+      mockFetch = mockFetchResponse({ data: mockTombstoneResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.maintenance.tombstoneCleanup();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/maintenance/tombstone-cleanup",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.deleted).toBe(42);
+      expect(result.warnings).toEqual([]);
+      expect(result.dryRun).toBe(false);
+    });
+
+    it("should include days and dryRun in request body", async () => {
+      const dryRunResult: TombstoneCleanupResult = {
+        deleted: 15,
+        warnings: ["Some records have dependencies"],
+        dryRun: true,
+      };
+
+      mockFetch = mockFetchResponse({ data: dryRunResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.maintenance.tombstoneCleanup({
+        days: 30,
+        dryRun: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/maintenance/tombstone-cleanup",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ days: 30, dryRun: true }),
+        })
+      );
+
+      expect(result.deleted).toBe(15);
+      expect(result.warnings).toEqual(["Some records have dependencies"]);
+      expect(result.dryRun).toBe(true);
+    });
+
+    it("throws EngramError on 500", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "INTERNAL_ERROR", message: "Server error" } },
+        500
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.maintenance.tombstoneCleanup()
+      ).rejects.toBeInstanceOf(EngramError);
+    });
+  });
+
+  // ==========================================================================
+  // maintenance.changelogCompact()
+  // ==========================================================================
+
+  describe("maintenance.changelogCompact", () => {
+    it("should POST to /v1/maintenance/changelog-compact", async () => {
+      mockFetch = mockFetchResponse({ data: mockChangelogResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.maintenance.changelogCompact();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/maintenance/changelog-compact",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.deleted).toBe(100);
+      expect(result.belowSeq).toBe("seq-500");
+      expect(result.dryRun).toBe(false);
+    });
+
+    it("should include days and dryRun in request body", async () => {
+      const dryRunResult: ChangelogCompactResult = {
+        deleted: 50,
+        belowSeq: "seq-200",
+        dryRun: true,
+        reason: "Preview only",
+      };
+
+      mockFetch = mockFetchResponse({ data: dryRunResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.maintenance.changelogCompact({
+        days: 90,
+        dryRun: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/maintenance/changelog-compact",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ days: 90, dryRun: true }),
+        })
+      );
+
+      expect(result.deleted).toBe(50);
+      expect(result.belowSeq).toBe("seq-200");
+      expect(result.dryRun).toBe(true);
+      expect(result.reason).toBe("Preview only");
+    });
+
+    it("throws EngramError on 500", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "INTERNAL_ERROR", message: "Server error" } },
+        500
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.maintenance.changelogCompact()
+      ).rejects.toBeInstanceOf(EngramError);
+    });
+  });
+});

--- a/packages/sdk/tests/resources/memory-spaces.test.ts
+++ b/packages/sdk/tests/resources/memory-spaces.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Memory Spaces Resource Tests
+ *
+ * Tests for the MemorySpacesResource SDK pattern (engram Knowledge API).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EngramClient } from "../../src/client.js";
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers({ "content-type": "application/json" }),
+  });
+}
+
+describe("MemorySpacesResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("memorySpaces.list", () => {
+    it("should GET /v1/memory-spaces", async () => {
+      const mockSpaces = [
+        {
+          id: "space-1",
+          title: "Shared Context",
+          description: "A shared space",
+          visibility: "shared",
+          nodeType: "memory_space",
+          createdAt: "2026-01-25T10:00:00Z",
+          updatedAt: "2026-01-25T10:00:00Z",
+        },
+      ];
+
+      mockFetch = mockFetchResponse({ data: { spaces: mockSpaces } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const spaces = await client.memorySpaces.list();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/memory-spaces",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(spaces).toHaveLength(1);
+      expect(spaces[0].title).toBe("Shared Context");
+    });
+
+    it("should pass agentId query param when specified", async () => {
+      mockFetch = mockFetchResponse({ data: { spaces: [] } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.memorySpaces.list({ agentId: "agent-42" });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v1/memory-spaces?");
+      expect(calledUrl).toContain("agentId=agent-42");
+    });
+  });
+
+  describe("memorySpaces.create", () => {
+    it("should POST to /v1/memory-spaces", async () => {
+      const mockSpace = {
+        id: "space-new",
+        title: "Team Knowledge",
+        description: "A shared team space",
+        visibility: "shared",
+        nodeType: "memory_space",
+        createdAt: "2026-01-25T10:00:00Z",
+        updatedAt: "2026-01-25T10:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: { space: mockSpace } }, 201);
+      vi.stubGlobal("fetch", mockFetch);
+
+      const createParams = {
+        title: "Team Knowledge",
+        description: "A shared team space",
+        visibility: "shared" as const,
+      };
+
+      const space = await client.memorySpaces.create(createParams);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/memory-spaces",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(createParams),
+        })
+      );
+
+      expect(space.id).toBe("space-new");
+      expect(space.title).toBe("Team Knowledge");
+    });
+  });
+
+  describe("memorySpaces.get", () => {
+    it("should GET /v1/memory-spaces/:id with members", async () => {
+      const mockSpace = {
+        id: "space-1",
+        title: "Shared Context",
+        description: "A shared space",
+        visibility: "shared",
+        nodeType: "memory_space",
+        createdAt: "2026-01-25T10:00:00Z",
+        updatedAt: "2026-01-25T10:00:00Z",
+        members: [
+          { agentId: "agent-1", permission: "admin", joinedAt: "2026-01-25T10:00:00Z" },
+          { agentId: "agent-2", permission: "read", joinedAt: "2026-01-25T11:00:00Z" },
+        ],
+      };
+
+      mockFetch = mockFetchResponse({ data: { space: mockSpace } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const space = await client.memorySpaces.get("space-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/memory-spaces/space-1",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(space.id).toBe("space-1");
+      expect(space.members).toHaveLength(2);
+      expect(space.members[0].agentId).toBe("agent-1");
+    });
+  });
+
+  describe("memorySpaces.join", () => {
+    it("should POST to /v1/memory-spaces/:id/join", async () => {
+      const mockMember = {
+        agentId: "agent-3",
+        permission: "write",
+        joinedAt: "2026-01-25T12:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: { member: mockMember } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const joinParams = { agentId: "agent-3", permission: "write" as const };
+      const member = await client.memorySpaces.join("space-1", joinParams);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/memory-spaces/space-1/join",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(joinParams),
+        })
+      );
+
+      expect(member.agentId).toBe("agent-3");
+      expect(member.permission).toBe("write");
+    });
+  });
+
+  describe("memorySpaces.leave", () => {
+    it("should DELETE /v1/memory-spaces/:id/leave with agentId query param", async () => {
+      mockFetch = mockFetchResponse({ data: { removed: true } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.memorySpaces.leave("space-1", "agent-3");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/memory-spaces/space-1/leave?agentId=agent-3",
+        expect.objectContaining({
+          method: "DELETE",
+        })
+      );
+
+      expect(result.removed).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/tests/resources/sessions.test.ts
+++ b/packages/sdk/tests/resources/sessions.test.ts
@@ -408,3 +408,58 @@ describe("NotesResource", () => {
     });
   });
 });
+
+describe("SessionsResource lifecycle stats", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("sessions.getLifecycleStats", () => {
+    it("should GET /v1/sessions/:id/lifecycle-stats", async () => {
+      const mockStats = {
+        noteCount: 15,
+        decisionCount: 3,
+        constraintCount: 2,
+        branchCount: 1,
+        stuckDetectionCount: 0,
+        durationMinutes: 45,
+      };
+      mockFetch = mockFetchResponse({ data: mockStats });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sessions.getLifecycleStats("session-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sessions/session-1/lifecycle-stats",
+        expect.objectContaining({ method: "GET" })
+      );
+      expect(result.noteCount).toBe(15);
+      expect(result.durationMinutes).toBe(45);
+    });
+
+    it("should handle null durationMinutes for active sessions", async () => {
+      mockFetch = mockFetchResponse({ data: {
+        noteCount: 5, decisionCount: 1, constraintCount: 0,
+        branchCount: 0, stuckDetectionCount: 0, durationMinutes: null,
+      } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sessions.getLifecycleStats("active-session");
+      expect(result.durationMinutes).toBeNull();
+    });
+  });
+});

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Sync Resource Tests
+ *
+ * Tests for the SyncResource and SyncPeersResource SDK patterns (engram Knowledge API).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EngramClient } from "../../src/client.js";
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers({ "content-type": "application/json" }),
+  });
+}
+
+describe("SyncResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("sync.push", () => {
+    it("should POST to /v1/sync/push", async () => {
+      const mockResult = {
+        success: true,
+        counts: { crystals: 3, notes: 7 },
+        conflicts: 0,
+        duration: 150,
+      };
+
+      mockFetch = mockFetchResponse({ data: mockResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.push();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/push",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.conflicts).toBe(0);
+    });
+  });
+
+  describe("sync.pull", () => {
+    it("should POST to /v1/sync/pull", async () => {
+      const mockChanges = [
+        { type: "crystal", id: "c-1", action: "upsert" },
+        { type: "note", id: "n-1", action: "upsert" },
+      ];
+
+      mockFetch = mockFetchResponse({ data: mockChanges });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.pull();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/pull",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("sync.getStatus", () => {
+    it("should GET /v1/sync/status", async () => {
+      const mockStatus = {
+        schemaVersion: "1.0.0",
+        lastPushSeq: "seq-100",
+        lastPullSeq: "seq-95",
+        pendingChanges: 3,
+        conflictCount: 1,
+      };
+
+      mockFetch = mockFetchResponse({ data: mockStatus });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const status = await client.sync.getStatus();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/status",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(status.schemaVersion).toBe("1.0.0");
+      expect(status.pendingChanges).toBe(3);
+    });
+  });
+
+  describe("sync.pushTo", () => {
+    it("should POST to /v1/sync/push-to with peer query param", async () => {
+      const mockResult = {
+        success: true,
+        counts: { crystals: 2 },
+        conflicts: 0,
+        duration: 80,
+      };
+
+      mockFetch = mockFetchResponse({ data: mockResult });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.pushTo("my-peer");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/push-to?peer=my-peer",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("sync.pullFrom", () => {
+    it("should POST to /v1/sync/pull-from with peer query param", async () => {
+      const mockChanges = [
+        { type: "crystal", id: "c-5", action: "upsert" },
+      ];
+
+      mockFetch = mockFetchResponse({ data: mockChanges });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.pullFrom("my-peer");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/pull-from?peer=my-peer",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("sync.listConflicts", () => {
+    it("should GET /v1/sync/conflicts", async () => {
+      const mockConflicts = [
+        {
+          id: "conflict-1",
+          entityType: "crystal",
+          entityId: "c-1",
+          fieldName: "title",
+          localValue: "Local Title",
+          remoteValue: "Remote Title",
+          winner: "local",
+          resolution: "auto_lww",
+          resolvedAt: null,
+          createdAt: "2026-01-25T10:00:00Z",
+        },
+      ];
+
+      mockFetch = mockFetchResponse({
+        data: mockConflicts,
+        meta: { pagination: { total: 1, limit: 100, hasMore: false } },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.listConflicts();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/conflicts",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("should pass unresolved query param when specified", async () => {
+      mockFetch = mockFetchResponse({
+        data: [],
+        meta: { pagination: { total: 0, limit: 100, hasMore: false } },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.sync.listConflicts({ unresolved: true });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v1/sync/conflicts?");
+      expect(calledUrl).toContain("unresolved=true");
+    });
+  });
+
+  describe("sync.resolveConflict", () => {
+    it("should POST to /v1/sync/conflicts/:id/resolve", async () => {
+      const mockResolved = {
+        id: "conflict-1",
+        entityType: "crystal",
+        entityId: "c-1",
+        fieldName: "title",
+        localValue: "Local Title",
+        remoteValue: "Remote Title",
+        winner: "local",
+        resolution: "manual",
+        resolvedAt: "2026-01-25T12:00:00Z",
+        createdAt: "2026-01-25T10:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: mockResolved });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.resolveConflict("conflict-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/conflicts/conflict-1/resolve",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      expect(result.id).toBe("conflict-1");
+      expect(result.resolvedAt).toBe("2026-01-25T12:00:00Z");
+    });
+  });
+});
+
+describe("SyncPeersResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("sync.peers.create", () => {
+    it("should POST to /v1/sync/peers", async () => {
+      const mockPeer = {
+        id: "peer-1",
+        name: "staging-node",
+        url: "https://staging.engram.local",
+        lastPushAt: null,
+        lastPullAt: null,
+        lastPushSeq: null,
+        lastPullSeq: null,
+        linkEnabled: false,
+        linkIntervalSeconds: 300,
+        linkLastSyncAt: null,
+        linkLastError: null,
+        linkPaused: false,
+        createdAt: "2026-01-25T10:00:00Z",
+        updatedAt: "2026-01-25T10:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({ data: mockPeer }, 201);
+      vi.stubGlobal("fetch", mockFetch);
+
+      const createParams = {
+        name: "staging-node",
+        url: "https://staging.engram.local",
+      };
+
+      const peer = await client.sync.peers.create(createParams);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(createParams),
+        })
+      );
+
+      expect(peer.name).toBe("staging-node");
+      expect(peer.url).toBe("https://staging.engram.local");
+    });
+  });
+
+  describe("sync.peers.list", () => {
+    it("should GET /v1/sync/peers", async () => {
+      const mockPeers = [
+        { id: "peer-1", name: "staging-node", url: "https://staging.engram.local" },
+        { id: "peer-2", name: "prod-node", url: "https://prod.engram.local" },
+      ];
+
+      mockFetch = mockFetchResponse({ data: mockPeers });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const peers = await client.sync.peers.list();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(peers).toHaveLength(2);
+    });
+  });
+
+  describe("sync.peers.get", () => {
+    it("should GET /v1/sync/peers/:name", async () => {
+      const mockPeer = {
+        id: "peer-1",
+        name: "staging-node",
+        url: "https://staging.engram.local",
+        linkEnabled: true,
+        linkPaused: false,
+      };
+
+      mockFetch = mockFetchResponse({ data: mockPeer });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const peer = await client.sync.peers.get("staging-node");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers/staging-node",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(peer.name).toBe("staging-node");
+    });
+  });
+
+  describe("sync.peers.delete", () => {
+    it("should DELETE /v1/sync/peers/:name", async () => {
+      mockFetch = mockFetchResponse({ data: { deleted: true } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.peers.delete("staging-node");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers/staging-node",
+        expect.objectContaining({ method: "DELETE" })
+      );
+
+      expect(result.deleted).toBe(true);
+    });
+  });
+
+  describe("sync.peers.link", () => {
+    it("should POST to /v1/sync/peers/:name/link", async () => {
+      mockFetch = mockFetchResponse({ data: undefined });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.sync.peers.link("staging-node");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers/staging-node/link",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  describe("sync.peers.unlink", () => {
+    it("should DELETE /v1/sync/peers/:name/link", async () => {
+      mockFetch = mockFetchResponse({ data: undefined });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.sync.peers.unlink("staging-node");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers/staging-node/link",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+  });
+
+  describe("sync.peers.pause", () => {
+    it("should POST to /v1/sync/peers/:name/link/pause", async () => {
+      mockFetch = mockFetchResponse({ data: undefined });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.sync.peers.pause("staging-node");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers/staging-node/link/pause",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  describe("sync.peers.resume", () => {
+    it("should POST to /v1/sync/peers/:name/link/resume", async () => {
+      mockFetch = mockFetchResponse({ data: undefined });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.sync.peers.resume("staging-node");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/sync/peers/staging-node/link/resume",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+});

--- a/packages/sdk/tests/resources/users.test.ts
+++ b/packages/sdk/tests/resources/users.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Users Resource Tests
+ *
+ * Tests for the UsersResource SDK pattern.
+ * Users are accounts with associated API key provisioning.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EngramClient } from "../../src/client.js";
+import { EngramError } from "../../src/errors.js";
+import type { User, ApiKey } from "../../src/resources/users.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockFetchResponse(data: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const USER_ID = "00000000-0000-4000-8000-000000000010";
+
+const mockUser: User = {
+  id: USER_ID,
+  name: "alice",
+  displayName: "Alice Smith",
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const mockApiKey: ApiKey = {
+  id: "key-001",
+  name: "default",
+  prefix: "eng_",
+  value: "eng_abc123secret",
+};
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+describe("UsersResource", () => {
+  let client: EngramClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new EngramClient({
+      baseUrl: "http://localhost:3100",
+      timeout: 5000,
+      retries: 1,
+    });
+    mockFetch = mockFetchResponse({});
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // users.create()
+  // ==========================================================================
+
+  describe("users.create", () => {
+    it("should POST to /v1/users and return user + key", async () => {
+      mockFetch = mockFetchResponse(
+        { data: { user: mockUser, key: mockApiKey } },
+        201
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.users.create({ name: "alice" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/users",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "alice" }),
+        })
+      );
+
+      expect(result.user.id).toBe(USER_ID);
+      expect(result.user.name).toBe("alice");
+      expect(result.key.prefix).toBe("eng_");
+      expect(result.key.value).toBe("eng_abc123secret");
+    });
+
+    it("throws EngramError on validation failure", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "VALIDATION_FAILED", message: "name is required" } },
+        400
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.users.create({ name: "" })
+      ).rejects.toBeInstanceOf(EngramError);
+    });
+  });
+
+  // ==========================================================================
+  // users.list()
+  // ==========================================================================
+
+  describe("users.list", () => {
+    it("should GET /v1/users and return User[]", async () => {
+      const secondUser: User = {
+        id: "00000000-0000-4000-8000-000000000011",
+        name: "bob",
+        displayName: null,
+        createdAt: "2026-01-02T00:00:00Z",
+      };
+
+      mockFetch = mockFetchResponse({
+        data: { users: [mockUser, secondUser] },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.users.list();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/users",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("alice");
+      expect(result[1].name).toBe("bob");
+    });
+  });
+
+  // ==========================================================================
+  // users.get()
+  // ==========================================================================
+
+  describe("users.get", () => {
+    it("should GET /v1/users/:idOrName and return User", async () => {
+      mockFetch = mockFetchResponse({ data: { user: mockUser } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.users.get("alice");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/users/alice",
+        expect.objectContaining({ method: "GET" })
+      );
+
+      expect(result.id).toBe(USER_ID);
+      expect(result.name).toBe("alice");
+      expect(result.displayName).toBe("Alice Smith");
+    });
+
+    it("throws EngramError on 404", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "NOT_FOUND", message: "User not found" } },
+        404
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.users.get("nonexistent")).rejects.toBeInstanceOf(
+        EngramError
+      );
+    });
+  });
+
+  // ==========================================================================
+  // users.delete()
+  // ==========================================================================
+
+  describe("users.delete", () => {
+    it("should DELETE /v1/users/:idOrName", async () => {
+      mockFetch = mockFetchResponse({
+        data: { deleted: true, revokedKeys: 0 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.users.delete("alice");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/users/alice",
+        expect.objectContaining({ method: "DELETE" })
+      );
+
+      expect(result.deleted).toBe(true);
+      expect(result.revokedKeys).toBe(0);
+    });
+
+    it("should DELETE /v1/users/:idOrName?revokeKeys=true with revokeKeys option", async () => {
+      mockFetch = mockFetchResponse({
+        data: { deleted: true, revokedKeys: 3 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.users.delete("alice", { revokeKeys: true });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v1/users/alice");
+      expect(calledUrl).toContain("revokeKeys=true");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ method: "DELETE" })
+      );
+
+      expect(result.deleted).toBe(true);
+      expect(result.revokedKeys).toBe(3);
+    });
+
+    it("throws EngramError on 500", async () => {
+      mockFetch = mockFetchResponse(
+        { error: { code: "INTERNAL_ERROR", message: "Server error" } },
+        500
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.users.delete("alice")).rejects.toBeInstanceOf(
+        EngramError
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **7 new resource classes**: Facts, MemorySpaces, Users, Audit, Sync (with Peers sub-resource), GC, Maintenance — bringing total from 13 to 20
- **Type expansions**: NodeType (+`system`, `memory_space`), KnowledgeCrystal (+6 lifecycle/relevance fields), KnowledgeCrystalEdge (+`supports` relationship, `weight`, `updatedAt`, `deletedAt`), session note edges (+`supports`, `contradicts`, `extends`), MembershipAddedBy (+`terrafirma`, `consolidation`)
- **Create/Update params**: `contentRef` (ContentRef object), `coherenceMode`, client-supplied `id`, `sourceSessionId` filter
- **New methods on existing resources**: `crystals.items().bulkAdd()`/`reorder()`, `sessions.getLifecycleStats()`, `entities.graph()` multi-hop traversal
- **Server compatibility**: `MIN_SERVER_VERSION = "0.22.4"` constant, `client.checkCompatibility()` method
- **Changeset**: minor bump to 1.4.0

## Breaking changes

- `SyncStatus` type export renamed to `TerrafirmaSyncStatus` (collision with new sync module type)
- `NodeType` union expanded — exhaustive switches need updating
- `KnowledgeCrystal` has 6 new required fields; `KnowledgeCrystalEdge` has 3 new required fields

## Test plan

- [x] `pnpm build` — clean TypeScript compilation
- [x] `pnpm test` — 19 test files, 373 tests, all passing
- [x] 7 new test files for new resources + 1 new client-compat test file
- [x] Tests added for bulkAdd, reorder, graph, getLifecycleStats, checkCompatibility
- [ ] Integration test against engram-server v0.22.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)