### PR TITLE
feat(secrets): allow dots in credential key names

### DIFF
--- a/.changeset/secrets-allow-dots-in-keys.md
+++ b/.changeset/secrets-allow-dots-in-keys.md
@@ -1,0 +1,16 @@
+---
+"@centient/secrets": minor
+---
+
+Relax `isValidKey` to permit `.` as a namespace separator in credential key names. The validation regex is now `/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/` — lowercase alphanumeric plus hyphen and dot, first and last character alphanumeric, up to 64 characters.
+
+Both conventions work now — pick whichever reads best:
+
+```ts
+await storeCredential("soma-anthropic-token1", value);  // hyphen-delimited
+await storeCredential("soma.anthropic.token1", value);  // dot-delimited
+```
+
+Strictly additive — every key that validated under the previous `[a-z0-9-]` regex still validates. Underscores, uppercase, whitespace, and shell metacharacters remain rejected so keys can be safely interpolated into subprocess argv positions without additional escaping.
+
+Motivation: the natural namespace shape for pooled Anthropic credentials is `soma.anthropic.token1`, matching dot-delimited conventions used elsewhere in the soma project. Prior to this change, callers had to pick hyphens to satisfy the vault's stricter-than-necessary validation, even though hyphens and dots are equally safe under the shell-escaping constraint the regex is actually protecting.

--- a/packages/secrets/src/vault/vault-utils.ts
+++ b/packages/secrets/src/vault/vault-utils.ts
@@ -4,13 +4,30 @@
  * Shared validation and helper functions used across all vault backends.
  */
 
