### PR TITLE
feat(secrets): cache Keychain enumeration + add --json CLI flag

### DIFF
--- a/.changeset/secrets-keychain-cache-json-cli.md
+++ b/.changeset/secrets-keychain-cache-json-cli.md
@@ -1,0 +1,9 @@
+---
+"@centient/secrets": minor
+---
+
+Add in-process TTL cache for macOS Keychain enumeration and `--json` output flag for `list-backend-keys` CLI subcommand.
+
+**Keychain cache:** `listAccountsInKeychain` now caches results for 5 seconds, keyed by `{service, prefix}`. Repeated `listCredentials` calls within the TTL window return cached results without re-spawning `security dump-keychain`. The cache is automatically invalidated when `storeStringInKeychain` or `deleteFromKeychain` is called, so stale reads after a write are not possible.
+
+**`--json` CLI flag:** `centient secrets list-backend-keys --json` outputs a sorted JSON array of key strings instead of the human-readable formatted list. On enumeration failure, outputs `{"error": "..."}` instead of the emoji-prefixed stderr message. Designed for scripting — e.g. `centient secrets list-backend-keys --prefix soma.anthropic. --json | jq '.[]'`.

--- a/packages/secrets/src/cli/secrets-cli.ts
+++ b/packages/secrets/src/cli/secrets-cli.ts
@@ -58,6 +58,8 @@ export interface SecretsOptions {
   secretValue?: string;
   /** Optional prefix filter for `list-backend-keys`. */
   prefix?: string;
+  /** Output JSON instead of human-readable text (`list-backend-keys --json`). */
+  json?: boolean;
 }
 
 // =============================================================================
