### PR TITLE
docs: add RELEASING.md and CLAUDE.md version drift check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SUMMARY := . $(TOOLKIT)/common.sh && . $(TOOLKIT)/summary.sh
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install build lint test check clean publish
+.PHONY: help install build lint test check clean publish claudemd-check
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -39,6 +39,10 @@ publish: build check ## Publish to npm via changesets
 	pnpm changeset publish
 	git push origin main --tags
 
+claudemd-check: ## Check CLAUDE.md package table matches actual versions
+	@./scripts/check-claudemd-versions.sh
+
 # Changelog
 # 2026-04-04  Add build summary (run_summarized via release-toolkit)
 # 2026-04-14  Make `publish` target idempotent on already-versioned state
+# 2026-04-15  Add claudemd-check target + RELEASING.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,101 @@
+# Releasing @centient packages
+
+This document describes the release process for packages in this monorepo.
+It exists to prevent a repeat of the 0.4.0 publish snag where the version
+bump landed in a feature PR, causing `make publish` to fail mid-flow.
+
+## The happy path
+
+```
+1. Land feature PRs on main (each PR includes a .changeset/*.md file)
+2. From a clean main:
+   make publish
+3. Done — packages are on npm, tags are on GitHub.
+```
+
+`make publish` runs: `build → check → changeset version → commit (if needed) → changeset publish → push + tags`.
+
+## Rules
+
+### Feature PRs include changesets, NOT version bumps
+
+A feature PR should contain:
+
+- The code changes
+- A `.changeset/<name>.md` file describing the change and the bump level
+- Tests
+
+A feature PR should **NOT** contain:
+
+- Manually edited `package.json` version fields
+- `CHANGELOG.md` updates
+- The output of `pnpm changeset version`
+
+The `make publish` target owns the version bump. If a feature PR consumes
+its own changeset before `make publish` runs, the publish target's
+`changeset version` step becomes a no-op and (prior to the idempotency
+fix in PR #19) the subsequent `git commit` would fail, aborting the
+entire release. The idempotency fix makes this survivable, but the
+correct flow is still: changesets in the PR, version bump in `make publish`.
+
+### One `make publish` per release batch
+
+All pending changesets are consumed together in a single `make publish`
+run. This produces one version bump per affected package, one CHANGELOG
+entry per package, and one npm publish per package. Do not run `make
+publish` multiple times for the same set of changesets.
+
+### npm 2FA
+
+`make publish` will prompt for an OTP if the npm account has 2FA enabled
+for publish operations (which it should). Have your authenticator ready.
+
+If the OTP prompt fails or times out, run the remaining steps manually:
+
+```bash
+pnpm changeset publish --otp=<code>
+git push origin main --tags
+```
+
+### Recovery from a failed publish
+
+If `make publish` fails partway through:
+
+1. Check `git status` — are there uncommitted version-bump changes?
+   - Yes → commit them: `git add -A && git commit -m "chore: version packages"`
+   - No → version bump either already committed or was a no-op
+2. Check npm: `npm view @centient/<pkg> version` — did the publish succeed?
+   - Yes → just push tags: `git push origin main --tags`
+   - No → re-run: `pnpm changeset publish` (add `--otp=<code>` if prompted)
+3. Push: `git push origin main --tags`
+
+### Pre-publish checklist
+
+Before running `make publish`:
+
+- [ ] You are on `main`, up to date with `origin/main`
+- [ ] Working tree is clean (`git status` shows nothing)
+- [ ] All pending changesets are the ones you want to release
+- [ ] You are logged in to npm as the correct user (`npm whoami`)
+- [ ] You have your 2FA authenticator available
+- [ ] `pnpm build && pnpm test && pnpm lint` all pass (make publish does this, but catching failures early is faster)
+
+## Versioning policy
+
+- **0.x packages** (pre-1.0): minor bumps may include breaking changes.
+  This is standard semver for 0.x — consumers should pin `^0.x.0` and
+  read the CHANGELOG on each update.
+- **1.x+ packages**: standard semver. Breaking changes require a major bump.
+
+All version bumps go through changesets. Never edit `package.json`
+version fields manually.
+
+## CLAUDE.md package table
+
+After a release, the `CLAUDE.md` package table should be updated to
+reflect the new version(s). Run `make claudemd-check` to detect drift.
+If it reports a mismatch, update `CLAUDE.md` and open a small docs PR.
+
+This is not automated in the release flow because `CLAUDE.md` is a
+human-curated document with descriptions that may need updating alongside
+the version number.

--- a/scripts/check-claudemd-versions.sh
+++ b/scripts/check-claudemd-versions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Verify that the package table in CLAUDE.md matches the actual
+# package.json versions in the monorepo. Exits non-zero on drift.
+#
+# Usage:
+#   ./scripts/check-claudemd-versions.sh      # from repo root
+#   make claudemd-check                        # via Makefile target
+
+set -euo pipefail
+
+CLAUDE_MD="CLAUDE.md"
+DRIFT=0
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  echo "error: $CLAUDE_MD not found (run from repo root)" >&2
+  exit 1
+fi
+
+for pkg_dir in packages/*/; do
+  pkg_json="${pkg_dir}package.json"
+  [ -f "$pkg_json" ] || continue
+
+  name=$(awk -F'"' '/"name"/{print $4; exit}' "$pkg_json")
+  actual=$(awk -F'"' '/"version"/{print $4; exit}' "$pkg_json")
+
+  # Table rows: | `@centient/foo` | 1.2.3 | description |
+  # Extract the version field (column 3) from the row matching this package name.
+  table_version=$(awk -F'|' -v pkg="\`${name}\`" \
+    '$2 ~ pkg { gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3 }' "$CLAUDE_MD")
+
+  if [ -z "$table_version" ]; then
+    echo "MISSING  $name  (actual: $actual, not in CLAUDE.md table)"
+    DRIFT=1
+  elif [ "$table_version" != "$actual" ]; then
+    echo "DRIFT    $name  (CLAUDE.md: $table_version, actual: $actual)"
+    DRIFT=1
+  else
+    echo "OK       $name  ($actual)"
+  fi
+done
+
+if [ "$DRIFT" -ne 0 ]; then
+  echo ""
+  echo "CLAUDE.md package table is out of sync. Update it and open a docs PR."
+  exit 1
+else
+  echo ""
+  echo "All package versions in CLAUDE.md match."
+fi


### PR DESCRIPTION
## Summary

Two repo-level improvements from the 0.4.0 release retrospective, referenced in ADR-002 (#22):

- **RELEASING.md** — documents the correct release flow (`make publish`), the rule that feature PRs include changesets but not version bumps, pre-publish checklist, npm 2FA handling, and recovery steps for failed publishes. Prevents a repeat of the 0.4.0 snag.
- **`make claudemd-check`** — a shell script (`scripts/check-claudemd-versions.sh`) that compares the `CLAUDE.md` package table against the actual `package.json` versions and exits non-zero on drift. Uses only POSIX tools (awk/bash) — works on macOS and Linux without extra dependencies.

## Context

During the `@centient/secrets@0.4.0` release:
1. The version bump was committed inside the feature PR instead of being left for `make publish`, which caused `make publish` to fail mid-flow (fixed by PR #19).
2. The `CLAUDE.md` package table was stale on 4 of 5 rows and missing `@centient/secrets` entirely (fixed by PR #20).

Both issues are now documented and detectable:
- RELEASING.md tells future contributors the correct flow so they don't re-learn it by breaking things.
- `make claudemd-check` catches drift before it accumulates.

## Demo

```
$ make claudemd-check
OK       @centient/events  (0.2.0)
OK       @centient/logger  (0.16.0)
OK       @centient/sdk  (1.4.1)
OK       @centient/secrets  (0.4.0)
OK       @centient/wal  (0.3.0)

All package versions in CLAUDE.md match.
```

## Test plan

- [x] `make claudemd-check` passes on current `main` (all 5 packages match)
- [x] Verified the script detects drift: temporarily changing a version in `CLAUDE.md` produces `DRIFT` output and exit code 1
- [x] `make help` shows the new `claudemd-check` target
- [x] No package code changed — no changeset needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)