-/** Allowed key name pattern — alphanumeric and hyphens only, 2-64 chars. */
-const VALID_KEY_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+/**
+ * Allowed key name pattern — lowercase alphanumeric plus hyphen and dot,
+ * 2-64 characters. The inner class permits hyphens and dots so that
+ * callers can use either `-` or `.` as a namespace separator (e.g.
+ * `soma-anthropic-token1` or `soma.anthropic.token1`). First and last
+ * characters must be alphanumeric so keys cannot start or end with a
+ * separator.
+ */
+const VALID_KEY_RE = /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/;
 
 /**
  * Returns true if the given credential key name is valid.
- * Keys must match /^[a-z0-9][a-z0-9-]*[a-z0-9]$/ and be at most 64 characters.
- * This enforces that keys cannot contain shell-special characters.
+ *
+ * Keys must:
+ * - match `/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/` (lowercase alphanumeric plus
+ *   hyphen and dot, starting and ending with an alphanumeric character),
+ * - be at most 64 characters long.
+ *
+ * Hyphens and dots are both permitted as namespace separators so callers
+ * can choose whichever convention reads best (`soma-anthropic-token1`,
+ * `soma.anthropic.token1`). Underscores, uppercase, whitespace, and
+ * shell metacharacters are deliberately rejected so keys can safely be
+ * interpolated into subprocess argv positions without additional
+ * escaping.
  */
 export function isValidKey(key: string): boolean {
   return VALID_KEY_RE.test(key) && key.length <= 64;

--- a/packages/secrets/src/vault/vault.ts
+++ b/packages/secrets/src/vault/vault.ts
@@ -167,13 +167,14 @@ export async function deleteCredential(key: string): Promise<boolean> {
  * @param prefix - optional key prefix filter. When omitted, all keys are
  *                 returned.
  *
- * Note: credential keys must match `isValidKey` (`[a-z0-9][a-z0-9-]*[a-z0-9]`,
- * <=64 chars) — lowercase alphanumeric plus hyphen, no dots. Callers that want
- * a namespace separator should use hyphens (`soma-anthropic-token1`).
+ * Note: credential keys must match `isValidKey` — lowercase alphanumeric
+ * plus hyphen and dot, first and last character alphanumeric, <=64 chars.
+ * Both `-` and `.` work as namespace separators; pick whichever convention
+ * reads best.
  *
  * @example
  *   // Enumerate all soma-owned Anthropic credentials
- *   const keys = await listCredentials("soma-anthropic-");
+ *   const keys = await listCredentials("soma.anthropic.");
  *   for (const key of keys) {
  *     const value = await getCredential(key);
  *     // ... round-robin rotation, etc.

--- a/packages/secrets/tests/vault-utils.test.ts
+++ b/packages/secrets/tests/vault-utils.test.ts
@@ -1,0 +1,55 @@
+/**
+ * vault-utils — isValidKey
+ *
+ * Pins the allowed credential key grammar. The regex intentionally
+ * permits both `-` and `.` as namespace separators so callers can use
+ * either convention (hyphen-delimited `soma-anthropic-token1` or
+ * dot-delimited `soma.anthropic.token1`), and deliberately rejects
+ * everything else so keys can be interpolated into subprocess argv
+ * without escaping.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isValidKey } from "../src/vault/vault-utils.js";
+
+describe("isValidKey — accepted shapes", () => {
+  it.each([
+    "auth-token",
+    "refresh-token",
+    "a1",
+    "ab",
+    "soma-anthropic-token1",
+    "soma-anthropic-token99",
+    "soma.anthropic.token1",
+    "soma.anthropic.token99",
+    "soma-anthropic.token1",
+    "1-2-3",
+    "a.b-c.d",
+    "x".repeat(64),
+  ])("accepts %s", (key) => {
+    expect(isValidKey(key)).toBe(true);
+  });
+});
+
+describe("isValidKey — rejected shapes", () => {
+  it.each([
+    ["empty string", ""],
+    ["single character", "a"],
+    ["uppercase", "Auth-Token"],
+    ["underscore", "auth_token"],
+    ["whitespace", "auth token"],
+    ["leading hyphen", "-auth"],
+    ["trailing hyphen", "auth-"],
+    ["leading dot", ".auth"],
+    ["trailing dot", "auth."],
+    ["shell metachar $", "auth$token"],
+    ["shell metachar ;", "auth;token"],
+    ["backslash", "auth\\token"],
+    ["forward slash", "auth/token"],
+    ["quote", "auth'token"],
+    ["65 characters", "x".repeat(65)],
+    ["non-ASCII", "auth-tökén"],
+  ])("rejects %s", (_label, key) => {
+    expect(isValidKey(key)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Relax `isValidKey` so `.` is a permitted namespace separator alongside `-`. Both conventions now validate; pick whichever reads best.
- Closes the H1 follow-up from the 0.4.0 code review — the `listCredentials` JSDoc example can finally show `soma.anthropic.` as a prefix without the validator blocking the underlying `storeCredential` calls.
- Queues a minor changeset toward `@centient/secrets@0.5.0`.

## Change

```diff
-const VALID_KEY_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+const VALID_KEY_RE = /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/;
```

Everything else about the regex stays: first and last character must be alphanumeric so keys cannot start or end with a separator; lowercase only; max 64 characters; underscores, whitespace, and shell metacharacters still rejected.

```ts
// After this PR — both of these are valid:
await storeCredential("soma-anthropic-token1", value);
await storeCredential("soma.anthropic.token1", value);
```

## Why it's safe

The constraint exists to make it safe to interpolate a credential key into subprocess argv positions without additional escaping. That's why uppercase, underscores, whitespace, quotes, and shell metacharacters are all rejected: each of them could break argument parsing in at least one of the backends that shell out (`security` on macOS, `secret-tool` on libsecret, PowerShell on Windows, `gpg` for the GPG file vault).

Dots are none of those things. Under every shell and every subprocess invocation we currently make, `.` is a literal character with no special meaning. The only reason they were excluded in the original regex is that the author picked a conservative minimum rather than specifically threat-modeling the separator character set.

## Backwards compat

Strictly additive. Every key that validated under the previous regex still validates — the character class only added new permitted characters, nothing was removed. No consumer needs to change anything. The changeset entry calls this out explicitly.

## Test plan

- [x] `pnpm -F @centient/secrets build` — clean
- [x] `pnpm -F @centient/secrets test` — 81 tests passing (was 53; +28 from the new `vault-utils.test.ts`)
- [x] `pnpm -F @centient/secrets lint` — clean
- [x] New parameterized tests cover:
  - Accepted: `auth-token`, `soma-anthropic-token1`, `soma.anthropic.token1`, mixed `a.b-c.d`, 64-char max, 2-char minimum
  - Rejected: empty string, single char, uppercase, underscores, whitespace, leading/trailing separator, shell metacharacters (`$`, `;`, backslash, slash, quote), 65-char length, non-ASCII
- [ ] CI green on this PR

## Release context

This is PR **A of 5** in the planned `@centient/secrets@0.5.0` train:

| PR | Status | Items |
|---|---|---|
| **A — allow dots in keys** | **this PR** | Item 1 |
| B — Keychain caching + `--json` CLI flag | not started | Items 2, 3 |
| C — libsecret via dbus (async `listKeys` interface) | not started | Item 4 |
| D — optional audit event emission | design in flight | Item 8 |
| E — RELEASING.md + CLAUDE.md drift CI check | not started | Items 6, 7 |

All five PRs will land independently; their changesets will accumulate and consume together on the next `make publish`, producing `@centient/secrets@0.5.0` as a single release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)