@@ -335,23 +337,36 @@ async function listSecrets(): Promise<void> {
  * vault at `~/.centient/secrets/vault.enc`. The two storage paths are
  * separate in this release.
  */
-async function listBackendKeys(prefix?: string): Promise<void> {
+async function listBackendKeys(
+  prefix?: string,
+  json?: boolean,
+): Promise<void> {
+  let keys: string[];
+  try {
+    keys = await listCredentials(prefix);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (json) {
+      process.stdout.write(JSON.stringify({ error: message }) + "\n");
+    } else {
+      console.error(`❌ Failed to enumerate backend keys: ${message}`);
+    }
+    process.exit(1);
+  }
+
+  const sorted = [...keys].sort();
+
+  if (json) {
+    process.stdout.write(JSON.stringify(sorted) + "\n");
+    return;
+  }
+
   const backendType = getActiveVaultType();
   const header = prefix !== undefined
     ? `\n🔑 Backend keys (${backendType}, prefix "${prefix}"):\n\n`
     : `\n🔑 Backend keys (${backendType}):\n\n`;
   process.stdout.write(header);
 
-  let keys: string[];
-  try {
-    keys = await listCredentials(prefix);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`❌ Failed to enumerate backend keys: ${message}`);
-    process.exit(1);
-  }
-
-  const sorted = [...keys].sort();
   if (sorted.length === 0) {
     process.stdout.write("   (no keys)\n\n");
     return;
@@ -759,7 +774,7 @@ export async function runSecrets(options: SecretsOptions): Promise<void> {
       await listSecrets();
       break;
     case "list-backend-keys":
-      await listBackendKeys(options.prefix);
+      await listBackendKeys(options.prefix, options.json);
       break;
     case "set":
       await setSecret(options.secretName || "");

--- a/packages/secrets/src/crypto/vault-common.ts
+++ b/packages/secrets/src/crypto/vault-common.ts
@@ -104,6 +104,31 @@ export function decryptObject(
 }
 
 // =============================================================================
+// Keychain enumeration cache
+// =============================================================================
+
+interface KeychainCacheEntry {
+  keys: string[];
+  expiresAt: number;
+}
+
+const KEYCHAIN_LIST_CACHE_TTL_MS = 5_000;
+const keychainListCache = new Map<string, KeychainCacheEntry>();
+
+function keychainCacheKey(service: string, prefix: string | undefined): string {
+  return `${service}\0${prefix ?? ""}`;
+}
+
+/**
+ * Invalidate all cached enumeration results. Called automatically
+ * by `storeStringInKeychain` and `deleteFromKeychain` so that
+ * `listAccountsInKeychain` never returns stale data after a write.
+ */
+export function invalidateKeychainListCache(): void {
+  keychainListCache.clear();
+}
+
+// =============================================================================
 // Keychain operations (macOS `security` CLI)
 // =============================================================================
 
@@ -187,6 +212,7 @@ export function storeStringInKeychain(
       ["add-generic-password", "-s", service, "-a", account, "-w", value, "-T", ""],
       { stdio: ["pipe", "pipe", "pipe"] },
     );
+    invalidateKeychainListCache();
     return true;
   } catch {
     return false;
@@ -227,6 +253,7 @@ export function deleteFromKeychain(
       ["delete-generic-password", "-s", service, "-a", account],
       { stdio: ["pipe", "pipe", "pipe"] },
     );
+    invalidateKeychainListCache();
     return true;
   } catch {
     // exit 44 = item not found — treat as success
@@ -258,6 +285,12 @@ export function listAccountsInKeychain(
   service: string,
   prefix?: string,
 ): string[] {
+  const ck = keychainCacheKey(service, prefix);
+  const cached = keychainListCache.get(ck);
+  if (cached !== undefined && Date.now() < cached.expiresAt) {
+    return cached.keys;
+  }
+
   const output = execFileSync(
     "security",
     ["dump-keychain"],
@@ -299,5 +332,10 @@ export function listAccountsInKeychain(
     }
   }
   flush();
+
+  keychainListCache.set(ck, {
+    keys,
+    expiresAt: Date.now() + KEYCHAIN_LIST_CACHE_TTL_MS,
+  });
   return keys;
 }

--- a/packages/secrets/tests/secrets-cli.listBackendKeys.test.ts
+++ b/packages/secrets/tests/secrets-cli.listBackendKeys.test.ts
@@ -213,12 +213,6 @@ describe("runSecrets list-backend-keys", () => {
   });
 
   it("does NOT touch the encrypted file vault (no readFileSync / decrypt)", async () => {
-    // listCredentials is the only surface this test needs to observe —
-    // the fact that the CLI handler only delegates to listCredentials
-    // and getActiveVaultType means the file-vault path (readFileSync /
-    // decryptObject) is never exercised. This test documents that
-    // separation by asserting listCredentials was called and the file-vault
-    // mock surface wasn't touched.
     mockListCredentials.mockResolvedValue(["auth-token"]);
     const { restore } = capture();
     try {
@@ -227,5 +221,87 @@ describe("runSecrets list-backend-keys", () => {
       restore();
     }
     expect(mockListCredentials).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runSecrets list-backend-keys --json", () => {
+  it("outputs a sorted JSON array of keys", async () => {
+    mockListCredentials.mockResolvedValue([
+      "soma-anthropic-token2",
+      "auth-token",
+      "soma-anthropic-token1",
+    ]);
+
+    const { captured, restore } = capture();
+    try {
+      await runSecrets({ command: "list-backend-keys", json: true });
+    } finally {
+      restore();
+    }
+
+    const parsed = JSON.parse(captured.stdout.trim());
+    expect(parsed).toEqual([
+      "auth-token",
+      "soma-anthropic-token1",
+      "soma-anthropic-token2",
+    ]);
+  });
+
+  it("outputs an empty JSON array when no keys exist", async () => {
+    mockListCredentials.mockResolvedValue([]);
+    const { captured, restore } = capture();
+    try {
+      await runSecrets({ command: "list-backend-keys", json: true });
+    } finally {
+      restore();
+    }
+    expect(JSON.parse(captured.stdout.trim())).toEqual([]);
+  });
+
+  it("outputs a JSON error object on enumeration failure", async () => {
+    mockListCredentials.mockRejectedValue(
+      new Error("keychain access denied"),
+    );
+    const { captured, restore } = capture();
+    try {
+      await expect(
+        runSecrets({ command: "list-backend-keys", json: true }),
+      ).rejects.toThrow(/__process_exit_1__/);
+    } finally {
+      restore();
+    }
+    const parsed = JSON.parse(captured.stdout.trim());
+    expect(parsed).toEqual({ error: "keychain access denied" });
+  });
+
+  it("does not include human-readable headers or emoji in JSON mode", async () => {
+    mockListCredentials.mockResolvedValue(["auth-token"]);
+    const { captured, restore } = capture();
+    try {
+      await runSecrets({ command: "list-backend-keys", json: true });
+    } finally {
+      restore();
+    }
+    expect(captured.stdout).not.toContain("🔑");
+    expect(captured.stdout).not.toContain("Backend keys");
+    expect(captured.stdout).not.toContain("keys)");
+  });
+
+  it("respects the prefix option in JSON mode", async () => {
+    mockListCredentials.mockResolvedValue(["soma-anthropic-token1"]);
+    const { captured, restore } = capture();
+    try {
+      await runSecrets({
+        command: "list-backend-keys",
+        prefix: "soma-anthropic-",
+        json: true,
+      });
+    } finally {
+      restore();
+    }
+    expect(mockListCredentials).toHaveBeenCalledWith("soma-anthropic-");
+    expect(JSON.parse(captured.stdout.trim())).toEqual([
+      "soma-anthropic-token1",
+    ]);
   });
 });

--- a/packages/secrets/tests/vault-common.listAccounts.test.ts
+++ b/packages/secrets/tests/vault-common.listAccounts.test.ts
@@ -17,7 +17,7 @@ vi.mock("child_process", () => ({
   execFileSync: mockExecFileSync,
 }));
 
-const { listAccountsInKeychain } = await import(
+const { listAccountsInKeychain, invalidateKeychainListCache } = await import(
   "../src/crypto/vault-common.js"
 );
 
@@ -61,6 +61,7 @@ attributes:
 
 beforeEach(() => {
   mockExecFileSync.mockReset();
+  invalidateKeychainListCache();
 });
 
 describe("listAccountsInKeychain", () => {
@@ -104,5 +105,55 @@ describe("listAccountsInKeychain", () => {
     expect(() => listAccountsInKeychain("centient-auth")).toThrow(
       /permission denied/,
     );
+  });
+});
+
+describe("listAccountsInKeychain — caching", () => {
+  it("returns cached results on second call without re-spawning security CLI", () => {
+    mockExecFileSync.mockReturnValue(SAMPLE_DUMP);
+    const first = listAccountsInKeychain("centient-auth");
+    const second = listAccountsInKeychain("centient-auth");
+    expect(second).toEqual(first);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches separately by prefix", () => {
+    mockExecFileSync.mockReturnValue(SAMPLE_DUMP);
+    listAccountsInKeychain("centient-auth");
+    listAccountsInKeychain("centient-auth", "soma-anthropic-");
+    // Two different cache keys → two subprocess invocations
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    // Second call to same prefix is cached
+    listAccountsInKeychain("centient-auth", "soma-anthropic-");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateKeychainListCache clears all cached entries", () => {
+    mockExecFileSync.mockReturnValue(SAMPLE_DUMP);
+    listAccountsInKeychain("centient-auth");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+
+    invalidateKeychainListCache();
+
+    listAccountsInKeychain("centient-auth");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failures", () => {
+    let callCount = 0;
+    mockExecFileSync.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) throw new Error("transient error");
+      return SAMPLE_DUMP;
+    });
+
+    expect(() => listAccountsInKeychain("centient-auth")).toThrow("transient error");
+    const result = listAccountsInKeychain("centient-auth");
+    expect(result.sort()).toEqual([
+      "auth-token",
+      "refresh-token",
+      "soma-anthropic-token1",
+      "soma-anthropic-token2",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Two improvements for the `listCredentials` / `list-backend-keys` surface, per items 2 and 3 of the 0.5.0 plan in ADR-002 (#22):

- **Keychain enumeration cache** — `listAccountsInKeychain` now caches results for 5 seconds (keyed by `{service, prefix}`). Repeated `listCredentials` calls within the TTL window skip the `security dump-keychain` subprocess, which is O(total-keychain-size) and can take 100ms+ on large keychains. Auto-invalidated on `storeStringInKeychain` / `deleteFromKeychain` so stale reads after a write are impossible.
- **`--json` CLI flag** — `centient secrets list-backend-keys --json` outputs a sorted JSON array of key strings instead of the human-readable formatted list. On failure, outputs `{"error": "..."}`. Designed for scripting: `centient secrets list-backend-keys --prefix soma.anthropic. --json | jq '.[]'`.

## Files changed

- `packages/secrets/src/crypto/vault-common.ts` — cache infrastructure (`keychainListCache` Map, 5s TTL, `invalidateKeychainListCache()` helper), cache read/write in `listAccountsInKeychain`, invalidation calls in `storeStringInKeychain` and `deleteFromKeychain`.
- `packages/secrets/src/cli/secrets-cli.ts` — `json?: boolean` on `SecretsOptions`, `listBackendKeys` early-returns JSON output when flag is set, JSON error object on failure path.
- `tests/vault-common.listAccounts.test.ts` — +4 cache tests (hit/miss/invalidation/failure-not-cached).
- `tests/secrets-cli.listBackendKeys.test.ts` — +5 JSON CLI tests.

## Test plan

- [x] `pnpm -F @centient/secrets build` — clean
- [x] `pnpm -F @centient/secrets test` — 90/90 passing (was 81)
- [x] `pnpm -F @centient/secrets lint` — clean
- [ ] CI green

## Release context

PR **B of 6** in the 0.5.0 train (items 2 + 3). See ADR-002 (#22) for the full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)