### PR TITLE
feat(events): add @centient/events typed event streaming package

### DIFF
--- a/.changeset/add-events-package.md
+++ b/.changeset/add-events-package.md
@@ -1,0 +1,5 @@
+---
+"@centient/events": minor
+---
+
+Add @centient/events — typed event streaming with backpressure, JSONL persistence/replay, and subscribe filters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,9 @@ See `.agent/DESIGN-PHILOSOPHY.md` for the 14 principles (3 tiers) that guide all
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| `@centient/sdk` | 1.4.0 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types. Factory: `createEngramClient()`. Requires engram-server >= 0.22.4 |
+| `@centient/events` | 0.1.0 | Typed event streaming with backpressure. AsyncIterable + callback fan-out, JSONL persistence/replay, configurable backpressure. Factory: `createEventStream()`, `fromJsonl()` |
 | `@centient/logger` | 0.16.0 | Structured logging with transport abstraction. 6 levels, Console/File/Null transports, audit events, data redaction. Factory: `createLogger()`, `createAuditWriter()` |
+| `@centient/sdk` | 1.4.0 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types. Factory: `createEngramClient()`. Requires engram-server >= 0.22.4 |
 | `@centient/wal` | 0.2.0 | Write-ahead log for crash recovery. `appendEntry`, `confirmEntry`, `replayUnconfirmed`, `compactWal` |
 | `sdk-python` | - | Python SDK client with Pydantic v2 (async + sync) |
 

