### PR TITLE
fix(makefile): make publish target idempotent on clean working tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,17 @@ clean: ## Remove build artifacts
 
 publish: build check ## Publish to npm via changesets
 	pnpm changeset version
-	git add -A && git commit -m "chore: version packages"
+	git add -A
+	@# Only commit when `changeset version` actually produced changes.
+	@# When every pending changeset has already been consumed (e.g. the
+	@# version bump landed in a prior feature PR), the working tree stays
+	@# clean after `changeset version` and a plain `git commit` would
+	@# fail with exit 1 — aborting publish+tag-push. Skip the commit in
+	@# that case so `changeset publish` still runs.
+	git diff --cached --quiet || git commit -m "chore: version packages"
 	pnpm changeset publish
 	git push origin main --tags
 
 # Changelog
 # 2026-04-04  Add build summary (run_summarized via release-toolkit)
+# 2026-04-14  Make `publish` target idempotent on already-versioned state


### PR DESCRIPTION
## Summary

- The `publish` Makefile target unconditionally runs `git commit -m "chore: version packages"` after `pnpm changeset version`. When all pending changesets have already been consumed (as happened during the `@centient/secrets@0.4.0` release, where the version bump was committed in the feature PR itself), `changeset version` is a no-op, the working tree stays clean, and the plain `git commit` fails with exit 1 — aborting `publish` before `changeset publish` or `git push --tags` ever run.
- This PR splits the staging and the commit, and guards the commit behind `git diff --cached --quiet || ...`, so the commit only runs when there is something staged. Publish proceeds in both the "fresh changeset" and "already versioned" states.

## Context

Hit during the `@centient/secrets@0.4.0` release flow. Everything upstream of the commit step worked (`tsc`, `vitest`, `changeset version`), but `make publish` exited non-zero, and completing the release required manually running `pnpm changeset publish && git push origin main --tags` outside the target.

## Diff

```make
 publish: build check ## Publish to npm via changesets
 	pnpm changeset version
-	git add -A && git commit -m "chore: version packages"
+	git add -A
+	@# Only commit when `changeset version` actually produced changes.
+	@# When every pending changeset has already been consumed (e.g. the
+	@# version bump landed in a prior feature PR), the working tree stays
+	@# clean after `changeset version` and a plain `git commit` would
+	@# fail with exit 1 — aborting publish+tag-push. Skip the commit in
+	@# that case so `changeset publish` still runs.
+	git diff --cached --quiet || git commit -m "chore: version packages"
 	pnpm changeset publish
 	git push origin main --tags
```

## Why this is the right shape

`git diff --cached --quiet` exits 0 when the index matches HEAD (nothing to commit) and non-zero when there are staged changes. `||` inverts — commit only when there is something to commit. The fix is surgical, preserves the "fresh changeset" happy path exactly, and uses only plumbing commands that are stable across git versions.

Alternatives considered and rejected:
- `git commit --allow-empty` — would pollute history with empty "chore: version packages" commits every time a release runs without fresh changesets.
- Detect via `[ -z "$(ls .changeset/*.md 2>/dev/null | grep -v README)" ]` and branch — more fragile, makes assumptions about file layout.

## Test plan

- [x] Visual inspection of the diff (no logic outside the `publish` target touched)
- [ ] Next `make publish` invocation on main succeeds on both states (fresh changeset and already-consumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)