### PR TITLE
docs(claudemd): sync package table with published versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ See `.agent/DESIGN-PHILOSOPHY.md` for the 14 principles (3 tiers) that guide all
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| `@centient/events` | 0.1.0 | Typed event streaming with backpressure. AsyncIterable + callback fan-out, JSONL persistence/replay, configurable backpressure. Factory: `createEventStream()`, `fromJsonl()` |
+| `@centient/events` | 0.2.0 | Typed event streaming with backpressure. AsyncIterable + callback fan-out, JSONL persistence/replay, configurable backpressure. Factory: `createEventStream()`, `fromJsonl()` |
 | `@centient/logger` | 0.16.0 | Structured logging with transport abstraction. 6 levels, Console/File/Null transports, audit events, data redaction. Factory: `createLogger()`, `createAuditWriter()` |
-| `@centient/sdk` | 1.4.0 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types. Factory: `createEngramClient()`. Requires engram-server >= 0.22.4 |
-| `@centient/wal` | 0.2.0 | Write-ahead log for crash recovery. `appendEntry`, `confirmEntry`, `replayUnconfirmed`, `compactWal` |
+| `@centient/secrets` | 0.4.0 | Cross-platform secrets vault with AES-256-GCM encryption and pluggable key providers. Keychain/libsecret/Windows Credential Manager/GPG file/env backends with prefix enumeration. Factory: `storeCredential()`, `getCredential()`, `deleteCredential()`, `listCredentials()` |
+| `@centient/sdk` | 1.4.1 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types. Factory: `createEngramClient()`. Requires engram-server >= 0.22.4 |
+| `@centient/wal` | 0.3.0 | Write-ahead log for crash recovery. `appendEntry`, `confirmEntry`, `replayUnconfirmed`, `compactWal` |
 | `sdk-python` | - | Python SDK client with Pydantic v2 (async + sync) |
 
 ## Tech Stack


### PR DESCRIPTION
## Summary

- Refresh the `## Packages` table in `CLAUDE.md` so the model's quick-reference context matches what's actually published on npm and in this monorepo's `package.json` files.
- Four of five rows had drifted. `@centient/secrets` was missing entirely — notable since it's the package we actively shipped into this week.

## Drift corrected

| Package | Was | Now |
|---|---|---|
| `@centient/events` | 0.1.0 | **0.2.0** |
| `@centient/logger` | 0.16.0 | 0.16.0 (unchanged) |
| `@centient/secrets` | *(missing)* | **0.4.0** *(new row)* |
| `@centient/sdk` | 1.4.0 | **1.4.1** |
| `@centient/wal` | 0.2.0 | **0.3.0** |

All five versions verified against each package's `package.json` and `npm view @centient/<pkg> version`.

## Why it matters

`CLAUDE.md` is loaded into the model's context at the start of every session in this repo. Stale version numbers in the package table aren't catastrophic, but they're a small ongoing source of model confusion — e.g. agents proposing features based on APIs that predate 0.4.0, or missing `@centient/secrets` entirely when surveying the workspace. Worth a one-line periodic refresh whenever a release lands.

## Follow-up idea (not in this PR)

Consider a CI check or pre-commit hook that fails if the `CLAUDE.md` package table drifts from the real `package.json` versions. The table is small (five rows), and a 20-line script could keep it in sync automatically. Not worth the infrastructure cost for this PR, but flagging it since this is the second time the table has needed a manual refresh.

## Test plan

- [x] Visual inspection of the diff — only the five table rows touched, no logic or prose edits elsewhere.
- [x] Every new version string verified against the corresponding `package.json` and the npm registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)