--- a/packages/events/2026.04.12-research-addendum.md
+++ b/packages/events/2026.04.12-research-addendum.md
@@ -1,0 +1,212 @@
+# @centient/events — Research Addendum
+
+**Date:** 2026-04-12
+**Context:** Findings from surveying the TypeScript event streaming landscape before finalizing the API.
+
+---
+
+## Read this before (or during) implementation
+
+This addendum supplements the original creation prompt. It contains patterns and
+design decisions informed by researching production event streaming libraries.
+
+## Libraries studied
+
+| Library | Weekly downloads | Key insight for us |
+|---|---|---|
+| [queueable](https://github.com/slikts/queueable) | ~5K | Push-to-pull bridge via buffering. Validates our `emit()` + `subscribe()` approach. Study its internal buffer implementation before writing ours. |
+| [strict-stream](https://www.npmjs.com/package/strict-stream) | ~1K | Composable operators (`map`, `filter`, `buffer`, `batchTimed`) on `AsyncIterable`. We don't need these for v0.1.0 but our API should be compatible. |
+| [ts-stream](https://github.com/poelstra/ts-stream) | ~2K | Single-reader design with explicit splitter. Validates our `tee()` as the fan-out mechanism. Key quote: "different choices can be made for backpressure, errors, and aborts" per subscriber. |
+| [mitt](https://github.com/developit/mitt) | 11.6M | 200 bytes. Proves tiny is better. Our package should stay minimal. |
+| [emittery](https://github.com/sindresorhus/emittery) | 29.7M | High-frequency event handling. Supports typed events. Good reference for perf-critical emit paths. |
+| [Temporal.io Event History](https://docs.temporal.io/encyclopedia/event-history) | N/A | Persists every workflow event. Replays from event log for crash recovery. Commands (requested) vs events (persisted facts). Determinism requirement for replay. |
+| [Effect-TS PubSub](https://effect.website/docs/concurrency/pubsub/) | N/A | `subscribe()` returns a `Stream`. Each subscriber gets its own queue. Failure and ending are signaled properly. |
+
+## Design decisions validated by research
+
+### 1. AsyncIterable for backpressure — CONFIRMED
+
+Node.js `for await...of` has built-in backpressure: the loop doesn't pull the
+next chunk until the current iteration completes. The producer's rate
+automatically matches the consumer's rate. No explicit `pause()`/`resume()`
+needed.
+
+```typescript
+// Backpressure is automatic — if processEvent() takes 500ms,
+// the stream naturally throttles to 2 events/second for this subscriber
+for await (const event of stream.subscribe()) {
+  await processEvent(event); // slow consumer = automatic backpressure
+}
+```
+
+This is confirmed by Node.js docs, queueable's design rationale, and
+strict-stream's architecture.
+
+### 2. Per-subscriber buffers with overflow policy — CONFIRMED
+
+queueable and ts-stream both use per-subscriber buffers to bridge push (emit)
+and pull (subscribe). Our `bufferSize` + `BackpressurePolicy` design is correct.
+
+**Implementation note from queueable:** The internal adapter maintains a queue
+of pending values AND a queue of pending resolvers. When a value is pushed and
+a resolver is waiting, they're matched immediately (no buffering needed). When
+a value is pushed with no resolver waiting, it goes to the buffer. When the
+buffer is full, the overflow policy kicks in.
+
+**Implement this two-queue approach** — it's more efficient than always buffering:
+
+```typescript
+// Internal state per subscriber
+interface SubscriberState<T> {
+  buffer: T[];                    // pending values (no consumer waiting)
+  resolvers: Array<{              // pending consumers (no value available)
+    resolve: (result: IteratorResult<T>) => void;
+    reject: (error: Error) => void;
+  }>;
+  closed: boolean;
+}
+```
+
+When `emit()` is called:
+1. If a resolver is waiting → resolve it immediately (zero-copy, no buffer)
+2. If no resolver → push to buffer (apply overflow policy if full)
+
+When `subscribe().next()` is called:
+1. If buffer has values → return next value immediately
+2. If buffer empty → add a resolver (consumer waits until next emit)
+
+### 3. Explicit fan-out via tee() — CONFIRMED
+
+ts-stream enforces single-reader by design and requires an explicit splitter
+for multi-reader. Their rationale: each subscriber may need different
+backpressure, error handling, and completion semantics.
+
+Our `tee()` is that explicit splitter. Each tee'd subscriber gets its own
+buffer and overflow policy, independent of other subscribers. This is correct.
+
+### 4. Keep it minimal — CONFIRMED
+
+mitt's success (11.6M downloads, 200 bytes) proves that small, focused APIs
+win. Resist adding operators in v0.1.0.
+
+## Changes to the original API based on research
+
+### Addition 1: Subscribe with filter
+
+Extremely common need — subscribe to a subset of events without receiving all
+of them. Add an optional `filter` to `SubscribeOptions`:
+
+```typescript
+interface SubscribeOptions<T> {
+  bufferSize?: number;
+  filter?: (event: T) => boolean;
+}
+
+// Usage:
+for await (const event of stream.subscribe({
+  filter: (e) => e.type.startsWith("container:")
+})) {
+  // only receives container events
+}
+```
+
+The filter runs synchronously before buffering — filtered-out events never
+enter the subscriber's buffer. This is more efficient than filtering after
+the fact, and prevents buffer overflow from irrelevant events.
+
+### Addition 2: fromJsonl() reader for replay
+
+Events persisted via `jsonl()` should be readable back as an `AsyncIterable`.
+This enables Temporal-style replay:
+
+```typescript
+// Persist events
+stream.jsonl("/var/log/soma-events.jsonl");
+
+// Later: replay events from the log
+import { fromJsonl } from "@centient/events";
+
+for await (const event of fromJsonl<SomaEvent>("/var/log/soma-events.jsonl")) {
+  // replays events in order, with original timestamps in _ts field
+}
+```
+
+Implementation: read file line-by-line, `JSON.parse()` each line, yield as
+`AsyncIterable`. Supports both completed files and live tailing (follow mode):
+
+```typescript
+function fromJsonl<T>(path: string, opts?: { follow?: boolean }): AsyncIterable<T>;
+```
+
+- `follow: false` (default): read to EOF, then complete
+- `follow: true`: read to EOF, then watch for new lines (like `tail -f`)
+
+This is critical for ADR-017's replay mode and for Temporal-style crash
+recovery patterns. Build it in v0.1.0 — it's small and high-value.
+
+### Addition 3: Event metadata convention
+
+Temporal distinguishes "commands" (requested actions) from "events" (persisted
+facts). We should establish a convention for event metadata without enforcing
+a specific type:
+
+```typescript
+/**
+ * Optional helper for consistent event metadata.
+ * Consumers are NOT required to use this — EventStream<T> accepts any T.
+ * But consumers that want consistent metadata should follow this convention.
+ */
+interface EventMeta {
+  /** ISO 8601 timestamp. Auto-set by emit() if using EventEnvelope helper. */
+  timestamp: string;
+  /** Source system (e.g., "membrane", "soma", "engram"). */
+  source: string;
+  /** Event type discriminant (e.g., "container:created", "block:started"). */
+  type: string;
+}
+```
+
+The `EventEnvelope<T, P>` helper from the original prompt already covers this.
+Just ensure the JSONL serializer respects the `timestamp` field for ordering
+during replay.
+
+### Non-addition: No operators in v0.1.0
+
+strict-stream has `map`, `filter`, `reduce`, `buffer`, `batchTimed`, `scale`.
+These are useful but premature for v0.1.0. Our API should be **compatible**
+with adding them later (i.e., `AsyncIterable`-based, so external operator
+libraries work), but we don't ship them.
+
+If operators are needed later, consider depending on strict-stream rather than
+reimplementing. Or add a `pipe()` method that accepts `AsyncIterable`
+transforms:
+
+```typescript
+// Future v0.2.0 — NOT for initial implementation
+stream.subscribe().pipe(
+  filter((e) => e.type === "block:started"),
+  map((e) => e.payload),
+);
+```
+
+## Implementation priority (updated)
+
+The original prompt listed 8 source files. Updated priority with research:
+
+1. **src/types.ts** — interfaces (add `filter` to SubscribeOptions)
+2. **src/stream.ts** — EventStream with two-queue subscriber model (from queueable pattern)
+3. **src/jsonl.ts** — JSONL writer subscriber
+4. **src/replay.ts** — `fromJsonl()` reader (NEW — add this file)
+5. **src/envelope.ts** — EventEnvelope helper
+6. **src/index.ts** — re-exports
+
+## Summary of changes vs original prompt
+
+| Aspect | Original | After research |
+|---|---|---|
+| Internal buffer | Simple array | Two-queue (values + resolvers) — zero-copy when consumer is waiting |
+| Subscribe filter | Not included | Added — `filter` option on subscribe, runs before buffering |
+| JSONL replay | Not included | Added — `fromJsonl()` with optional follow mode |
+| Operators | Not included | Confirmed: NOT in v0.1.0, but API is compatible for future |
+| Event metadata | EventEnvelope helper | Same, plus ensure JSONL respects timestamp for replay ordering |
+| Core approach | Validated | Confirmed by queueable, ts-stream, Effect-TS, Temporal patterns |

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,186 @@
+# @centient/events
+
+Typed event streaming with backpressure for Node.js. AsyncIterable fan-out, JSONL persistence, configurable backpressure, and live replay.
+
+## Installation
+
+```bash
+pnpm add @centient/events
+```
+
+## Quick Start
+
+```typescript
+import { createEventStream } from "@centient/events";
+
+type AppEvent = { type: "user:login"; userId: string } | { type: "order:placed"; orderId: string };
+
+const stream = createEventStream<AppEvent>();
+
+const events = stream.subscribe();
+(async () => {
+  for await (const event of events) {
+    console.log(event.type, event);
+  }
+})();
+
+stream.emit({ type: "user:login", userId: "u-1" });
+stream.emit({ type: "order:placed", orderId: "ord-42" });
+
+await stream.close();
+```
+
+## API
+
+### `createEventStream<T>(opts?)`
+
+```typescript
+const stream = createEventStream<MyEvent>({
+  backpressure: "drop-oldest", // default
+  defaultBufferSize: 1000,     // default
+});
+```
+
+Returns an `EventStream<T>`.
+
+### `EventStream<T>`
+
+| Member | Signature | Description |
+|--------|-----------|-------------|
+| `emit` | `(event: T) => void` | Deliver an event to all subscribers |
+| `subscribe` | `(opts?: SubscribeOptions<T>) => AsyncIterable<T>` | AsyncIterable for `for await...of` consumption |
+| `tee` | `(name: string, subscriber: EventSubscriber<T>) => () => void` | Add a named callback subscriber; returns a dispose function |
+| `jsonl` | `(filePath: string) => () => void` | Persist events to a JSONL file; returns a dispose function |
+| `subscriberCount` | `readonly number` | Active subscriber count (AsyncIterable + tee'd) |
+| `close` | `() => Promise<void>` | Flush, signal completion, and clean up all subscribers |
+
+### `SubscribeOptions<T>`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `bufferSize` | `number` | Override the per-subscriber buffer capacity |
+| `filter` | `(event: T) => boolean` | Only deliver events that pass this predicate |
+
+### `BackpressurePolicy`
+
+| Value | Behavior |
+|-------|----------|
+| `"drop-oldest"` | Drop the oldest buffered event to make room (default) |
+| `"drop-newest"` | Reject the incoming event; keep the buffer intact |
+| `"block"` | Block `emit()` until buffer space is available — use carefully |
+
+### `EventSubscriber<T>`
+
+Callback-based subscriber for use with `tee()`.
+
+```typescript
+interface EventSubscriber<T> {
+  name: string;
+  onEvent(event: T): void | Promise<void>;
+  onError?(error: Error): void;
+  onClose?(): void;
+}
+```
+
+### `defineEvent<T, P>(type)`
+
+Create a typed event envelope factory for a given discriminant string. Timestamps are auto-generated (ISO 8601).
+
+```typescript
+import { defineEvent } from "@centient/events";
+import type { EventEnvelope } from "@centient/events";
+
+const blockStarted = defineEvent<"block:started", { blockPath: string }>("block:started");
+const event = blockStarted({ blockPath: "implement/auth" });
+// => { type: "block:started", timestamp: "2026-...", payload: { blockPath: "implement/auth" } }
+```
+
+### `fromJsonl<T>(path, opts?)`
+
+Read events from a JSONL file as an `AsyncIterable`. Replays logs written by `stream.jsonl()`.
+
+```typescript
+import { fromJsonl } from "@centient/events";
+
+// One-shot replay
+for await (const event of fromJsonl<MyEvent>("/var/log/events.jsonl")) { ... }
+
+// Live tail (like tail -f)
+for await (const event of fromJsonl<MyEvent>("/var/log/events.jsonl", { follow: true })) { ... }
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `follow` | `boolean` | `false` | Continue watching after EOF (live tail mode) |
+| `keepMeta` | `boolean` | `false` | Keep the `_ts` metadata field in emitted events |
+
+### `createJsonlSubscriber<T>(filePath)`
+
+Standalone JSONL file subscriber factory. Returns `{ subscriber, flush }` for use with `stream.tee()` when manual lifecycle control is needed.
+
+```typescript
+import { createJsonlSubscriber } from "@centient/events";
+
+const { subscriber, flush } = createJsonlSubscriber<MyEvent>("/var/log/events.jsonl");
+const dispose = stream.tee("my-log", subscriber);
+await flush();
+dispose();
+```
+
+Writes are buffered (flushed every 100 ms or every 100 events, whichever comes first). `stream.jsonl(filePath)` is a convenience wrapper around this.
+
+## Examples
+
+### Subscribe with filter
+
+```typescript
+const stream = createEventStream<AppEvent>();
+
+const logins = stream.subscribe({
+  filter: (e) => e.type === "user:login",
+});
+
+for await (const event of logins) {
+  console.log("login:", event.userId);
+}
+```
+
+### JSONL persistence and replay
+
+```typescript
+import { createEventStream, fromJsonl } from "@centient/events";
+
+const LOG = "/var/log/app-events.jsonl";
+const stream = createEventStream<AppEvent>();
+
+const stopLogging = stream.jsonl(LOG);
+stream.emit({ type: "user:login", userId: "u-1" });
+await stream.close();
+
+// Replay on next startup
+for await (const event of fromJsonl<AppEvent>(LOG)) {
+  console.log("replaying:", event);
+}
+```
+
+### Typed event envelopes
+
+```typescript
+import { createEventStream, defineEvent } from "@centient/events";
+import type { EventEnvelope } from "@centient/events";
+
+type BlockEvent =
+  | EventEnvelope<"block:started", { blockPath: string }>
+  | EventEnvelope<"block:completed", { blockPath: string; durationMs: number }>;
+
+const blockStarted = defineEvent<"block:started", { blockPath: string }>("block:started");
+const blockCompleted = defineEvent<"block:completed", { blockPath: string; durationMs: number }>("block:completed");
+
+const stream = createEventStream<BlockEvent>();
+stream.emit(blockStarted({ blockPath: "implement/auth" }));
+stream.emit(blockCompleted({ blockPath: "implement/auth", durationMs: 3200 }));
+```
+
+## License
+
+MIT

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@centient/events",
+  "version": "0.1.0",
+  "description": "Typed event streaming with backpressure for Centient packages",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/centient-labs/centient-sdk.git",
+    "directory": "packages/events"
+  },
+  "bugs": {
+    "url": "https://github.com/centient-labs/centient-sdk/issues"
+  },
+  "homepage": "https://github.com/centient-labs/centient-sdk/tree/main/packages/events#readme",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "centient",
+    "events",
+    "event-stream",
+    "async-iterable",
+    "backpressure"
+  ],
+  "author": "Owen Johnson",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@centient/logger": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^4.0.17",
+    "typescript": "^5.3.0",
+    "vitest": "^4.0.17"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/events/src/envelope.ts
+++ b/packages/events/src/envelope.ts
@@ -1,0 +1,37 @@
+/**
+ * Event Envelope Helper
+ *
+ * Optional typed envelope for standardizing event metadata.
+ * Consumers can use any event type with EventStream — this helper
+ * provides a convenient factory for creating typed events with
+ * auto-generated timestamps.
+ */
+
+import type { EventEnvelope } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a typed event factory for a given event type discriminant.
+ *
+ * @param type - The event type string (e.g., "block:started")
+ * @returns A factory function that creates EventEnvelope instances
+ *
+ * @example
+ * ```ts
+ * const blockStarted = defineEvent<"block:started", { blockPath: string }>("block:started");
+ * const event = blockStarted({ blockPath: "implement/auth" });
+ * // => { type: "block:started", timestamp: "2026-...", payload: { blockPath: "implement/auth" } }
+ * ```
+ */
+export function defineEvent<T extends string, P>(
+  type: T,
+): (payload: P) => EventEnvelope<T, P> {
+  return (payload: P): EventEnvelope<T, P> => ({
+    type,
+    timestamp: new Date().toISOString(),
+    payload,
+  });
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -13,6 +13,5 @@ export type {
   SubscribeOptions,
   BackpressurePolicy,
   EventEnvelope,
+  FromJsonlOptions,
 } from "./types.js";
-
-export type { FromJsonlOptions } from "./replay.js";

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,0 +1,18 @@
+export { createEventStream } from "./stream.js";
+
+export { createJsonlSubscriber } from "./jsonl.js";
+
+export { defineEvent } from "./envelope.js";
+
+export { fromJsonl } from "./replay.js";
+
+export type {
+  EventStream,
+  EventStreamOptions,
+  EventSubscriber,
+  SubscribeOptions,
+  BackpressurePolicy,
+  EventEnvelope,
+} from "./types.js";
+
+export type { FromJsonlOptions } from "./replay.js";

--- a/packages/events/src/jsonl.ts
+++ b/packages/events/src/jsonl.ts
@@ -2,7 +2,7 @@
  * JSONL File Subscriber
  *
  * Appends events as newline-delimited JSON to a file. Each event is
- * serialized with a `_ts` field prepended (ISO 8601 timestamp).
+ * wrapped in `{ _ts, event }` (ISO 8601 timestamp + original payload).
  *
  * Writes are buffered and flushed periodically (every 100ms or 100 events).
  * File writes use append mode — safe for concurrent reads (tail -f).
@@ -23,6 +23,20 @@ const logger = createComponentLogger("centient", "events:jsonl");
 
 const FLUSH_INTERVAL_MS = 100;
 const FLUSH_BATCH_SIZE = 100;
+const MAX_BUFFER_SIZE = FLUSH_BATCH_SIZE * 10;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function errorContext(err: unknown, filePath?: string): Record<string, unknown> {
+  const ctx: Record<string, unknown> = {
+    error: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+  };
+  if (filePath !== undefined) ctx.filePath = filePath;
+  return ctx;
+}
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -41,12 +55,13 @@ export function createJsonlSubscriber<T>(filePath: string): {
   let buffer: string[] = [];
   let flushTimer: ReturnType<typeof setInterval> | null = null;
   let dirCreated = false;
+  let flushChain: Promise<void> = Promise.resolve();
 
   // -------------------------------------------------------------------------
   // Flush
   // -------------------------------------------------------------------------
 
-  async function flush(): Promise<void> {
+  async function doFlush(): Promise<void> {
     if (buffer.length === 0) return;
 
     const lines = buffer;
@@ -59,8 +74,28 @@ export function createJsonlSubscriber<T>(filePath: string): {
       }
       await appendFile(filePath, lines.join(""), "utf-8");
     } catch (err) {
-      logger.error({ filePath, error: String(err) }, "JSONL write error");
+      // Reset dirCreated if the directory was removed
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+        dirCreated = false;
+      }
+
+      // Prepend failed lines back into the buffer for retry
+      buffer = [...lines, ...buffer];
+
+      // Cap buffer to prevent infinite growth
+      if (buffer.length > MAX_BUFFER_SIZE) {
+        const dropped = buffer.length - MAX_BUFFER_SIZE;
+        buffer = buffer.slice(dropped);
+        logger.warn({ filePath, droppedLines: dropped }, "JSONL buffer overflow, oldest lines dropped");
+      }
+
+      logger.error(errorContext(err, filePath), "JSONL write error");
     }
+  }
+
+  function flush(): Promise<void> {
+    flushChain = flushChain.then(doFlush);
+    return flushChain;
   }
 
   // -------------------------------------------------------------------------
@@ -71,7 +106,7 @@ export function createJsonlSubscriber<T>(filePath: string): {
     if (flushTimer) return;
     flushTimer = setInterval(() => {
       flush().catch((err) => {
-        logger.error({ error: String(err) }, "JSONL periodic flush error");
+        logger.error(errorContext(err, filePath), "JSONL periodic flush error");
       });
     }, FLUSH_INTERVAL_MS);
     // Unref so the timer doesn't keep the process alive
@@ -92,33 +127,29 @@ export function createJsonlSubscriber<T>(filePath: string): {
   // -------------------------------------------------------------------------
 
   const subscriber: EventSubscriber<T> = {
-    name: `jsonl:${filePath}`,
-
     onEvent(event: T): void {
-      const line = JSON.stringify({ _ts: new Date().toISOString(), ...event as object }) + "\n";
+      const line = JSON.stringify({ _ts: new Date().toISOString(), event }) + "\n";
       buffer.push(line);
-      startTimer();
+      if (!flushTimer) startTimer();
 
       // Flush eagerly if batch size reached
       if (buffer.length >= FLUSH_BATCH_SIZE) {
         flush().catch((err) => {
-          logger.error({ error: String(err) }, "JSONL batch flush error");
+          logger.error(errorContext(err, filePath), "JSONL batch flush error");
         });
       }
     },
 
     onError(error: Error): void {
-      logger.error({ filePath, error: error.message }, "JSONL subscriber received error");
+      logger.error({ filePath, error: error.message, stack: error.stack }, "JSONL subscriber received error");
     },
 
     onClose(): void {
       stopTimer();
-      // Synchronous-safe: schedule final flush (close() awaits the flush promise)
-      flush().catch((err) => {
-        logger.error({ error: String(err) }, "JSONL final flush error");
-      });
     },
   };
+
+  logger.info({ filePath }, "JSONL subscriber created");
 
   return { subscriber, flush: async () => { stopTimer(); await flush(); } };
 }

--- a/packages/events/src/jsonl.ts
+++ b/packages/events/src/jsonl.ts
@@ -1,0 +1,124 @@
+/**
+ * JSONL File Subscriber
+ *
+ * Appends events as newline-delimited JSON to a file. Each event is
+ * serialized with a `_ts` field prepended (ISO 8601 timestamp).
+ *
+ * Writes are buffered and flushed periodically (every 100ms or 100 events).
+ * File writes use append mode — safe for concurrent reads (tail -f).
+ */
+
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { createComponentLogger } from "@centient/logger";
+
+import type { EventSubscriber } from "./types.js";
+
+const logger = createComponentLogger("centient", "events:jsonl");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FLUSH_INTERVAL_MS = 100;
+const FLUSH_BATCH_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a JSONL file subscriber and its flush function.
+ *
+ * @param filePath - Path to the JSONL output file (created/appended)
+ * @returns subscriber for use with `tee()`, and a `flush()` to drain the buffer
+ */
+export function createJsonlSubscriber<T>(filePath: string): {
+  subscriber: EventSubscriber<T>;
+  flush: () => Promise<void>;
+} {
+  let buffer: string[] = [];
+  let flushTimer: ReturnType<typeof setInterval> | null = null;
+  let dirCreated = false;
+
+  // -------------------------------------------------------------------------
+  // Flush
+  // -------------------------------------------------------------------------
+
+  async function flush(): Promise<void> {
+    if (buffer.length === 0) return;
+
+    const lines = buffer;
+    buffer = [];
+
+    try {
+      if (!dirCreated) {
+        await mkdir(dirname(filePath), { recursive: true });
+        dirCreated = true;
+      }
+      await appendFile(filePath, lines.join(""), "utf-8");
+    } catch (err) {
+      logger.error({ filePath, error: String(err) }, "JSONL write error");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Timer
+  // -------------------------------------------------------------------------
+
+  function startTimer(): void {
+    if (flushTimer) return;
+    flushTimer = setInterval(() => {
+      flush().catch((err) => {
+        logger.error({ error: String(err) }, "JSONL periodic flush error");
+      });
+    }, FLUSH_INTERVAL_MS);
+    // Unref so the timer doesn't keep the process alive
+    if (typeof flushTimer === "object" && "unref" in flushTimer) {
+      flushTimer.unref();
+    }
+  }
+
+  function stopTimer(): void {
+    if (flushTimer) {
+      clearInterval(flushTimer);
+      flushTimer = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Subscriber
+  // -------------------------------------------------------------------------
+
+  const subscriber: EventSubscriber<T> = {
+    name: `jsonl:${filePath}`,
+
+    onEvent(event: T): void {
+      const line = JSON.stringify({ _ts: new Date().toISOString(), ...event as object }) + "\n";
+      buffer.push(line);
+      startTimer();
+
+      // Flush eagerly if batch size reached
+      if (buffer.length >= FLUSH_BATCH_SIZE) {
+        flush().catch((err) => {
+          logger.error({ error: String(err) }, "JSONL batch flush error");
+        });
+      }
+    },
+
+    onError(error: Error): void {
+      logger.error({ filePath, error: error.message }, "JSONL subscriber received error");
+    },
+
+    onClose(): void {
+      stopTimer();
+      // Synchronous-safe: schedule final flush (close() awaits the flush promise)
+      flush().catch((err) => {
+        logger.error({ error: String(err) }, "JSONL final flush error");
+      });
+    },
+  };
+
+  return { subscriber, flush: async () => { stopTimer(); await flush(); } };
+}

--- a/packages/events/src/replay.ts
+++ b/packages/events/src/replay.ts
@@ -20,25 +20,15 @@ import { open, type FileHandle } from "node:fs/promises";
 
 import { createComponentLogger } from "@centient/logger";
 
+import type { FromJsonlOptions } from "./types.js";
+
 const logger = createComponentLogger("centient", "events:replay");
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+/** Maximum line size before discarding (1 MB). */
+const MAX_LINE_BYTES = 1_048_576;
 
-/** Options for `fromJsonl()`. */
-export interface FromJsonlOptions {
-  /**
-   * If true, continue watching for new lines after reaching EOF (like tail -f).
-   * Default: false (read to EOF then complete).
-   */
-  follow?: boolean;
-  /**
-   * If true, keep the `_ts` metadata field in emitted events.
-   * Default: false (strip `_ts` before yielding).
-   */
-  keepMeta?: boolean;
-}
+/** Reusable read buffer size for follow mode (64 KB). */
+const READ_BUFFER_SIZE = 65_536;
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -75,14 +65,17 @@ function createOneShotIterator<T>(path: string, keepMeta: boolean): AsyncIterato
   let rl: ReadlineInterface | null = null;
   const buffer: T[] = [];
   let done = false;
+  let streamError: Error | null = null;
   let waiting: ((result: IteratorResult<T>) => void) | null = null;
+  let waitingReject: ((error: Error) => void) | null = null;
 
   function init(): void {
     stream = createReadStream(path, { encoding: "utf-8" });
     rl = createInterface({ input: stream, crlfDelay: Infinity });
+    logger.info({ path }, "JSONL reader opened");
 
     rl.on("line", (line: string) => {
-      const parsed = parseLine<T>(line, keepMeta);
+      const parsed = parseLine<T>(line, keepMeta, path);
       if (parsed === null) return;
 
       if (waiting) {
@@ -96,6 +89,9 @@ function createOneShotIterator<T>(path: string, keepMeta: boolean): AsyncIterato
 
     rl.on("close", () => {
       done = true;
+      stream = null;
+      rl = null;
+      logger.info({ path }, "JSONL reader closed");
       if (waiting) {
         const resolve = waiting;
         waiting = null;
@@ -104,22 +100,26 @@ function createOneShotIterator<T>(path: string, keepMeta: boolean): AsyncIterato
     });
 
     rl.on("error", (err: Error) => {
-      logger.error({ error: err.message }, "JSONL readline error");
+      logger.error({ error: err.message, stack: err.stack, path }, "JSONL readline error");
+      streamError = err;
       done = true;
-      if (waiting) {
-        const resolve = waiting;
+      if (waitingReject) {
+        const reject = waitingReject;
         waiting = null;
-        resolve({ done: true, value: undefined });
+        waitingReject = null;
+        reject(err);
       }
     });
 
     stream.on("error", (err: Error) => {
-      logger.error({ error: err.message }, "JSONL read stream error");
+      logger.error({ error: err.message, stack: err.stack, path }, "JSONL read stream error");
+      streamError = err;
       done = true;
-      if (waiting) {
-        const resolve = waiting;
+      if (waitingReject) {
+        const reject = waitingReject;
         waiting = null;
-        resolve({ done: true, value: undefined });
+        waitingReject = null;
+        reject(err);
       }
     });
   }
@@ -133,25 +133,33 @@ function createOneShotIterator<T>(path: string, keepMeta: boolean): AsyncIterato
         return Promise.resolve({ done: false, value: buffer.shift()! });
       }
 
-      // If we've finished reading, signal done
+      // If we've finished reading, signal done or propagate error
       if (done) {
+        if (streamError) {
+          const err = streamError;
+          streamError = null;
+          return Promise.reject(err);
+        }
         return Promise.resolve({ done: true, value: undefined });
       }
 
       // Wait for the next line
-      return new Promise<IteratorResult<T>>((resolve) => {
+      return new Promise<IteratorResult<T>>((resolve, reject) => {
         waiting = resolve;
+        waitingReject = reject;
       });
     },
 
     return(): Promise<IteratorResult<T>> {
-      cleanup(rl, stream, null);
+      done = true;
+      try { rl?.close(); } catch (err) { logger.warn({ error: String(err) }, "cleanup error"); }
+      try { stream?.destroy(); } catch (err) { logger.warn({ error: String(err) }, "cleanup error"); }
       rl = null;
       stream = null;
-      done = true;
       if (waiting) {
         const resolve = waiting;
         waiting = null;
+        waitingReject = null;
         resolve({ done: true, value: undefined });
       }
       return Promise.resolve({ done: true, value: undefined });
@@ -172,45 +180,87 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
   let closed = false;
   let waiting: ((result: IteratorResult<T>) => void) | null = null;
   let initialized = false;
+  let initError: Error | null = null;
+
+  const readBuf = Buffer.allocUnsafe(READ_BUFFER_SIZE);
 
   async function init(): Promise<void> {
     if (initialized) return;
-    initialized = true;
+    try {
+      fh = await open(path, "r");
 
-    fh = await open(path, "r");
+      // Read initial content
+      await readNewContent();
 
-    // Read initial content
-    await readNewContent();
-
-    // Watch for changes
-    watcher = watch(path, () => {
-      readNewContent().catch((err) => {
-        logger.error({ error: String(err) }, "follow mode read error");
+      // Watch for changes
+      watcher = watch(path, () => {
+        readNewContent().catch((err) => {
+          logger.error(
+            { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined, path },
+            "follow mode read error",
+          );
+          closed = true;
+          if (waiting) {
+            const resolve = waiting;
+            waiting = null;
+            resolve({ done: true, value: undefined });
+          }
+        });
       });
-    });
-    watcher.unref();
+      watcher.unref();
+      initialized = true;
+      logger.info({ path }, "follow mode reader opened");
+    } catch (err) {
+      closed = true;
+      initError = err instanceof Error ? err : new Error(String(err));
+      logger.error({ error: initError.message, stack: initError.stack, path }, "follow mode init failed");
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: true, value: undefined });
+      }
+    }
   }
 
   async function readNewContent(): Promise<void> {
     if (!fh || closed) return;
 
+    // Detect file truncation before reading
     const stat = await fh.stat();
+    if (stat.size < offset) {
+      logger.warn({ path, previousOffset: offset, newSize: stat.size }, "JSONL file truncated — resetting read position");
+      offset = 0;
+      remainder = "";
+    }
     if (stat.size <= offset) return;
 
-    const readSize = stat.size - offset;
-    const buf = Buffer.alloc(readSize);
-    const { bytesRead } = await fh.read(buf, 0, readSize, offset);
-    offset += bytesRead;
+    let totalRead = 0;
+    let text = remainder;
 
-    const text = remainder + buf.toString("utf-8", 0, bytesRead);
+    while (true) {
+      const { bytesRead } = await fh.read(readBuf, 0, READ_BUFFER_SIZE, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+      text += readBuf.toString("utf-8", 0, bytesRead);
+      totalRead += bytesRead;
+    }
+
+    if (totalRead === 0) return;
+
     const lines = text.split("\n");
 
     // Last element may be incomplete — save for next read
     remainder = lines.pop() ?? "";
 
+    // Guard against unbounded remainder growth
+    if (remainder.length > MAX_LINE_BYTES) {
+      logger.warn({ path }, "follow mode: oversized line discarded");
+      remainder = "";
+    }
+
     for (const line of lines) {
       if (line.trim() === "") continue;
-      const parsed = parseLine<T>(line, keepMeta);
+      const parsed = parseLine<T>(line, keepMeta, path);
       if (parsed === null) continue;
 
       if (waiting) {
@@ -226,6 +276,10 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
   return {
     async next(): Promise<IteratorResult<T>> {
       await init();
+
+      if (initError) {
+        return Promise.reject(initError);
+      }
 
       // Return buffered item if available
       if (buffer.length > 0) {
@@ -245,11 +299,11 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
     async return(): Promise<IteratorResult<T>> {
       closed = true;
       if (watcher) {
-        watcher.close();
+        try { watcher.close(); } catch (err) { logger.warn({ error: String(err) }, "cleanup error"); }
         watcher = null;
       }
       if (fh) {
-        await fh.close();
+        try { await fh.close(); } catch (err) { logger.warn({ error: String(err) }, "cleanup error"); }
         fh = null;
       }
       if (waiting) {
@@ -267,29 +321,40 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
 // ---------------------------------------------------------------------------
 
 /** Parse a JSONL line, optionally stripping the `_ts` metadata field. */
-function parseLine<T>(line: string, keepMeta: boolean): T | null {
+function parseLine<T>(line: string, keepMeta: boolean, path: string): T | null {
   const trimmed = line.trim();
   if (trimmed === "") return null;
 
   try {
-    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-    if (!keepMeta && "_ts" in parsed) {
-      delete parsed["_ts"];
+    const raw: unknown = JSON.parse(trimmed);
+
+    // Type guard: only accept plain objects
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      logger.warn({ path, line: trimmed.slice(0, 120) }, "skipping non-object JSONL line");
+      return null;
     }
+
+    const parsed = raw as Record<string, unknown>;
+
+    // Handle wrapper format { _ts, event: ... } from updated jsonl.ts
+    if ("event" in parsed) {
+      const event = parsed["event"];
+      if (keepMeta) {
+        return { _ts: parsed["_ts"], ...(event as object) } as T;
+      }
+      return event as T;
+    }
+
+    // Legacy spread format (backwards compatibility)
+    if (!keepMeta && "_ts" in parsed) {
+      const { _ts, ...rest } = parsed;
+      void _ts;
+      return rest as T;
+    }
+
     return parsed as T;
   } catch {
-    logger.warn("skipping malformed JSONL line");
+    logger.warn({ path, line: trimmed.slice(0, 120) }, "skipping malformed JSONL line");
     return null;
   }
-}
-
-/** Clean up readline, stream, and watcher resources. */
-function cleanup(
-  rl: ReadlineInterface | null,
-  stream: ReadStream | null,
-  watcher: FSWatcher | null,
-): void {
-  try { rl?.close(); } catch { /* ignore */ }
-  try { stream?.destroy(); } catch { /* ignore */ }
-  try { watcher?.close(); } catch { /* ignore */ }
 }

--- a/packages/events/src/replay.ts
+++ b/packages/events/src/replay.ts
@@ -1,0 +1,295 @@
+/**
+ * JSONL Replay Reader
+ *
+ * Reads events from a JSONL file as an AsyncIterable, enabling replay
+ * of persisted event logs. Supports both one-shot reads and live
+ * tailing (follow mode) for real-time consumption.
+ *
+ * Usage:
+ *   // Read completed file
+ *   for await (const event of fromJsonl<MyEvent>("/path/to/events.jsonl")) { ... }
+ *
+ *   // Live tail (like tail -f)
+ *   for await (const event of fromJsonl<MyEvent>("/path/to/events.jsonl", { follow: true })) { ... }
+ */
+
+import { createReadStream, type ReadStream } from "node:fs";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import { watch, type FSWatcher } from "node:fs";
+import { open, type FileHandle } from "node:fs/promises";
+
+import { createComponentLogger } from "@centient/logger";
+
+const logger = createComponentLogger("centient", "events:replay");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for `fromJsonl()`. */
+export interface FromJsonlOptions {
+  /**
+   * If true, continue watching for new lines after reaching EOF (like tail -f).
+   * Default: false (read to EOF then complete).
+   */
+  follow?: boolean;
+  /**
+   * If true, keep the `_ts` metadata field in emitted events.
+   * Default: false (strip `_ts` before yielding).
+   */
+  keepMeta?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Read events from a JSONL file as an AsyncIterable.
+ * Enables replay of persisted event logs written by `EventStream.jsonl()`.
+ *
+ * @param path - Path to the JSONL file
+ * @param opts - Options (follow mode for live tailing, keepMeta to preserve `_ts`)
+ * @returns AsyncIterable that yields parsed events
+ */
+export function fromJsonl<T>(path: string, opts?: FromJsonlOptions): AsyncIterable<T> {
+  const follow = opts?.follow ?? false;
+  const keepMeta = opts?.keepMeta ?? false;
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      if (follow) {
+        return createFollowIterator<T>(path, keepMeta);
+      }
+      return createOneShotIterator<T>(path, keepMeta);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// One-Shot Reader (read to EOF, then done)
+// ---------------------------------------------------------------------------
+
+function createOneShotIterator<T>(path: string, keepMeta: boolean): AsyncIterator<T> {
+  let stream: ReadStream | null = null;
+  let rl: ReadlineInterface | null = null;
+  const buffer: T[] = [];
+  let done = false;
+  let waiting: ((result: IteratorResult<T>) => void) | null = null;
+
+  function init(): void {
+    stream = createReadStream(path, { encoding: "utf-8" });
+    rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+    rl.on("line", (line: string) => {
+      const parsed = parseLine<T>(line, keepMeta);
+      if (parsed === null) return;
+
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: false, value: parsed });
+      } else {
+        buffer.push(parsed);
+      }
+    });
+
+    rl.on("close", () => {
+      done = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: true, value: undefined });
+      }
+    });
+
+    rl.on("error", (err: Error) => {
+      logger.error({ error: err.message }, "JSONL readline error");
+      done = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: true, value: undefined });
+      }
+    });
+
+    stream.on("error", (err: Error) => {
+      logger.error({ error: err.message }, "JSONL read stream error");
+      done = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: true, value: undefined });
+      }
+    });
+  }
+
+  return {
+    next(): Promise<IteratorResult<T>> {
+      if (!rl) init();
+
+      // Return buffered item if available
+      if (buffer.length > 0) {
+        return Promise.resolve({ done: false, value: buffer.shift()! });
+      }
+
+      // If we've finished reading, signal done
+      if (done) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+
+      // Wait for the next line
+      return new Promise<IteratorResult<T>>((resolve) => {
+        waiting = resolve;
+      });
+    },
+
+    return(): Promise<IteratorResult<T>> {
+      cleanup(rl, stream, null);
+      rl = null;
+      stream = null;
+      done = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: true, value: undefined });
+      }
+      return Promise.resolve({ done: true, value: undefined });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Follow Reader (tail -f mode)
+// ---------------------------------------------------------------------------
+
+function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator<T> {
+  let fh: FileHandle | null = null;
+  let watcher: FSWatcher | null = null;
+  let offset = 0;
+  let remainder = "";
+  const buffer: T[] = [];
+  let closed = false;
+  let waiting: ((result: IteratorResult<T>) => void) | null = null;
+  let initialized = false;
+
+  async function init(): Promise<void> {
+    if (initialized) return;
+    initialized = true;
+
+    fh = await open(path, "r");
+
+    // Read initial content
+    await readNewContent();
+
+    // Watch for changes
+    watcher = watch(path, () => {
+      readNewContent().catch((err) => {
+        logger.error({ error: String(err) }, "follow mode read error");
+      });
+    });
+    watcher.unref();
+  }
+
+  async function readNewContent(): Promise<void> {
+    if (!fh || closed) return;
+
+    const stat = await fh.stat();
+    if (stat.size <= offset) return;
+
+    const readSize = stat.size - offset;
+    const buf = Buffer.alloc(readSize);
+    const { bytesRead } = await fh.read(buf, 0, readSize, offset);
+    offset += bytesRead;
+
+    const text = remainder + buf.toString("utf-8", 0, bytesRead);
+    const lines = text.split("\n");
+
+    // Last element may be incomplete — save for next read
+    remainder = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      const parsed = parseLine<T>(line, keepMeta);
+      if (parsed === null) continue;
+
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: false, value: parsed });
+      } else {
+        buffer.push(parsed);
+      }
+    }
+  }
+
+  return {
+    async next(): Promise<IteratorResult<T>> {
+      await init();
+
+      // Return buffered item if available
+      if (buffer.length > 0) {
+        return { done: false, value: buffer.shift()! };
+      }
+
+      if (closed) {
+        return { done: true, value: undefined };
+      }
+
+      // Wait for the next event from the file watcher
+      return new Promise<IteratorResult<T>>((resolve) => {
+        waiting = resolve;
+      });
+    },
+
+    async return(): Promise<IteratorResult<T>> {
+      closed = true;
+      if (watcher) {
+        watcher.close();
+        watcher = null;
+      }
+      if (fh) {
+        await fh.close();
+        fh = null;
+      }
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ done: true, value: undefined });
+      }
+      return { done: true, value: undefined };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse a JSONL line, optionally stripping the `_ts` metadata field. */
+function parseLine<T>(line: string, keepMeta: boolean): T | null {
+  const trimmed = line.trim();
+  if (trimmed === "") return null;
+
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    if (!keepMeta && "_ts" in parsed) {
+      delete parsed["_ts"];
+    }
+    return parsed as T;
+  } catch {
+    logger.warn("skipping malformed JSONL line");
+    return null;
+  }
+}
+
+/** Clean up readline, stream, and watcher resources. */
+function cleanup(
+  rl: ReadlineInterface | null,
+  stream: ReadStream | null,
+  watcher: FSWatcher | null,
+): void {
+  try { rl?.close(); } catch { /* ignore */ }
+  try { stream?.destroy(); } catch { /* ignore */ }
+  try { watcher?.close(); } catch { /* ignore */ }
+}

--- a/packages/events/src/stream.ts
+++ b/packages/events/src/stream.ts
@@ -1,0 +1,317 @@
+/**
+ * EventStream Core Implementation
+ *
+ * Generic event stream with fan-out to multiple subscribers.
+ * Supports both AsyncIterable (for-await-of) and callback-based
+ * subscribers. Per-subscriber bounded buffers with configurable
+ * backpressure policy.
+ *
+ * Lifecycle:
+ * 1. Create a stream via `createEventStream<T>()`
+ * 2. Attach subscribers via `subscribe()` or `tee()`
+ * 3. Emit events via `emit()` — delivered to all subscribers
+ * 4. Call `close()` to flush, signal completion, and clean up
+ */
+
+import { createComponentLogger } from "@centient/logger";
+
+import type {
+  EventStream,
+  EventStreamOptions,
+  EventSubscriber,
+  SubscribeOptions,
+  BackpressurePolicy,
+} from "./types.js";
+import { createJsonlSubscriber } from "./jsonl.js";
+
+const logger = createComponentLogger("centient", "events");
+
+// ---------------------------------------------------------------------------
+// Internal Types
+// ---------------------------------------------------------------------------
+
+/** Resolve/value pair buffered for an AsyncIterable subscriber. */
+interface BufferedItem<T> {
+  value: T;
+}
+
+/** State for an AsyncIterable subscriber. */
+interface IterableSubscriber<T> {
+  buffer: BufferedItem<T>[];
+  bufferSize: number;
+  /** Resolve function for the pending next() call, if the consumer is waiting. */
+  waiting: ((result: IteratorResult<T>) => void) | null;
+  closed: boolean;
+  /** Optional filter — only events passing this predicate are delivered. */
+  filter?: (event: T) => boolean;
+}
+
+/** State for a tee'd (callback-based) subscriber. */
+interface TeeSubscriber<T> {
+  name: string;
+  subscriber: EventSubscriber<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new EventStream.
+ *
+ * @param opts - Stream options (backpressure policy, default buffer size)
+ * @returns A typed EventStream instance
+ */
+export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> {
+  const backpressure: BackpressurePolicy = opts?.backpressure ?? "drop-oldest";
+  const defaultBufferSize = opts?.defaultBufferSize ?? 1000;
+
+  const iterableSubs = new Set<IterableSubscriber<T>>();
+  const teeSubs = new Map<string, TeeSubscriber<T>>();
+  /** JSONL dispose functions keyed by file path for cleanup on close. */
+  const jsonlDisposers = new Map<string, () => Promise<void>>();
+  let closed = false;
+
+  // -------------------------------------------------------------------------
+  // Emit
+  // -------------------------------------------------------------------------
+
+  function emit(event: T): void {
+    if (closed) {
+      logger.warn("emit() called on closed stream — event dropped");
+      return;
+    }
+
+    // Deliver to AsyncIterable subscribers
+    for (const sub of iterableSubs) {
+      if (sub.filter && !sub.filter(event)) continue;
+      deliverToIterable(sub, event, backpressure);
+    }
+
+    // Deliver to tee'd subscribers (fire-and-forget for async)
+    for (const [, teeSub] of teeSubs) {
+      deliverToTee(teeSub, event);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Subscribe (AsyncIterable)
+  // -------------------------------------------------------------------------
+
+  function subscribe(subOpts?: SubscribeOptions<T>): AsyncIterable<T> {
+    if (closed) {
+      // Return an immediately-done iterable
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      };
+    }
+
+    const bufferSize = subOpts?.bufferSize ?? defaultBufferSize;
+    const sub: IterableSubscriber<T> = {
+      buffer: [],
+      bufferSize,
+      waiting: null,
+      closed: false,
+      filter: subOpts?.filter,
+    };
+    iterableSubs.add(sub);
+
+    return {
+      [Symbol.asyncIterator](): AsyncIterator<T> {
+        return {
+          next(): Promise<IteratorResult<T>> {
+            // If there's a buffered item, return it immediately
+            const item = sub.buffer.shift();
+            if (item) {
+              return Promise.resolve({ done: false, value: item.value });
+            }
+
+            // If the stream is closed and buffer is empty, we're done
+            if (sub.closed) {
+              iterableSubs.delete(sub);
+              return Promise.resolve({ done: true, value: undefined });
+            }
+
+            // Otherwise, wait for the next event
+            return new Promise<IteratorResult<T>>((resolve) => {
+              sub.waiting = resolve;
+            });
+          },
+
+          return(): Promise<IteratorResult<T>> {
+            sub.closed = true;
+            sub.waiting = null;
+            iterableSubs.delete(sub);
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        };
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Tee (callback-based)
+  // -------------------------------------------------------------------------
+
+  function tee(name: string, subscriber: EventSubscriber<T>): () => void {
+    if (closed) {
+      logger.warn(`tee() called on closed stream — subscriber '${name}' not added`);
+      return () => {};
+    }
+
+    teeSubs.set(name, { name, subscriber });
+    logger.debug(`subscriber '${name}' added via tee()`);
+
+    return () => {
+      teeSubs.delete(name);
+      logger.debug(`subscriber '${name}' removed`);
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // JSONL
+  // -------------------------------------------------------------------------
+
+  function jsonl(filePath: string): () => void {
+    const { subscriber, flush } = createJsonlSubscriber<T>(filePath);
+    const dispose = tee(`jsonl:${filePath}`, subscriber);
+    jsonlDisposers.set(filePath, flush);
+
+    return () => {
+      dispose();
+      jsonlDisposers.delete(filePath);
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Close
+  // -------------------------------------------------------------------------
+
+  async function close(): Promise<void> {
+    if (closed) return;
+    closed = true;
+
+    // Flush all JSONL buffers
+    const flushPromises = Array.from(jsonlDisposers.values()).map((flush) =>
+      flush().catch((err) => {
+        logger.error({ error: String(err) }, "JSONL flush error on close");
+      }),
+    );
+    await Promise.all(flushPromises);
+    jsonlDisposers.clear();
+
+    // Signal completion to all AsyncIterable subscribers
+    for (const sub of iterableSubs) {
+      sub.closed = true;
+      if (sub.waiting) {
+        sub.waiting({ done: true, value: undefined });
+        sub.waiting = null;
+      }
+    }
+    iterableSubs.clear();
+
+    // Notify tee'd subscribers
+    for (const [, teeSub] of teeSubs) {
+      try {
+        teeSub.subscriber.onClose?.();
+      } catch (err) {
+        logger.error({ error: String(err) }, `onClose error in subscriber '${teeSub.name}'`);
+      }
+    }
+
+    teeSubs.clear();
+    logger.debug("stream closed");
+  }
+
+  // -------------------------------------------------------------------------
+  // Public Interface
+  // -------------------------------------------------------------------------
+
+  return {
+    emit,
+    subscribe,
+    tee,
+    jsonl,
+    get subscriberCount() {
+      return iterableSubs.size + teeSubs.size;
+    },
+    close,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal Helpers
+// ---------------------------------------------------------------------------
+
+/** Deliver an event to an AsyncIterable subscriber, respecting backpressure. */
+function deliverToIterable<T>(
+  sub: IterableSubscriber<T>,
+  event: T,
+  policy: BackpressurePolicy,
+): void {
+  // If the consumer is waiting, resolve immediately (no buffering needed)
+  if (sub.waiting) {
+    const resolve = sub.waiting;
+    sub.waiting = null;
+    resolve({ done: false, value: event });
+    return;
+  }
+
+  // Buffer the event
+  if (sub.buffer.length < sub.bufferSize) {
+    sub.buffer.push({ value: event });
+    return;
+  }
+
+  // Buffer is full — apply backpressure policy
+  switch (policy) {
+    case "drop-oldest":
+      sub.buffer.shift();
+      sub.buffer.push({ value: event });
+      break;
+    case "drop-newest":
+      // New event is dropped — buffer stays intact
+      break;
+    case "block":
+      // For "block" policy in a sync emit, we can't truly block.
+      // We add to the buffer beyond the limit. The consumer drains it.
+      // This is the best we can do without making emit() async.
+      sub.buffer.push({ value: event });
+      break;
+  }
+}
+
+/** Deliver an event to a tee'd subscriber. Errors are isolated. */
+function deliverToTee<T>(teeSub: TeeSubscriber<T>, event: T): void {
+  try {
+    const result = teeSub.subscriber.onEvent(event);
+    // If onEvent returns a Promise, catch errors from it
+    if (result && typeof result === "object" && "catch" in result) {
+      (result as Promise<void>).catch((err) => {
+        handleTeeError(teeSub, err);
+      });
+    }
+  } catch (err) {
+    handleTeeError(teeSub, err);
+  }
+}
+
+/** Forward an error to a tee'd subscriber's onError callback. */
+function handleTeeError<T>(teeSub: TeeSubscriber<T>, err: unknown): void {
+  const error = err instanceof Error ? err : new Error(String(err));
+  logger.error({ error: error.message }, `subscriber '${teeSub.name}' onEvent error`);
+  try {
+    teeSub.subscriber.onError?.(error);
+  } catch (onErrorErr) {
+    logger.error(
+      { error: String(onErrorErr) },
+      `subscriber '${teeSub.name}' onError handler threw`,
+    );
+  }
+}

--- a/packages/events/src/stream.ts
+++ b/packages/events/src/stream.ts
@@ -30,20 +30,17 @@ const logger = createComponentLogger("centient", "events");
 // Internal Types
 // ---------------------------------------------------------------------------
 
-/** Resolve/value pair buffered for an AsyncIterable subscriber. */
-interface BufferedItem<T> {
-  value: T;
-}
-
 /** State for an AsyncIterable subscriber. */
 interface IterableSubscriber<T> {
-  buffer: BufferedItem<T>[];
+  buffer: T[];
   bufferSize: number;
   /** Resolve function for the pending next() call, if the consumer is waiting. */
   waiting: ((result: IteratorResult<T>) => void) | null;
   closed: boolean;
   /** Optional filter — only events passing this predicate are delivered. */
   filter?: (event: T) => boolean;
+  /** Count of events dropped due to backpressure. */
+  droppedCount: number;
 }
 
 /** State for a tee'd (callback-based) subscriber. */
@@ -84,12 +81,22 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
 
     // Deliver to AsyncIterable subscribers
     for (const sub of iterableSubs) {
-      if (sub.filter && !sub.filter(event)) continue;
+      if (sub.filter) {
+        try {
+          if (!sub.filter(event)) continue;
+        } catch (err) {
+          logger.error(
+            { error: err instanceof Error ? err.message : String(err) },
+            "subscriber filter threw — event skipped for this subscriber",
+          );
+          continue;
+        }
+      }
       deliverToIterable(sub, event, backpressure);
     }
 
     // Deliver to tee'd subscribers (fire-and-forget for async)
-    for (const [, teeSub] of teeSubs) {
+    for (const teeSub of teeSubs.values()) {
       deliverToTee(teeSub, event);
     }
   }
@@ -100,6 +107,7 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
 
   function subscribe(subOpts?: SubscribeOptions<T>): AsyncIterable<T> {
     if (closed) {
+      logger.warn("subscribe() called on closed stream — iterable will be immediately done");
       // Return an immediately-done iterable
       return {
         [Symbol.asyncIterator]() {
@@ -119,6 +127,7 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
       waiting: null,
       closed: false,
       filter: subOpts?.filter,
+      droppedCount: 0,
     };
     iterableSubs.add(sub);
 
@@ -128,8 +137,8 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
           next(): Promise<IteratorResult<T>> {
             // If there's a buffered item, return it immediately
             const item = sub.buffer.shift();
-            if (item) {
-              return Promise.resolve({ done: false, value: item.value });
+            if (item !== undefined) {
+              return Promise.resolve({ done: false, value: item });
             }
 
             // If the stream is closed and buffer is empty, we're done
@@ -146,7 +155,11 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
 
           return(): Promise<IteratorResult<T>> {
             sub.closed = true;
-            sub.waiting = null;
+            if (sub.waiting) {
+              const resolve = sub.waiting;
+              sub.waiting = null;
+              resolve({ done: true, value: undefined });
+            }
             iterableSubs.delete(sub);
             return Promise.resolve({ done: true, value: undefined });
           },
@@ -161,16 +174,20 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
 
   function tee(name: string, subscriber: EventSubscriber<T>): () => void {
     if (closed) {
-      logger.warn(`tee() called on closed stream — subscriber '${name}' not added`);
+      logger.warn({ subscriberName: name }, "tee() called on closed stream — subscriber not added");
       return () => {};
     }
 
+    if (teeSubs.has(name)) {
+      logger.warn({ subscriberName: name }, "tee() overwriting existing subscriber with same name");
+    }
+
     teeSubs.set(name, { name, subscriber });
-    logger.debug(`subscriber '${name}' added via tee()`);
+    logger.debug({ subscriberName: name }, "subscriber added via tee()");
 
     return () => {
       teeSubs.delete(name);
-      logger.debug(`subscriber '${name}' removed`);
+      logger.debug({ subscriberName: name }, "subscriber removed");
     };
   }
 
@@ -184,6 +201,12 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
     jsonlDisposers.set(filePath, flush);
 
     return () => {
+      const flushFn = jsonlDisposers.get(filePath);
+      if (flushFn) {
+        flushFn().catch((err) => {
+          logger.error({ error: String(err) }, "JSONL flush error on dispose");
+        });
+      }
       dispose();
       jsonlDisposers.delete(filePath);
     };
@@ -200,7 +223,10 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
     // Flush all JSONL buffers
     const flushPromises = Array.from(jsonlDisposers.values()).map((flush) =>
       flush().catch((err) => {
-        logger.error({ error: String(err) }, "JSONL flush error on close");
+        logger.error(
+          { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined },
+          "JSONL flush error on close",
+        );
       }),
     );
     await Promise.all(flushPromises);
@@ -216,14 +242,27 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
     }
     iterableSubs.clear();
 
-    // Notify tee'd subscribers
-    for (const [, teeSub] of teeSubs) {
+    // Notify tee'd subscribers and await async onClose handlers
+    const closePromises: Promise<void>[] = [];
+    for (const teeSub of teeSubs.values()) {
       try {
-        teeSub.subscriber.onClose?.();
+        const result = teeSub.subscriber.onClose?.() as void | Promise<void>;
+        if (result instanceof Promise) {
+          closePromises.push(result.catch((err) => {
+            logger.error(
+              { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined },
+              `onClose error in subscriber '${teeSub.name}'`,
+            );
+          }));
+        }
       } catch (err) {
-        logger.error({ error: String(err) }, `onClose error in subscriber '${teeSub.name}'`);
+        logger.error(
+          { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined },
+          `onClose error in subscriber '${teeSub.name}'`,
+        );
       }
     }
+    await Promise.all(closePromises);
 
     teeSubs.clear();
     logger.debug("stream closed");
@@ -232,6 +271,8 @@ export function createEventStream<T>(opts?: EventStreamOptions): EventStream<T> 
   // -------------------------------------------------------------------------
   // Public Interface
   // -------------------------------------------------------------------------
+
+  logger.debug({ backpressure, defaultBufferSize }, "stream created");
 
   return {
     emit,
@@ -265,7 +306,7 @@ function deliverToIterable<T>(
 
   // Buffer the event
   if (sub.buffer.length < sub.bufferSize) {
-    sub.buffer.push({ value: event });
+    sub.buffer.push(event);
     return;
   }
 
@@ -273,16 +314,18 @@ function deliverToIterable<T>(
   switch (policy) {
     case "drop-oldest":
       sub.buffer.shift();
-      sub.buffer.push({ value: event });
+      sub.buffer.push(event);
+      sub.droppedCount++;
+      if (sub.droppedCount === 1) {
+        logger.warn("subscriber buffer full — dropping oldest events (backpressure: drop-oldest)");
+      }
       break;
     case "drop-newest":
       // New event is dropped — buffer stays intact
-      break;
-    case "block":
-      // For "block" policy in a sync emit, we can't truly block.
-      // We add to the buffer beyond the limit. The consumer drains it.
-      // This is the best we can do without making emit() async.
-      sub.buffer.push({ value: event });
+      sub.droppedCount++;
+      if (sub.droppedCount === 1) {
+        logger.warn("subscriber buffer full — dropping newest events (backpressure: drop-newest)");
+      }
       break;
   }
 }
@@ -292,8 +335,8 @@ function deliverToTee<T>(teeSub: TeeSubscriber<T>, event: T): void {
   try {
     const result = teeSub.subscriber.onEvent(event);
     // If onEvent returns a Promise, catch errors from it
-    if (result && typeof result === "object" && "catch" in result) {
-      (result as Promise<void>).catch((err) => {
+    if (result instanceof Promise) {
+      result.catch((err) => {
         handleTeeError(teeSub, err);
       });
     }
@@ -305,12 +348,15 @@ function deliverToTee<T>(teeSub: TeeSubscriber<T>, event: T): void {
 /** Forward an error to a tee'd subscriber's onError callback. */
 function handleTeeError<T>(teeSub: TeeSubscriber<T>, err: unknown): void {
   const error = err instanceof Error ? err : new Error(String(err));
-  logger.error({ error: error.message }, `subscriber '${teeSub.name}' onEvent error`);
+  logger.error(
+    { error: error.message, stack: error.stack },
+    `subscriber '${teeSub.name}' onEvent error`,
+  );
   try {
     teeSub.subscriber.onError?.(error);
   } catch (onErrorErr) {
     logger.error(
-      { error: String(onErrorErr) },
+      { error: onErrorErr instanceof Error ? onErrorErr.message : String(onErrorErr), stack: onErrorErr instanceof Error ? onErrorErr.stack : undefined },
       `subscriber '${teeSub.name}' onError handler threw`,
     );
   }

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Event Streaming Type Definitions
+ *
+ * Types for the typed event streaming library. Generic over the event
+ * type — consumers define their own event shapes; this package provides
+ * the streaming infrastructure.
+ */
+
+// ---------------------------------------------------------------------------
+// Backpressure
+// ---------------------------------------------------------------------------
+
+/** Policy applied when a subscriber's buffer is full. */
+export type BackpressurePolicy =
+  | "drop-oldest"  // Drop oldest buffered event, add new one (default)
+  | "drop-newest"  // Reject new event, keep buffer intact
+  | "block";       // Block emit() until buffer has space (use carefully)
+
+// ---------------------------------------------------------------------------
+// Subscribe Options
+// ---------------------------------------------------------------------------
+
+/** Options for `subscribe()`. Generic over the stream's event type. */
+export interface SubscribeOptions<T = unknown> {
+  /**
+   * Buffer size for this subscriber (events queued if consumer is slow).
+   * Default: inherited from EventStreamOptions.defaultBufferSize (1000).
+   * When buffer is full, the stream-level backpressure policy applies.
+   */
+  bufferSize?: number;
+  /**
+   * Optional filter — only events passing this predicate are delivered
+   * to this subscriber. Runs synchronously before buffering. Filtered-out
+   * events never enter the buffer.
+   */
+  filter?: (event: T) => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Event Subscriber (callback-based)
+// ---------------------------------------------------------------------------
+
+/** Callback-based subscriber attached via `tee()`. */
+export interface EventSubscriber<T> {
+  /** Subscriber name (used for logging and diagnostics). */
+  name: string;
+  /** Called for each emitted event. May be async. */
+  onEvent(event: T): void | Promise<void>;
+  /** Called when a subscriber-side error occurs. */
+  onError?(error: Error): void;
+  /** Called when the stream closes. */
+  onClose?(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Event Stream
+// ---------------------------------------------------------------------------
+
+/** Options for `createEventStream()`. */
+export interface EventStreamOptions {
+  /** Backpressure policy when a subscriber's buffer is full. Default: 'drop-oldest'. */
+  backpressure?: BackpressurePolicy;
+  /** Default buffer size for subscribers. Default: 1000. */
+  defaultBufferSize?: number;
+}
+
+/** The primary event streaming abstraction. Generic over event type T. */
+export interface EventStream<T> {
+  /** Emit an event to all subscribers. */
+  emit(event: T): void;
+
+  /** Subscribe to the event stream (AsyncIterable for async-for-of consumption). */
+  subscribe(opts?: SubscribeOptions<T>): AsyncIterable<T>;
+
+  /**
+   * Fan-out: add a named subscriber that receives all events.
+   * Returns a dispose function to remove the subscriber.
+   */
+  tee(name: string, subscriber: EventSubscriber<T>): () => void;
+
+  /**
+   * Convenience: add a JSONL file subscriber (appends events as JSON lines).
+   * Returns a dispose function to remove the subscriber.
+   */
+  jsonl(filePath: string): () => void;
+
+  /** Current number of active subscribers (both AsyncIterable and tee'd). */
+  readonly subscriberCount: number;
+
+  /** Close the stream — all subscribers receive completion signal. */
+  close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Event Envelope (optional helper)
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed envelope that consumers can use to standardize event metadata.
+ * Optional — consumers can use any event type with EventStream.
+ */
+export interface EventEnvelope<T extends string, P> {
+  /** Discriminant (e.g., "block:started"). */
+  type: T;
+  /** ISO 8601 timestamp (auto-set if not provided). */
+  timestamp: string;
+  /** Type-specific data. */
+  payload: P;
+}

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -12,9 +12,8 @@
 
 /** Policy applied when a subscriber's buffer is full. */
 export type BackpressurePolicy =
-  | "drop-oldest"  // Drop oldest buffered event, add new one (default)
-  | "drop-newest"  // Reject new event, keep buffer intact
-  | "block";       // Block emit() until buffer has space (use carefully)
+  | "drop-oldest"   // Drop oldest buffered event, add new one (default)
+  | "drop-newest";  // Reject new event, keep buffer intact
 
 // ---------------------------------------------------------------------------
 // Subscribe Options
@@ -42,14 +41,12 @@ export interface SubscribeOptions<T = unknown> {
 
 /** Callback-based subscriber attached via `tee()`. */
 export interface EventSubscriber<T> {
-  /** Subscriber name (used for logging and diagnostics). */
-  name: string;
   /** Called for each emitted event. May be async. */
   onEvent(event: T): void | Promise<void>;
   /** Called when a subscriber-side error occurs. */
   onError?(error: Error): void;
-  /** Called when the stream closes. */
-  onClose?(): void;
+  /** Called when the stream closes. May be async for cleanup. */
+  onClose?(): void | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +78,8 @@ export interface EventStream<T> {
   /**
    * Convenience: add a JSONL file subscriber (appends events as JSON lines).
    * Returns a dispose function to remove the subscriber.
+   * Note: This is a Node.js-specific convenience. Use tee() with
+   * createJsonlSubscriber() directly for the same functionality.
    */
   jsonl(filePath: string): () => void;
 
@@ -89,6 +88,24 @@ export interface EventStream<T> {
 
   /** Close the stream — all subscribers receive completion signal. */
   close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Replay Options
+// ---------------------------------------------------------------------------
+
+/** Options for `fromJsonl()`. */
+export interface FromJsonlOptions {
+  /**
+   * If true, continue watching for new lines after reaching EOF (like tail -f).
+   * Default: false (read to EOF then complete).
+   */
+  follow?: boolean;
+  /**
+   * If true, keep the `_ts` metadata field in emitted events.
+   * Default: false (strip `_ts` before yielding).
+   */
+  keepMeta?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/events/tests/edge-cases.test.ts
+++ b/packages/events/tests/edge-cases.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Edge-Case Tests for EventStream and JSONL Subscriber
+ *
+ * Covers:
+ *   - Emit before any subscriber exists (events are lost)
+ *   - Buffer boundary: bufferSize 1 (only last event survives drop-oldest)
+ *   - Buffer boundary: bufferSize 0 (oscillates between 0-1 under drop-oldest)
+ *   - Concurrent subscribers with different buffer sizes
+ *   - Duplicate tee name overwrites previous subscriber
+ *   - onClose throwing does not reject close() or block other subscribers
+ *   - Filter that throws does not crash the stream
+ *   - Subscriber error without onError handler (no unhandled rejection)
+ *   - AsyncIterable return() with pending waiting resolves parked next()
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  createEventStream,
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestEvent {
+  type: string;
+  value: number;
+}
+
+/** Collect events from an AsyncIterable into an array (with optional limit). */
+async function collect<T>(
+  iter: AsyncIterable<T>,
+  limit: number,
+): Promise<T[]> {
+  const results: T[] = [];
+  for await (const event of iter) {
+    results.push(event);
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+/** Wait for a short tick to allow async delivery. */
+function tick(ms = 10): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Emit Before Any Subscriber
+// ---------------------------------------------------------------------------
+
+describe("EventStream edge cases", () => {
+  describe("emit before any subscriber exists", () => {
+    it("events emitted before subscribe are lost; only post-subscribe events are received", async () => {
+      const stream = createEventStream<TestEvent>();
+
+      // Emit 3 events with no subscriber attached
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+      stream.emit({ type: "c", value: 3 });
+
+      // Now subscribe
+      const iter = stream.subscribe();
+
+      // Emit 1 more event
+      stream.emit({ type: "d", value: 4 });
+
+      const result = await collect(iter, 1);
+      expect(result).toEqual([{ type: "d", value: 4 }]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Buffer Boundary: bufferSize 1
+  // -------------------------------------------------------------------------
+
+  describe("buffer boundary: bufferSize 1", () => {
+    it("only the last event survives under drop-oldest when buffer is 1", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "drop-oldest",
+        defaultBufferSize: 1,
+      });
+      const iter = stream.subscribe();
+
+      // Emit 3 events before consuming — buffer holds 1, so only the last survives
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+      stream.emit({ type: "c", value: 3 });
+
+      const result = await collect(iter, 1);
+      expect(result).toEqual([{ type: "c", value: 3 }]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Buffer Boundary: bufferSize 0
+  // -------------------------------------------------------------------------
+
+  describe("buffer boundary: bufferSize 0", () => {
+    it("oscillates between 0-1 under drop-oldest since shift on empty is a no-op", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "drop-oldest",
+        defaultBufferSize: 0,
+      });
+      const iter = stream.subscribe();
+
+      // With bufferSize 0: `buffer.length < bufferSize` is `0 < 0` which is false.
+      // So every emit hits the backpressure path: shift() (no-op on empty) + push().
+      // This means buffer oscillates at size 0-1. The last event should survive.
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+      stream.emit({ type: "c", value: 3 });
+
+      const result = await collect(iter, 1);
+      // The buffer ends up with the last event because shift+push on a single-element
+      // array replaces the element each time.
+      expect(result).toEqual([{ type: "c", value: 3 }]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Concurrent Subscribers with Different Buffer Sizes
+  // -------------------------------------------------------------------------
+
+  describe("concurrent subscribers with different buffer sizes", () => {
+    it("each subscriber retains the correct tail of events under drop-oldest", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "drop-oldest",
+        defaultBufferSize: 1000,
+      });
+
+      const iterSmall = stream.subscribe({ bufferSize: 2 });
+      const iterLarge = stream.subscribe({ bufferSize: 5 });
+
+      // Emit 10 events before consuming
+      for (let i = 1; i <= 10; i++) {
+        stream.emit({ type: "e", value: i });
+      }
+
+      const resultSmall = await collect(iterSmall, 2);
+      const resultLarge = await collect(iterLarge, 5);
+
+      // bufferSize 2 should have the last 2 events
+      expect(resultSmall).toEqual([
+        { type: "e", value: 9 },
+        { type: "e", value: 10 },
+      ]);
+
+      // bufferSize 5 should have the last 5 events
+      expect(resultLarge).toEqual([
+        { type: "e", value: 6 },
+        { type: "e", value: 7 },
+        { type: "e", value: 8 },
+        { type: "e", value: 9 },
+        { type: "e", value: 10 },
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Duplicate tee Name Overwrites
+  // -------------------------------------------------------------------------
+
+  describe("duplicate tee name overwrites", () => {
+    it("second tee with same name replaces the first; only the second receives events", () => {
+      const stream = createEventStream<TestEvent>();
+      const eventsA: TestEvent[] = [];
+      const eventsB: TestEvent[] = [];
+
+      stream.tee("dup", {
+        name: "dup",
+        onEvent: (e) => { eventsA.push(e); },
+      });
+
+      stream.tee("dup", {
+        name: "dup",
+        onEvent: (e) => { eventsB.push(e); },
+      });
+
+      stream.emit({ type: "x", value: 42 });
+
+      expect(eventsA).toEqual([]);
+      expect(eventsB).toEqual([{ type: "x", value: 42 }]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onClose Throwing
+  // -------------------------------------------------------------------------
+
+  describe("onClose throwing", () => {
+    it("close() resolves even when a subscriber onClose throws; other subscribers still fire", async () => {
+      const stream = createEventStream<TestEvent>();
+      const onCloseGood = vi.fn();
+
+      stream.tee("bad-close", {
+        name: "bad-close",
+        onEvent: () => {},
+        onClose: () => { throw new Error("onClose boom"); },
+      });
+
+      stream.tee("good-close", {
+        name: "good-close",
+        onEvent: () => {},
+        onClose: onCloseGood,
+      });
+
+      // close() should not reject
+      await expect(stream.close()).resolves.toBeUndefined();
+
+      // The good subscriber's onClose should still have been called
+      expect(onCloseGood).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Filter That Throws
+  // -------------------------------------------------------------------------
+
+  describe("filter that throws", () => {
+    it("does not crash the stream; other subscribers continue receiving events", async () => {
+      const stream = createEventStream<TestEvent>();
+
+      // Subscriber with a filter that throws
+      const badIter = stream.subscribe({
+        filter: () => { throw new Error("filter boom"); },
+      });
+
+      // Good subscriber
+      const goodIter = stream.subscribe();
+
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+
+      const goodResult = await collect(goodIter, 2);
+      expect(goodResult).toEqual([
+        { type: "a", value: 1 },
+        { type: "b", value: 2 },
+      ]);
+
+      // Clean up the bad iterator
+      const asyncBadIter = badIter[Symbol.asyncIterator]();
+      await asyncBadIter.return?.();
+
+      await stream.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Subscriber Error Without onError
+  // -------------------------------------------------------------------------
+
+  describe("subscriber error without onError", () => {
+    it("tee subscriber with no onError whose onEvent throws does not cause unhandled rejection", async () => {
+      const stream = createEventStream<TestEvent>();
+
+      // Subscriber with no onError callback
+      stream.tee("no-onerror", {
+        name: "no-onerror",
+        onEvent: () => { throw new Error("onEvent boom"); },
+        // Note: no onError callback provided
+      });
+
+      // Should not throw
+      expect(() => stream.emit({ type: "a", value: 1 })).not.toThrow();
+
+      // Give time for any async error propagation
+      await tick(50);
+
+      // Stream should still be functional
+      const events: TestEvent[] = [];
+      stream.tee("good", {
+        name: "good",
+        onEvent: (e) => { events.push(e); },
+      });
+
+      stream.emit({ type: "b", value: 2 });
+      expect(events).toEqual([{ type: "b", value: 2 }]);
+
+      await stream.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AsyncIterable return() with Pending Waiting
+  // -------------------------------------------------------------------------
+
+  describe("AsyncIterable return() with pending waiting", () => {
+    it("parked next() resolves with { done: true } when return() is called", async () => {
+      const stream = createEventStream<TestEvent>();
+      const iter = stream.subscribe();
+      const asyncIter = iter[Symbol.asyncIterator]();
+
+      // Call next() to park the consumer waiting (no events in buffer)
+      const pendingNext = asyncIter.next();
+
+      // Call return() from another async context
+      await tick();
+      await asyncIter.return?.();
+
+      // The parked next() should resolve with done: true
+      const result = await pendingNext;
+      expect(result.done).toBe(true);
+    });
+  });
+});

--- a/packages/events/tests/events.test.ts
+++ b/packages/events/tests/events.test.ts
@@ -5,7 +5,7 @@
  *   - Basic emit/subscribe (single subscriber, multiple events)
  *   - Multiple subscribers (fan-out, each gets all events)
  *   - AsyncIterable consumption (for-await-of pattern)
- *   - Backpressure: drop-oldest, drop-newest, block policies
+ *   - Backpressure: drop-oldest, drop-newest policies
  *   - JSONL subscriber (write to temp file, verify contents)
  *   - Subscriber removal (dispose function from tee())
  *   - Error isolation (subscriber error doesn't affect others)
@@ -250,26 +250,7 @@ describe("EventStream", () => {
       ]);
     });
 
-    it("block: allows buffer to grow beyond limit", async () => {
-      const stream = createEventStream<TestEvent>({
-        backpressure: "block",
-        defaultBufferSize: 2,
-      });
-      const iter = stream.subscribe();
-
-      // Emit 4 events — "block" in sync mode just allows overflow
-      for (let i = 1; i <= 4; i++) {
-        stream.emit({ type: "e", value: i });
-      }
-
-      const result = await collect(iter, 4);
-      expect(result).toEqual([
-        { type: "e", value: 1 },
-        { type: "e", value: 2 },
-        { type: "e", value: 3 },
-        { type: "e", value: 4 },
-      ]);
-    });
+    // "block" policy removed — it was misleading (allowed unbounded buffer growth)
 
     it("per-subscriber bufferSize overrides default", async () => {
       const stream = createEventStream<TestEvent>({
@@ -503,12 +484,12 @@ describe("JSONL subscriber", () => {
 
     const parsed0 = JSON.parse(lines[0]!);
     expect(parsed0._ts).toBeDefined();
-    expect(parsed0.type).toBe("a");
-    expect(parsed0.value).toBe(1);
+    expect(parsed0.event.type).toBe("a");
+    expect(parsed0.event.value).toBe(1);
 
     const parsed1 = JSON.parse(lines[1]!);
-    expect(parsed1.type).toBe("b");
-    expect(parsed1.value).toBe(2);
+    expect(parsed1.event.type).toBe("b");
+    expect(parsed1.event.value).toBe(2);
   });
 
   it("creates parent directories if they don't exist", async () => {
@@ -543,7 +524,7 @@ describe("JSONL subscriber", () => {
     const content = readFileSync(filePath, "utf-8");
     const lines = content.trim().split("\n");
     expect(lines).toHaveLength(1);
-    expect(JSON.parse(lines[0]!).type).toBe("a");
+    expect(JSON.parse(lines[0]!).event.type).toBe("a");
   });
 });
 

--- a/packages/events/tests/events.test.ts
+++ b/packages/events/tests/events.test.ts
@@ -1,0 +1,594 @@
+/**
+ * EventStream Tests
+ *
+ * Covers:
+ *   - Basic emit/subscribe (single subscriber, multiple events)
+ *   - Multiple subscribers (fan-out, each gets all events)
+ *   - AsyncIterable consumption (for-await-of pattern)
+ *   - Backpressure: drop-oldest, drop-newest, block policies
+ *   - JSONL subscriber (write to temp file, verify contents)
+ *   - Subscriber removal (dispose function from tee())
+ *   - Error isolation (subscriber error doesn't affect others)
+ *   - Close semantics (flush, completion signal, cleanup)
+ *   - Event envelope helper (defineEvent factory)
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createEventStream,
+  defineEvent,
+} from "../src/index.js";
+
+import type {
+  EventSubscriber,
+  EventEnvelope,
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestEvent {
+  type: string;
+  value: number;
+}
+
+/** Collect events from an AsyncIterable into an array (with optional limit). */
+async function collect<T>(
+  iter: AsyncIterable<T>,
+  limit: number,
+): Promise<T[]> {
+  const results: T[] = [];
+  for await (const event of iter) {
+    results.push(event);
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+/** Wait for a short tick to allow async delivery. */
+function tick(ms = 10): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Basic Emit / Subscribe
+// ---------------------------------------------------------------------------
+
+describe("EventStream", () => {
+  describe("basic emit/subscribe", () => {
+    it("delivers events to a single subscriber", async () => {
+      const stream = createEventStream<TestEvent>();
+      const events = collect(stream.subscribe(), 3);
+
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+      stream.emit({ type: "c", value: 3 });
+
+      const result = await events;
+      expect(result).toEqual([
+        { type: "a", value: 1 },
+        { type: "b", value: 2 },
+        { type: "c", value: 3 },
+      ]);
+    });
+
+    it("delivers buffered events when subscriber starts consuming later", async () => {
+      const stream = createEventStream<TestEvent>();
+      const iter = stream.subscribe();
+
+      // Emit before consuming
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+
+      const result = await collect(iter, 2);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ type: "a", value: 1 });
+      expect(result[1]).toEqual({ type: "b", value: 2 });
+    });
+
+    it("reports subscriberCount correctly", async () => {
+      const stream = createEventStream<TestEvent>();
+      expect(stream.subscriberCount).toBe(0);
+
+      const iter = stream.subscribe();
+      expect(stream.subscriberCount).toBe(1);
+
+      const dispose = stream.tee("test", {
+        name: "test",
+        onEvent: () => {},
+      });
+      expect(stream.subscriberCount).toBe(2);
+
+      dispose();
+      expect(stream.subscriberCount).toBe(1);
+
+      // Clean up the iterable subscriber
+      const asyncIter = iter[Symbol.asyncIterator]();
+      await asyncIter.return?.();
+      expect(stream.subscriberCount).toBe(0);
+
+      await stream.close();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple Subscribers (fan-out)
+  // -------------------------------------------------------------------------
+
+  describe("fan-out (multiple subscribers)", () => {
+    it("delivers each event to all AsyncIterable subscribers", async () => {
+      const stream = createEventStream<TestEvent>();
+      const sub1 = collect(stream.subscribe(), 2);
+      const sub2 = collect(stream.subscribe(), 2);
+
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+
+      const [r1, r2] = await Promise.all([sub1, sub2]);
+      expect(r1).toEqual([{ type: "a", value: 1 }, { type: "b", value: 2 }]);
+      expect(r2).toEqual([{ type: "a", value: 1 }, { type: "b", value: 2 }]);
+    });
+
+    it("delivers events to both tee'd and AsyncIterable subscribers", async () => {
+      const stream = createEventStream<TestEvent>();
+      const teeEvents: TestEvent[] = [];
+      stream.tee("tee-sub", {
+        name: "tee-sub",
+        onEvent: (e) => { teeEvents.push(e); },
+      });
+
+      const iterEvents = collect(stream.subscribe(), 2);
+
+      stream.emit({ type: "a", value: 1 });
+      stream.emit({ type: "b", value: 2 });
+
+      const result = await iterEvents;
+      expect(result).toHaveLength(2);
+      expect(teeEvents).toHaveLength(2);
+      expect(teeEvents).toEqual(result);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AsyncIterable Consumption
+  // -------------------------------------------------------------------------
+
+  describe("AsyncIterable consumption", () => {
+    it("supports for-await-of pattern", async () => {
+      const stream = createEventStream<TestEvent>();
+      const received: TestEvent[] = [];
+
+      const consumer = (async () => {
+        for await (const event of stream.subscribe()) {
+          received.push(event);
+          if (received.length >= 3) break;
+        }
+      })();
+
+      stream.emit({ type: "x", value: 10 });
+      stream.emit({ type: "y", value: 20 });
+      stream.emit({ type: "z", value: 30 });
+
+      await consumer;
+      expect(received).toHaveLength(3);
+    });
+
+    it("exits for-await-of when stream closes", async () => {
+      const stream = createEventStream<TestEvent>();
+      const received: TestEvent[] = [];
+
+      const consumer = (async () => {
+        for await (const event of stream.subscribe()) {
+          received.push(event);
+        }
+      })();
+
+      stream.emit({ type: "a", value: 1 });
+      await tick();
+      await stream.close();
+      await consumer;
+
+      expect(received).toEqual([{ type: "a", value: 1 }]);
+    });
+
+    it("returns immediately-done iterable when subscribing to closed stream", async () => {
+      const stream = createEventStream<TestEvent>();
+      await stream.close();
+
+      const result = await collect(stream.subscribe(), 10);
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Backpressure
+  // -------------------------------------------------------------------------
+
+  describe("backpressure", () => {
+    it("drop-oldest: drops oldest events when buffer is full", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "drop-oldest",
+        defaultBufferSize: 3,
+      });
+      const iter = stream.subscribe();
+
+      // Emit 5 events — buffer is 3, so first 2 should be dropped
+      for (let i = 1; i <= 5; i++) {
+        stream.emit({ type: "e", value: i });
+      }
+
+      const result = await collect(iter, 3);
+      expect(result).toEqual([
+        { type: "e", value: 3 },
+        { type: "e", value: 4 },
+        { type: "e", value: 5 },
+      ]);
+    });
+
+    it("drop-newest: drops new events when buffer is full", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "drop-newest",
+        defaultBufferSize: 3,
+      });
+      const iter = stream.subscribe();
+
+      // Emit 5 events — buffer is 3, so events 4 and 5 should be dropped
+      for (let i = 1; i <= 5; i++) {
+        stream.emit({ type: "e", value: i });
+      }
+
+      const result = await collect(iter, 3);
+      expect(result).toEqual([
+        { type: "e", value: 1 },
+        { type: "e", value: 2 },
+        { type: "e", value: 3 },
+      ]);
+    });
+
+    it("block: allows buffer to grow beyond limit", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "block",
+        defaultBufferSize: 2,
+      });
+      const iter = stream.subscribe();
+
+      // Emit 4 events — "block" in sync mode just allows overflow
+      for (let i = 1; i <= 4; i++) {
+        stream.emit({ type: "e", value: i });
+      }
+
+      const result = await collect(iter, 4);
+      expect(result).toEqual([
+        { type: "e", value: 1 },
+        { type: "e", value: 2 },
+        { type: "e", value: 3 },
+        { type: "e", value: 4 },
+      ]);
+    });
+
+    it("per-subscriber bufferSize overrides default", async () => {
+      const stream = createEventStream<TestEvent>({
+        backpressure: "drop-oldest",
+        defaultBufferSize: 100,
+      });
+      const iter = stream.subscribe({ bufferSize: 2 });
+
+      // Emit 4 events — subscriber buffer is 2
+      for (let i = 1; i <= 4; i++) {
+        stream.emit({ type: "e", value: i });
+      }
+
+      const result = await collect(iter, 2);
+      expect(result).toEqual([
+        { type: "e", value: 3 },
+        { type: "e", value: 4 },
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Subscriber Removal
+  // -------------------------------------------------------------------------
+
+  describe("subscriber removal", () => {
+    it("tee dispose stops delivery to that subscriber", () => {
+      const stream = createEventStream<TestEvent>();
+      const events: TestEvent[] = [];
+      const dispose = stream.tee("removable", {
+        name: "removable",
+        onEvent: (e) => { events.push(e); },
+      });
+
+      stream.emit({ type: "a", value: 1 });
+      dispose();
+      stream.emit({ type: "b", value: 2 });
+
+      expect(events).toEqual([{ type: "a", value: 1 }]);
+    });
+
+    it("AsyncIterable return() stops delivery", async () => {
+      const stream = createEventStream<TestEvent>();
+      const iter = stream.subscribe();
+      const asyncIter = iter[Symbol.asyncIterator]();
+
+      stream.emit({ type: "a", value: 1 });
+      const first = await asyncIter.next();
+      expect(first.value).toEqual({ type: "a", value: 1 });
+
+      await asyncIter.return?.();
+      expect(stream.subscriberCount).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error Isolation
+  // -------------------------------------------------------------------------
+
+  describe("error isolation", () => {
+    it("sync error in one tee subscriber does not affect others", () => {
+      const stream = createEventStream<TestEvent>();
+      const goodEvents: TestEvent[] = [];
+      const errorCb = vi.fn();
+
+      stream.tee("bad", {
+        name: "bad",
+        onEvent: () => { throw new Error("boom"); },
+        onError: errorCb,
+      });
+      stream.tee("good", {
+        name: "good",
+        onEvent: (e) => { goodEvents.push(e); },
+      });
+
+      stream.emit({ type: "a", value: 1 });
+
+      expect(goodEvents).toEqual([{ type: "a", value: 1 }]);
+      expect(errorCb).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it("async error in one tee subscriber does not affect others", async () => {
+      const stream = createEventStream<TestEvent>();
+      const goodEvents: TestEvent[] = [];
+      const errorCb = vi.fn();
+
+      stream.tee("bad-async", {
+        name: "bad-async",
+        onEvent: async () => { throw new Error("async boom"); },
+        onError: errorCb,
+      });
+      stream.tee("good", {
+        name: "good",
+        onEvent: (e) => { goodEvents.push(e); },
+      });
+
+      stream.emit({ type: "a", value: 1 });
+      await tick(50);
+
+      expect(goodEvents).toEqual([{ type: "a", value: 1 }]);
+      expect(errorCb).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it("error in onError handler does not throw to emitter", () => {
+      const stream = createEventStream<TestEvent>();
+
+      stream.tee("double-bad", {
+        name: "double-bad",
+        onEvent: () => { throw new Error("boom"); },
+        onError: () => { throw new Error("onError also throws"); },
+      });
+
+      // Should not throw
+      expect(() => stream.emit({ type: "a", value: 1 })).not.toThrow();
+    });
+
+    it("emit on closed stream does not throw", () => {
+      const stream = createEventStream<TestEvent>();
+      stream.close();
+      expect(() => stream.emit({ type: "a", value: 1 })).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Close Semantics
+  // -------------------------------------------------------------------------
+
+  describe("close semantics", () => {
+    it("signals onClose to all tee subscribers", async () => {
+      const stream = createEventStream<TestEvent>();
+      const onClose1 = vi.fn();
+      const onClose2 = vi.fn();
+
+      stream.tee("sub1", { name: "sub1", onEvent: () => {}, onClose: onClose1 });
+      stream.tee("sub2", { name: "sub2", onEvent: () => {}, onClose: onClose2 });
+
+      await stream.close();
+
+      expect(onClose1).toHaveBeenCalledOnce();
+      expect(onClose2).toHaveBeenCalledOnce();
+    });
+
+    it("completes all AsyncIterable subscribers on close", async () => {
+      const stream = createEventStream<TestEvent>();
+      const received: TestEvent[] = [];
+
+      const consumer = (async () => {
+        for await (const event of stream.subscribe()) {
+          received.push(event);
+        }
+        return "done";
+      })();
+
+      stream.emit({ type: "a", value: 1 });
+      await tick();
+      await stream.close();
+
+      const result = await consumer;
+      expect(result).toBe("done");
+      expect(received).toEqual([{ type: "a", value: 1 }]);
+    });
+
+    it("close is idempotent", async () => {
+      const stream = createEventStream<TestEvent>();
+      const onClose = vi.fn();
+      stream.tee("sub", { name: "sub", onEvent: () => {}, onClose });
+
+      await stream.close();
+      await stream.close();
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("clears subscriber count on close", async () => {
+      const stream = createEventStream<TestEvent>();
+      stream.subscribe();
+      stream.tee("sub", { name: "sub", onEvent: () => {} });
+      expect(stream.subscriberCount).toBe(2);
+
+      await stream.close();
+      expect(stream.subscriberCount).toBe(0);
+    });
+
+    it("tee on closed stream is a no-op", async () => {
+      const stream = createEventStream<TestEvent>();
+      await stream.close();
+
+      const events: TestEvent[] = [];
+      const dispose = stream.tee("late", {
+        name: "late",
+        onEvent: (e) => { events.push(e); },
+      });
+
+      stream.emit({ type: "a", value: 1 });
+      expect(events).toEqual([]);
+      dispose(); // should not throw
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSONL Subscriber
+// ---------------------------------------------------------------------------
+
+describe("JSONL subscriber", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes events as newline-delimited JSON with _ts field", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "events-jsonl-"));
+    const filePath = join(tmpDir, "events.jsonl");
+
+    const stream = createEventStream<TestEvent>();
+    stream.jsonl(filePath);
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+
+    await stream.close();
+    // Give a small tick for the flush to complete
+    await tick(50);
+
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(2);
+
+    const parsed0 = JSON.parse(lines[0]!);
+    expect(parsed0._ts).toBeDefined();
+    expect(parsed0.type).toBe("a");
+    expect(parsed0.value).toBe(1);
+
+    const parsed1 = JSON.parse(lines[1]!);
+    expect(parsed1.type).toBe("b");
+    expect(parsed1.value).toBe(2);
+  });
+
+  it("creates parent directories if they don't exist", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "events-jsonl-"));
+    const filePath = join(tmpDir, "nested", "deep", "events.jsonl");
+
+    const stream = createEventStream<TestEvent>();
+    stream.jsonl(filePath);
+
+    stream.emit({ type: "a", value: 1 });
+    await stream.close();
+    await tick(50);
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content.trim()).not.toBe("");
+  });
+
+  it("dispose removes the JSONL subscriber", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "events-jsonl-"));
+    const filePath = join(tmpDir, "events.jsonl");
+
+    const stream = createEventStream<TestEvent>();
+    const dispose = stream.jsonl(filePath);
+
+    stream.emit({ type: "a", value: 1 });
+    await tick(150); // wait for flush
+    dispose();
+    stream.emit({ type: "b", value: 2 });
+    await stream.close();
+    await tick(50);
+
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).type).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event Envelope
+// ---------------------------------------------------------------------------
+
+describe("EventEnvelope / defineEvent", () => {
+  it("creates an event with auto-generated timestamp", () => {
+    const blockStarted = defineEvent<"block:started", { blockPath: string }>("block:started");
+    const event = blockStarted({ blockPath: "implement/auth" });
+
+    expect(event.type).toBe("block:started");
+    expect(event.payload).toEqual({ blockPath: "implement/auth" });
+    expect(event.timestamp).toBeDefined();
+    // Verify it's a valid ISO 8601 timestamp
+    expect(new Date(event.timestamp).toISOString()).toBe(event.timestamp);
+  });
+
+  it("works with EventStream", async () => {
+    type MyEvent =
+      | EventEnvelope<"block:started", { blockPath: string }>
+      | EventEnvelope<"block:done", { blockPath: string; result: string }>;
+
+    const stream = createEventStream<MyEvent>();
+    const blockStarted = defineEvent<"block:started", { blockPath: string }>("block:started");
+    const blockDone = defineEvent<"block:done", { blockPath: string; result: string }>("block:done");
+
+    const events = collect(stream.subscribe(), 2);
+
+    stream.emit(blockStarted({ blockPath: "implement/auth" }));
+    stream.emit(blockDone({ blockPath: "implement/auth", result: "pass" }));
+
+    const result = await events;
+    expect(result).toHaveLength(2);
+    expect(result[0]!.type).toBe("block:started");
+    expect(result[1]!.type).toBe("block:done");
+  });
+
+  it("preserves full type safety via discriminated union", async () => {
+    const started = defineEvent<"started", { id: number }>("started");
+    const event = started({ id: 42 });
+
+    // TypeScript should narrow these correctly
+    expect(event.type).toBe("started");
+    expect(event.payload.id).toBe(42);
+  });
+});

--- a/packages/events/tests/filter.test.ts
+++ b/packages/events/tests/filter.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Subscribe Filter Tests
+ *
+ * Covers:
+ *   - Subscribe with filter, only matching events received
+ *   - Filtered events don't consume buffer space
+ *   - Filter with multiple subscribers (independent filters)
+ *   - No filter (default) — all events delivered
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { createEventStream } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestEvent {
+  type: string;
+  value: number;
+}
+
+async function collect<T>(iter: AsyncIterable<T>, limit: number): Promise<T[]> {
+  const results: T[] = [];
+  for await (const event of iter) {
+    results.push(event);
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("subscribe with filter", () => {
+  it("delivers only events matching the filter predicate", async () => {
+    const stream = createEventStream<TestEvent>();
+    const events = collect(
+      stream.subscribe({
+        filter: (e) => e.type === "a",
+      }),
+      2,
+    );
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+    stream.emit({ type: "a", value: 3 });
+    stream.emit({ type: "c", value: 4 });
+
+    const result = await events;
+    expect(result).toEqual([
+      { type: "a", value: 1 },
+      { type: "a", value: 3 },
+    ]);
+  });
+
+  it("filtered events do not consume buffer space", async () => {
+    const stream = createEventStream<TestEvent>({
+      backpressure: "drop-oldest",
+      defaultBufferSize: 100,
+    });
+
+    // Subscribe with filter that passes ~50 of 2000 events
+    const iter = stream.subscribe({
+      bufferSize: 100,
+      filter: (e) => e.value % 40 === 0,
+    });
+
+    // Emit 2000 events — only 50 pass the filter (values 0, 40, 80, ..., 1960)
+    for (let i = 0; i < 2000; i++) {
+      stream.emit({ type: "e", value: i });
+    }
+
+    // All 50 matching events should be in the buffer (buffer size is 100)
+    const result = await collect(iter, 50);
+    expect(result).toHaveLength(50);
+    // First match should be 0 (not dropped by backpressure)
+    expect(result[0]).toEqual({ type: "e", value: 0 });
+    // Last match should be 1960
+    expect(result[49]).toEqual({ type: "e", value: 1960 });
+  });
+
+  it("different subscribers can have independent filters", async () => {
+    const stream = createEventStream<TestEvent>();
+
+    const typeA = collect(
+      stream.subscribe({ filter: (e) => e.type === "a" }),
+      2,
+    );
+    const typeB = collect(
+      stream.subscribe({ filter: (e) => e.type === "b" }),
+      1,
+    );
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+    stream.emit({ type: "a", value: 3 });
+
+    const [resultA, resultB] = await Promise.all([typeA, typeB]);
+    expect(resultA).toEqual([
+      { type: "a", value: 1 },
+      { type: "a", value: 3 },
+    ]);
+    expect(resultB).toEqual([
+      { type: "b", value: 2 },
+    ]);
+  });
+
+  it("subscriber without filter receives all events (default behavior)", async () => {
+    const stream = createEventStream<TestEvent>();
+
+    const filtered = collect(
+      stream.subscribe({ filter: (e) => e.type === "a" }),
+      1,
+    );
+    const unfiltered = collect(stream.subscribe(), 3);
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+    stream.emit({ type: "c", value: 3 });
+
+    const [fResult, uResult] = await Promise.all([filtered, unfiltered]);
+    expect(fResult).toEqual([{ type: "a", value: 1 }]);
+    expect(uResult).toHaveLength(3);
+  });
+
+  it("filter that rejects everything yields no events before close", async () => {
+    const stream = createEventStream<TestEvent>();
+    const events: TestEvent[] = [];
+
+    const consumer = (async () => {
+      for await (const event of stream.subscribe({ filter: () => false })) {
+        events.push(event);
+      }
+    })();
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+    await stream.close();
+    await consumer;
+
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/events/tests/replay-edge-cases.test.ts
+++ b/packages/events/tests/replay-edge-cases.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Replay Reader Edge-Case Tests
+ *
+ * Covers:
+ *   - File not found — fromJsonl rejects with an error
+ *   - File truncation in follow mode — reader resets and yields new events
+ *   - return() while follow iterator is waiting — resolves cleanly
+ *   - Multiple rapid appends in follow mode — all events eventually yielded
+ *   - Round-trip without extra tick — close() properly awaits flush
+ *   - keepMeta preserves all fields including _ts
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  appendFileSync,
+  truncateSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createEventStream,
+  fromJsonl,
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function makeTmpDir(): string {
+  tmpDir = mkdtempSync(join(tmpdir(), "events-replay-edge-"));
+  return tmpDir;
+}
+
+function tick(ms = 20): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function collect<T>(iter: AsyncIterable<T>, limit: number): Promise<T[]> {
+  const results: T[] = [];
+  for await (const event of iter) {
+    results.push(event);
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+afterEach(() => {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// File Not Found
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — file not found", () => {
+  it("rejects when the file does not exist", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "nonexistent.jsonl");
+
+    const iter = fromJsonl(filePath);
+    let caughtError: Error | null = null;
+
+    try {
+      for await (const _event of iter) {
+        // Should not yield any events
+      }
+    } catch (err) {
+      caughtError = err instanceof Error ? err : new Error(String(err));
+    }
+
+    expect(caughtError).not.toBeNull();
+    expect(caughtError!.message).toMatch(/ENOENT/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File Truncation in Follow Mode
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — file truncation in follow mode", () => {
+  it("resets offset and yields new events after file is truncated", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "truncate.jsonl");
+
+    // Write initial events
+    writeFileSync(filePath, [
+      JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "initial", value: 1 }),
+      JSON.stringify({ _ts: "2026-01-01T00:00:01.000Z", type: "initial", value: 2 }),
+    ].join("\n") + "\n");
+
+    const received: Array<{ type: string; value: number }> = [];
+    const iter = fromJsonl<{ type: string; value: number }>(filePath, { follow: true });
+    const asyncIter = iter[Symbol.asyncIterator]();
+
+    // Read the 2 initial events
+    const first = await asyncIter.next();
+    expect(first.done).toBe(false);
+    received.push(first.value!);
+
+    const second = await asyncIter.next();
+    expect(second.done).toBe(false);
+    received.push(second.value!);
+
+    // Truncate the file
+    await tick(50);
+    truncateSync(filePath, 0);
+    await tick(50);
+
+    // Append new events after truncation
+    appendFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:01:00.000Z", type: "after-truncate", value: 99 }) + "\n");
+    await tick(300);
+
+    const third = await asyncIter.next();
+    expect(third.done).toBe(false);
+    received.push(third.value!);
+
+    // Clean up
+    await asyncIter.return!();
+
+    expect(received).toHaveLength(3);
+    expect(received[0]!.type).toBe("initial");
+    expect(received[1]!.type).toBe("initial");
+    expect(received[2]!.type).toBe("after-truncate");
+    expect(received[2]!.value).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// return() While Follow Iterator is Waiting
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — return() while follow iterator is waiting", () => {
+  it("resolves cleanly when return() is called while next() is parked", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "follow-return.jsonl");
+    writeFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "x" }) + "\n");
+
+    const iter = fromJsonl<{ type: string }>(filePath, { follow: true });
+    const asyncIter = iter[Symbol.asyncIterator]();
+
+    // Consume the initial event
+    const first = await asyncIter.next();
+    expect(first.done).toBe(false);
+
+    // Park a next() call — no more data to read
+    const pendingNext = asyncIter.next();
+
+    // Call return() to stop the iterator
+    await tick();
+    const returnResult = await asyncIter.return!();
+    expect(returnResult.done).toBe(true);
+
+    // The parked next() should also resolve with done: true
+    const result = await pendingNext;
+    expect(result.done).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple Rapid Appends in Follow Mode
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — multiple rapid appends in follow mode", () => {
+  it("yields all events from rapid successive appends", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "rapid.jsonl");
+    writeFileSync(filePath, "");
+
+    const iter = fromJsonl<{ type: string; value: number }>(filePath, { follow: true });
+    const asyncIter = iter[Symbol.asyncIterator]();
+
+    // Allow the follow reader to initialize and attach the watcher
+    await tick(50);
+
+    // Append 5 events rapidly without ticking between them
+    for (let i = 1; i <= 5; i++) {
+      appendFileSync(filePath, JSON.stringify({ _ts: `2026-01-01T00:00:0${i}.000Z`, type: "rapid", value: i }) + "\n");
+    }
+
+    // Wait for the watcher to fire and process all events
+    await tick(300);
+
+    // Collect all 5 events
+    const received: Array<{ type: string; value: number }> = [];
+    for (let i = 0; i < 5; i++) {
+      const result = await asyncIter.next();
+      expect(result.done).toBe(false);
+      received.push(result.value!);
+    }
+
+    await asyncIter.return!();
+
+    expect(received).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(received[i]!.value).toBe(i + 1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip Without Extra Tick
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — round-trip without extra tick", () => {
+  it("events written via stream.jsonl() can be read immediately after close() (no tick)", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "roundtrip-notick.jsonl");
+
+    const stream = createEventStream<{ type: string; value: number }>();
+    stream.jsonl(filePath);
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+    stream.emit({ type: "c", value: 3 });
+
+    // close() should await flush — no tick needed after this
+    await stream.close();
+
+    // Read immediately
+    const events = await collect(
+      fromJsonl<{ type: string; value: number }>(filePath),
+      10,
+    );
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: "a", value: 1 });
+    expect(events[1]).toEqual({ type: "b", value: 2 });
+    expect(events[2]).toEqual({ type: "c", value: 3 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// keepMeta Preserves All Fields
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — keepMeta preserves all fields", () => {
+  it("includes _ts and all other fields when keepMeta is true", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "keepmeta.jsonl");
+
+    const ts = "2026-04-12T10:30:00.000Z";
+
+    writeFileSync(filePath, [
+      JSON.stringify({ _ts: ts, type: "a", value: 1, extra: "hello" }),
+      JSON.stringify({ _ts: ts, type: "b", value: 2, nested: { key: "val" } }),
+    ].join("\n") + "\n");
+
+    const events = await collect(
+      fromJsonl<Record<string, unknown>>(filePath, { keepMeta: true }),
+      10,
+    );
+
+    expect(events).toHaveLength(2);
+
+    // First event: _ts should be present and correct
+    expect(events[0]!["_ts"]).toBe(ts);
+    expect(events[0]!["type"]).toBe("a");
+    expect(events[0]!["value"]).toBe(1);
+    expect(events[0]!["extra"]).toBe("hello");
+
+    // Second event: _ts should be present; nested fields preserved
+    expect(events[1]!["_ts"]).toBe(ts);
+    expect(events[1]!["type"]).toBe("b");
+    expect(events[1]!["value"]).toBe(2);
+    expect(events[1]!["nested"]).toEqual({ key: "val" });
+  });
+});

--- a/packages/events/tests/replay.test.ts
+++ b/packages/events/tests/replay.test.ts
@@ -1,0 +1,218 @@
+/**
+ * fromJsonl Replay Reader Tests
+ *
+ * Covers:
+ *   - Read JSONL file, verify events match
+ *   - Malformed line in JSONL — skipped, other events readable
+ *   - Empty file — iteration completes immediately
+ *   - follow mode — live tailing of new events appended to file
+ *   - keepMeta option — preserve or strip _ts field
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { fromJsonl } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function makeTmpDir(): string {
+  tmpDir = mkdtempSync(join(tmpdir(), "events-replay-"));
+  return tmpDir;
+}
+
+function tick(ms = 20): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function collect<T>(iter: AsyncIterable<T>, limit: number): Promise<T[]> {
+  const results: T[] = [];
+  for await (const event of iter) {
+    results.push(event);
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+afterEach(() => {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// One-Shot Read
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — one-shot read", () => {
+  it("reads events from a JSONL file", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+
+    writeFileSync(filePath, [
+      JSON.stringify({ _ts: "2026-04-12T12:00:00.000Z", type: "a", value: 1 }),
+      JSON.stringify({ _ts: "2026-04-12T12:00:01.000Z", type: "b", value: 2 }),
+      JSON.stringify({ _ts: "2026-04-12T12:00:02.000Z", type: "c", value: 3 }),
+    ].join("\n") + "\n");
+
+    const events = await collect(fromJsonl<{ type: string; value: number }>(filePath), 10);
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: "a", value: 1 });
+    expect(events[1]).toEqual({ type: "b", value: 2 });
+    expect(events[2]).toEqual({ type: "c", value: 3 });
+  });
+
+  it("strips _ts field by default", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+
+    writeFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "x" }) + "\n");
+
+    const events = await collect(fromJsonl(filePath), 1);
+    expect(events[0]).toEqual({ type: "x" });
+    expect((events[0] as Record<string, unknown>)["_ts"]).toBeUndefined();
+  });
+
+  it("keeps _ts field when keepMeta: true", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+
+    writeFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "x" }) + "\n");
+
+    const events = await collect(fromJsonl(filePath, { keepMeta: true }), 1);
+    expect((events[0] as Record<string, unknown>)["_ts"]).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("skips malformed lines and continues", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+
+    writeFileSync(filePath, [
+      JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "a", value: 1 }),
+      "this is not json {{{",
+      "",
+      JSON.stringify({ _ts: "2026-01-01T00:00:01.000Z", type: "b", value: 2 }),
+    ].join("\n") + "\n");
+
+    const events = await collect(fromJsonl<{ type: string; value: number }>(filePath), 10);
+    expect(events).toHaveLength(2);
+    expect(events[0]!.type).toBe("a");
+    expect(events[1]!.type).toBe("b");
+  });
+
+  it("handles empty file — completes immediately", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+    writeFileSync(filePath, "");
+
+    const events = await collect(fromJsonl(filePath), 10);
+    expect(events).toEqual([]);
+  });
+
+  it("handles file with only blank lines", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+    writeFileSync(filePath, "\n\n\n");
+
+    const events = await collect(fromJsonl(filePath), 10);
+    expect(events).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Follow Mode
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — follow mode", () => {
+  it("reads initial content then yields new events as they are appended", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+
+    // Write initial content
+    writeFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "initial" }) + "\n");
+
+    const received: Array<{ type: string }> = [];
+    const iter = fromJsonl<{ type: string }>(filePath, { follow: true });
+    const asyncIter = iter[Symbol.asyncIterator]();
+
+    // Read the initial event
+    const first = await asyncIter.next();
+    expect(first.done).toBe(false);
+    received.push(first.value!);
+
+    // Append new events
+    await tick(50);
+    appendFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:00:01.000Z", type: "appended" }) + "\n");
+
+    // Wait for fs.watch to fire
+    await tick(200);
+
+    const second = await asyncIter.next();
+    expect(second.done).toBe(false);
+    received.push(second.value!);
+
+    // Clean up
+    await asyncIter.return!();
+
+    expect(received).toHaveLength(2);
+    expect(received[0]!.type).toBe("initial");
+    expect(received[1]!.type).toBe("appended");
+  });
+
+  it("return() stops the follow iterator", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "events.jsonl");
+    writeFileSync(filePath, JSON.stringify({ _ts: "2026-01-01T00:00:00.000Z", type: "x" }) + "\n");
+
+    const iter = fromJsonl<{ type: string }>(filePath, { follow: true });
+    const asyncIter = iter[Symbol.asyncIterator]();
+
+    const first = await asyncIter.next();
+    expect(first.done).toBe(false);
+
+    const result = await asyncIter.return!();
+    expect(result.done).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: write with EventStream.jsonl(), read with fromJsonl()
+// ---------------------------------------------------------------------------
+
+describe("fromJsonl — round-trip with EventStream.jsonl()", () => {
+  it("events written by jsonl() can be replayed by fromJsonl()", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "roundtrip.jsonl");
+
+    // Dynamic import to avoid circular reference concerns
+    const { createEventStream } = await import("../src/index.js");
+
+    const stream = createEventStream<{ type: string; value: number }>();
+    stream.jsonl(filePath);
+
+    stream.emit({ type: "a", value: 1 });
+    stream.emit({ type: "b", value: 2 });
+    stream.emit({ type: "c", value: 3 });
+
+    await stream.close();
+    await tick(50);
+
+    // Replay
+    const events = await collect(
+      fromJsonl<{ type: string; value: number }>(filePath),
+      10,
+    );
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: "a", value: 1 });
+    expect(events[1]).toEqual({ type: "b", value: 2 });
+    expect(events[2]).toEqual({ type: "c", value: 3 });
+  });
+});

--- a/packages/events/tsconfig.json
+++ b/packages/events/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    /* Language and Environment */
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+
+    /* Emit */
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": true,
+
+    /* Interop Constraints */
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+
+    /* Type Checking */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+
+    /* Completeness */
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,25 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  packages/events:
+    dependencies:
+      '@centient/logger':
+        specifier: workspace:*
+        version: link:../logger
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      '@vitest/coverage-v8':
+        specifier: ^4.0.17
+        version: 4.1.2(vitest@4.1.2(@types/node@20.19.37)(vite@8.0.3(@types/node@20.19.37)))
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.1.2(@types/node@20.19.37)(vite@8.0.3(@types/node@20.19.37))
+
   packages/logger:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

- Adds `@centient/events` — a new typed, generic event streaming package for the centient-sdk monorepo
- Provides `createEventStream<T>()` with AsyncIterable-based consumption, per-subscriber backpressure, JSONL persistence, and replay capabilities
- Includes `fromJsonl<T>()` for replaying persisted event logs with optional follow (tail -f) mode
- Zero external dependencies (only `@centient/logger` workspace dep)

### Core API

| Export | Description |
|--------|-------------|
| `createEventStream<T>(opts?)` | Factory — emit/subscribe/tee/jsonl/close |
| `fromJsonl<T>(path, opts?)` | JSONL replay reader with follow mode |
| `defineEvent<T, P>(type)` | Typed event envelope factory |
| `createJsonlSubscriber<T>(path)` | Standalone JSONL file subscriber |

### Design decisions (from research addendum)

- AsyncIterable for natural backpressure (validated by queueable, strict-stream patterns)
- Per-subscriber buffers with configurable overflow policy (`drop-oldest`, `drop-newest`)
- Subscribe filters run before buffering — filtered events never consume buffer space
- JSONL wrapper format `{ _ts, event }` preserves event integrity for all types

### Quality

- 10-dimension code review performed (Security, Performance, Quality, Tests, Architecture, Documentation, Standards, Logging, Dependencies, Completeness)
- 58 findings identified and remediated before merge
- Key fixes: P2-compliant error propagation, flush serialization, file truncation recovery, filter error isolation, stack traces in all error logging

## Test plan

- [x] 57 tests passing across 5 test files
- [x] TypeScript strict mode — clean build
- [x] Basic emit/subscribe, fan-out, AsyncIterable consumption
- [x] Backpressure policies (drop-oldest, drop-newest, buffer boundaries 0/1)
- [x] JSONL persistence and round-trip replay
- [x] Subscribe filters (matching, buffer space, independent filters, error isolation)
- [x] Follow mode (live tailing, file truncation recovery, rapid appends)
- [x] Error isolation (subscriber errors, filter throws, onClose throws, missing onError)
- [x] Close semantics (flush, completion signal, async onClose, idempotency)
- [x] Edge cases (emit before subscribe, duplicate tee names, file-not-found, return() with pending waiting)


🤖 Generated with [Claude Code](https://claude.com/claude-code)