### PR TITLE
feat(secrets): async listKeys + libsecret via D-Bus

### DIFF
--- a/.changeset/secrets-async-listkeys-dbus.md
+++ b/.changeset/secrets-async-listkeys-dbus.md
@@ -1,0 +1,15 @@
+---
+"@centient/secrets": minor
+---
+
+Make `VaultBackend.listKeys` async (`Promise<string[]>`) and replace libsecret's `secret-tool search --all` CLI with a D-Bus client via `dbus-next`.
+
+**Interface change:** `VaultBackend.listKeys(prefix?)` now returns `Promise<string[]>` instead of `string[]`. This is a compile-time breaking change for any external implementations of `VaultBackend`. No external implementations are known; accepting as a minor bump under 0.x semver per ADR-002 §0.5.0.
+
+**Security fix (libsecret):** The previous implementation shelled out to `secret-tool search --all`, which emitted every stored credential's decrypted value on stdout alongside the attribute lines we parsed. The new D-Bus path calls `org.freedesktop.secrets.Service.SearchItems`, which returns item object paths without decrypting secret values — secret material never crosses process memory during enumeration.
+
+**Fallback:** If the D-Bus session bus is unavailable (e.g. SSH without `DBUS_SESSION_BUS_ADDRESS`, headless server), the libsecret backend falls back to the `secret-tool` CLI parser automatically. The fallback carries the same transient-exposure trade-off as before; the JSDoc documents this.
+
+**Other backends:** Keychain, Windows Credential Manager, GPG file vault, and EnvVault simply mark their `listKeys` as `async` — the underlying sync work is unchanged, auto-wrapped in a resolved promise.
+
+**New runtime dependency:** `dbus-next@^0.10.2` (pure JavaScript, no native bindings). This is the first runtime dependency on `@centient/secrets`. It is dynamically imported inside `listKeysViaDbus` so it is only loaded on Linux when the libsecret backend is active and D-Bus is available.

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -52,5 +52,8 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "dbus-next": "^0.10.2"
+  }
 }

--- a/packages/secrets/src/vault/types.ts
+++ b/packages/secrets/src/vault/types.ts
@@ -102,8 +102,11 @@ export interface VaultBackend {
    * (keychain access denied, libsecret timeout, filesystem permission
    * error) should throw, so the caller can retry or surface the problem.
    *
-   * Synchronous to match the existing store/retrieve/delete signatures;
-   * any async wrapping happens in the public `listCredentials` function.
+   * Async to support backends (e.g. libsecret via D-Bus) that require
+   * non-blocking I/O for enumeration. Backends whose enumeration is
+   * naturally synchronous (Keychain, GPG, env-var) can simply mark the
+   * method `async` — the sync return value is auto-wrapped in a resolved
+   * promise.
    */
-  listKeys(prefix?: string): string[];
+  listKeys(prefix?: string): Promise<string[]>;
 }

--- a/packages/secrets/src/vault/vault-env.ts
+++ b/packages/secrets/src/vault/vault-env.ts
@@ -87,7 +87,7 @@ export class EnvVault implements VaultBackend {
    * There is no user-defined naming convention over `process.env`, so
    * arbitrary prefixes that don't match `auth-token` always produce `[]`.
    */
-  listKeys(prefix?: string): string[] {
+  async listKeys(prefix?: string): Promise<string[]> {
     if (process.env["ENGRAM_API_KEY"] === undefined) return [];
     if (prefix !== undefined && !"auth-token".startsWith(prefix)) return [];
     return ["auth-token"];

--- a/packages/secrets/src/vault/vault-gpg.ts
+++ b/packages/secrets/src/vault/vault-gpg.ts
@@ -174,7 +174,7 @@ export class GpgVault implements VaultBackend {
    * filesystem error (e.g. EACCES) is propagated so the caller can retry
    * or surface the problem, per the VaultBackend contract.
    */
-  listKeys(prefix?: string): string[] {
+  async listKeys(prefix?: string): Promise<string[]> {
     let entries: string[];
     try {
       entries = readdirSync(AUTH_DIR);

--- a/packages/secrets/src/vault/vault-libsecret.ts
+++ b/packages/secrets/src/vault/vault-libsecret.ts
@@ -125,24 +125,95 @@ export class LibsecretVault implements VaultBackend {
 
   /**
    * Enumerate credential keys stored under the `centient` service in
-   * libsecret via `secret-tool search --all service centient`.
+   * libsecret.
    *
-   * Only the `attribute.key = <key>` lines in the output are inspected;
-   * the secret values that appear in the same output are ignored.
+   * Primary path: connects to the session D-Bus and calls the
+   * `org.freedesktop.secrets` SearchItems API, which returns item
+   * object paths without decrypting secret values — eliminating the
+   * transient in-process exposure that the old `secret-tool search
+   * --all` approach had.
    *
-   * Security note: `secret-tool search --all` emits the decrypted secret
-   * for every matching item on stdout as `secret = <value>` lines. This
-   * means every stored credential's plaintext is briefly materialized in
-   * this process's Node string buffer before being discarded and GC'd.
-   * No values are returned to callers or logged, but the transient
-   * exposure is inherent to the `secret-tool` CLI. A future switch to the
-   * libsecret D-Bus API would allow value-less enumeration.
+   * Fallback: if the D-Bus connection fails (e.g. SSH session without
+   * `DBUS_SESSION_BUS_ADDRESS`, headless server), falls back to
+   * `secret-tool search --all` and parses `attribute.key` lines.
+   * The fallback still briefly materializes secret values on stdout;
+   * the JSDoc on the `secret-tool` path in the fallback documents
+   * this trade-off.
    *
-   * No results -> empty list. A transient `secret-tool` failure (e.g.
-   * D-Bus unavailable, keyring locked) is propagated per the VaultBackend
-   * contract so the caller can retry.
+   * No results -> empty list. A transient failure from both paths is
+   * propagated per the VaultBackend contract so the caller can retry.
    */
-  listKeys(prefix?: string): string[] {
+  async listKeys(prefix?: string): Promise<string[]> {
+    try {
+      return await this.listKeysViaDbus(prefix);
+    } catch {
+      return this.listKeysViaSecretTool(prefix);
+    }
+  }
+
+  /**
+   * D-Bus primary path for listKeys — no secret values cross process
+   * memory. Uses dynamic import so `dbus-next` is only loaded on
+   * Linux when actually needed.
+   */
+  private async listKeysViaDbus(prefix?: string): Promise<string[]> {
+    const dbus = await import("dbus-next");
+    const bus = dbus.sessionBus();
+
+    try {
+      const serviceObj = await bus.getProxyObject(
+        "org.freedesktop.secrets",
+        "/org/freedesktop/secrets",
+      );
+      // dbus-next generates method stubs dynamically from introspection —
+      // TypeScript cannot know about SearchItems / Get at compile time.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const service = serviceObj.getInterface("org.freedesktop.Secret.Service") as any;
+
+      const [unlocked, locked] = await service.SearchItems(
+        { service: SERVICE_ATTR },
+      ) as [string[], string[]];
+
+      const allPaths = [...unlocked, ...locked];
+      const keys: string[] = [];
+
+      for (const itemPath of allPaths) {
+        const itemObj = await bus.getProxyObject(
+          "org.freedesktop.secrets",
+          itemPath,
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const props = itemObj.getInterface("org.freedesktop.DBus.Properties") as any;
+        const attrs = await props.Get(
+          "org.freedesktop.Secret.Item",
+          "Attributes",
+        ) as { value: Array<[{ value: string }, { value: string }]> };
+
+        let keyVal: string | undefined;
+        for (const [attrName, attrValue] of attrs.value) {
+          if (attrName.value === "key") {
+            keyVal = attrValue.value;
+            break;
+          }
+        }
+        if (keyVal === undefined) continue;
+        if (prefix !== undefined && !keyVal.startsWith(prefix)) continue;
+        keys.push(keyVal);
+      }
+
+      return keys;
+    } finally {
+      bus.disconnect();
+    }
+  }
+
+  /**
+   * Fallback: parse `secret-tool search --all` output. Secret values
+   * are emitted on stdout by secret-tool and briefly live in the Node
+   * string buffer before GC — only `attribute.key` lines are parsed,
+   * but the transient exposure exists.
+   */
+  private listKeysViaSecretTool(prefix?: string): string[] {
     let output: string;
     try {
       output = execSync(
@@ -153,7 +224,6 @@ export class LibsecretVault implements VaultBackend {
         },
       );
     } catch (err) {
-      // secret-tool exits non-zero when no matches are found — treat as empty.
       const status = (err as { status?: number } | null)?.status;
       if (status === 1) return [];
       throw err;

--- a/packages/secrets/src/vault/vault-windows.ts
+++ b/packages/secrets/src/vault/vault-windows.ts
@@ -216,7 +216,7 @@ export class WindowsVault implements VaultBackend {
    * A null result from `runPowershell` (powershell.exe itself failed to
    * execute) is propagated as a thrown error per the VaultBackend contract.
    */
-  listKeys(prefix?: string): string[] {
+  async listKeys(prefix?: string): Promise<string[]> {
     const command = [
       "& {",
       "[void][Windows.Security.Credentials.PasswordVault,Windows.Security.Credentials,ContentType=WindowsRuntime];",

--- a/packages/secrets/src/vault/vault.ts
+++ b/packages/secrets/src/vault/vault.ts
@@ -60,7 +60,7 @@ class KeychainVault implements VaultBackend {
     return deleteFromKeychain(AUTH_KEYCHAIN_SERVICE, key);
   }
 
-  listKeys(prefix?: string): string[] {
+  async listKeys(prefix?: string): Promise<string[]> {
     return listAccountsInKeychain(AUTH_KEYCHAIN_SERVICE, prefix);
   }
 }
@@ -181,7 +181,7 @@ export async function deleteCredential(key: string): Promise<boolean> {
  *   }
  */
 export async function listCredentials(prefix?: string): Promise<string[]> {
-  const keys = activeBackend.listKeys(prefix);
+  const keys = await activeBackend.listKeys(prefix);
   if (keys.length > 0) touchSession();
   return keys;
 }

--- a/packages/secrets/tests/vault-env.test.ts
+++ b/packages/secrets/tests/vault-env.test.ts
@@ -24,28 +24,28 @@ describe("EnvVault.listKeys", () => {
     }
   });
 
-  it("returns [] when ENGRAM_API_KEY is not set", () => {
+  it("returns [] when ENGRAM_API_KEY is not set", async () => {
     const vault = new EnvVault();
-    expect(vault.listKeys()).toEqual([]);
+    await expect(vault.listKeys()).resolves.toEqual([]);
   });
 
-  it("returns ['auth-token'] when ENGRAM_API_KEY is set (no prefix)", () => {
+  it("returns ['auth-token'] when ENGRAM_API_KEY is set (no prefix)", async () => {
     process.env["ENGRAM_API_KEY"] = "eng_test_value";
     const vault = new EnvVault();
-    expect(vault.listKeys()).toEqual(["auth-token"]);
+    await expect(vault.listKeys()).resolves.toEqual(["auth-token"]);
   });
 
-  it("returns ['auth-token'] when ENGRAM_API_KEY is set and prefix matches", () => {
+  it("returns ['auth-token'] when ENGRAM_API_KEY is set and prefix matches", async () => {
     process.env["ENGRAM_API_KEY"] = "eng_test_value";
     const vault = new EnvVault();
-    expect(vault.listKeys("auth")).toEqual(["auth-token"]);
-    expect(vault.listKeys("auth-token")).toEqual(["auth-token"]);
+    await expect(vault.listKeys("auth")).resolves.toEqual(["auth-token"]);
+    await expect(vault.listKeys("auth-token")).resolves.toEqual(["auth-token"]);
   });
 
-  it("returns [] when the prefix doesn't match auth-token", () => {
+  it("returns [] when the prefix doesn't match auth-token", async () => {
     process.env["ENGRAM_API_KEY"] = "eng_test_value";
     const vault = new EnvVault();
-    expect(vault.listKeys("refresh")).toEqual([]);
-    expect(vault.listKeys("soma-")).toEqual([]);
+    await expect(vault.listKeys("refresh")).resolves.toEqual([]);
+    await expect(vault.listKeys("soma-")).resolves.toEqual([]);
   });
 });

--- a/packages/secrets/tests/vault-gpg.test.ts
+++ b/packages/secrets/tests/vault-gpg.test.ts
@@ -59,18 +59,18 @@ describe("GpgVault.listKeys", () => {
     rmSync(AUTH_DIR, { recursive: true, force: true });
   });
 
-  it("returns [] when the auth directory does not exist", () => {
+  it("returns [] when the auth directory does not exist", async () => {
     const vault = new GpgVault();
-    expect(vault.listKeys()).toEqual([]);
+    await expect(vault.listKeys()).resolves.toEqual([]);
   });
 
-  it("returns [] when the auth directory exists but is empty", () => {
+  it("returns [] when the auth directory exists but is empty", async () => {
     mkdirSync(AUTH_DIR, { recursive: true });
     const vault = new GpgVault();
-    expect(vault.listKeys()).toEqual([]);
+    await expect(vault.listKeys()).resolves.toEqual([]);
   });
 
-  it("returns every stored key when no prefix is supplied", () => {
+  it("returns every stored key when no prefix is supplied", async () => {
     mkdirSync(AUTH_DIR, { recursive: true });
     writeFileSync(join(AUTH_DIR, "credentials-auth-token.gpg"), "fake");
     writeFileSync(join(AUTH_DIR, "credentials-refresh-token.gpg"), "fake");
@@ -81,7 +81,7 @@ describe("GpgVault.listKeys", () => {
     writeFileSync(join(AUTH_DIR, "something-else.txt"), "fake");
 
     const vault = new GpgVault();
-    const result = vault.listKeys();
+    const result = await vault.listKeys();
     expect(result.sort()).toEqual([
       "auth-token",
       "refresh-token",
@@ -89,7 +89,7 @@ describe("GpgVault.listKeys", () => {
     ]);
   });
 
-  it("filters by prefix — includes matches, excludes non-matches", () => {
+  it("filters by prefix — includes matches, excludes non-matches", async () => {
     mkdirSync(AUTH_DIR, { recursive: true });
     writeFileSync(join(AUTH_DIR, "credentials-auth-token.gpg"), "fake");
     writeFileSync(
@@ -102,7 +102,7 @@ describe("GpgVault.listKeys", () => {
     );
 
     const vault = new GpgVault();
-    const result = vault.listKeys("soma-anthropic-");
+    const result = await vault.listKeys("soma-anthropic-");
     expect(result.sort()).toEqual([
       "soma-anthropic-token1",
       "soma-anthropic-token2",
@@ -110,7 +110,7 @@ describe("GpgVault.listKeys", () => {
     expect(result).not.toContain("auth-token");
   });
 
-  it("ignores files that don't match the credentials-*.gpg naming scheme", () => {
+  it("ignores files that don't match the credentials-*.gpg naming scheme", async () => {
     mkdirSync(AUTH_DIR, { recursive: true });
     writeFileSync(join(AUTH_DIR, "credentials-auth-token.gpg"), "fake");
     writeFileSync(join(AUTH_DIR, "credentials-auth-token.gpg.bak"), "fake");
@@ -118,6 +118,6 @@ describe("GpgVault.listKeys", () => {
     writeFileSync(join(AUTH_DIR, "README"), "fake");
 
     const vault = new GpgVault();
-    expect(vault.listKeys()).toEqual(["auth-token"]);
+    await expect(vault.listKeys()).resolves.toEqual(["auth-token"]);
   });
 });

--- a/packages/secrets/tests/vault-libsecret.test.ts
+++ b/packages/secrets/tests/vault-libsecret.test.ts
@@ -1,59 +1,120 @@
 /**
  * LibsecretVault — listKeys tests
  *
- * Mocks `child_process.execSync` so the real `secret-tool` CLI is never
- * invoked. Exercises the parser that extracts `attribute.key = <key>`
- * lines from `secret-tool search --all` output and confirms that:
+ * Tests both the D-Bus primary path (via mocked dbus-next) and the
+ * secret-tool fallback path (via mocked child_process.execSync).
  *
- *   - status=1 (no matches) is mapped to an empty list
- *   - other transient failures propagate
- *   - prefix filtering behaves correctly
- *   - the secret-value lines in the same output are ignored
+ * The dbus-next mock simulates the freedesktop secrets service API:
+ *   - sessionBus() → bus
+ *   - bus.getProxyObject() → proxy with getInterface()
+ *   - service.SearchItems() → [unlockedPaths, lockedPaths]
+ *   - props.Get("...Item", "Attributes") → attribute dict
+ *
+ * When dbus-next throws (simulating no session bus), the fallback
+ * exercises the secret-tool CLI parser — same as the pre-0.5.0 code.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockExecSync = vi.hoisted(() => vi.fn());
+const mockSessionBus = vi.hoisted(() => vi.fn());
 
 vi.mock("child_process", () => ({
   execSync: mockExecSync,
 }));
 
+vi.mock("dbus-next", () => ({
+  sessionBus: mockSessionBus,
+}));
+
 const { LibsecretVault } = await import("../src/vault/vault-libsecret.js");
 
-const SAMPLE_OUTPUT = `[/org/freedesktop/secrets/collection/login/123]
+// ---------------------------------------------------------------------------
+// D-Bus mock helpers
+// ---------------------------------------------------------------------------
+
+function makeDbusItem(key: string): {
+  getInterface: (name: string) => {
+    Get: (_iface: string, _prop: string) => Promise<{
+      value: Array<[{ value: string }, { value: string }]>;
+    }>;
+  };
+} {
+  return {
+    getInterface: (_name: string) => ({
+      Get: async () => ({
+        value: [
+          [{ value: "service" }, { value: "centient" }],
+          [{ value: "key" }, { value: key }],
+        ],
+      }),
+    }),
+  };
+}
+
+function setupDbusMock(keys: string[]): void {
+  const itemPaths = keys.map((_, i) => `/org/freedesktop/secrets/collection/login/${i}`);
+  const itemMap = new Map<string, ReturnType<typeof makeDbusItem>>();
+  keys.forEach((key, i) => {
+    itemMap.set(itemPaths[i]!, makeDbusItem(key));
+  });
+
+  const bus = {
+    getProxyObject: vi.fn(async (_service: string, path: string) => {
+      if (path === "/org/freedesktop/secrets") {
+        return {
+          getInterface: (_name: string) => ({
+            SearchItems: async () => [itemPaths, []],
+          }),
+        };
+      }
+      const item = itemMap.get(path);
+      if (!item) throw new Error(`Unknown path: ${path}`);
+      return item;
+    }),
+    disconnect: vi.fn(),
+  };
+
+  mockSessionBus.mockReturnValue(bus);
+}
+
+// ---------------------------------------------------------------------------
+// secret-tool fallback output fixture
+// ---------------------------------------------------------------------------
+
+const SAMPLE_SECRET_TOOL_OUTPUT = `[/org/freedesktop/secrets/collection/login/123]
 label = centient-auth
 secret = super-secret-value-should-not-be-returned
-created = 2026-01-01 00:00:00
-modified = 2026-01-01 00:00:00
-schema = org.freedesktop.Secret.Generic
 attribute.service = centient
 attribute.key = auth-token
 
 [/org/freedesktop/secrets/collection/login/124]
 label = centient-auth
 secret = another-secret-value
-schema = org.freedesktop.Secret.Generic
 attribute.service = centient
 attribute.key = soma-anthropic-token1
 
 [/org/freedesktop/secrets/collection/login/125]
 label = centient-auth
 secret = yet-another
-schema = org.freedesktop.Secret.Generic
 attribute.service = centient
 attribute.key = soma-anthropic-token2
 `;
 
 beforeEach(() => {
   mockExecSync.mockReset();
+  mockSessionBus.mockReset();
 });
 
-describe("LibsecretVault.listKeys", () => {
-  it("returns every attribute.key from the parsed output", () => {
-    mockExecSync.mockReturnValue(SAMPLE_OUTPUT);
+// ---------------------------------------------------------------------------
+// D-Bus primary path
+// ---------------------------------------------------------------------------
+
+describe("LibsecretVault.listKeys — D-Bus path", () => {
+  it("returns every key from the SearchItems results", async () => {
+    setupDbusMock(["auth-token", "soma-anthropic-token1", "soma-anthropic-token2"]);
     const vault = new LibsecretVault();
-    const result = vault.listKeys();
+    const result = await vault.listKeys();
     expect(result.sort()).toEqual([
       "auth-token",
       "soma-anthropic-token1",
@@ -61,10 +122,10 @@ describe("LibsecretVault.listKeys", () => {
     ]);
   });
 
-  it("filters by prefix — matches kept, non-matches excluded", () => {
-    mockExecSync.mockReturnValue(SAMPLE_OUTPUT);
+  it("filters by prefix", async () => {
+    setupDbusMock(["auth-token", "soma-anthropic-token1", "soma-anthropic-token2"]);
     const vault = new LibsecretVault();
-    const result = vault.listKeys("soma-anthropic-");
+    const result = await vault.listKeys("soma-anthropic-");
     expect(result.sort()).toEqual([
       "soma-anthropic-token1",
       "soma-anthropic-token2",
@@ -72,57 +133,87 @@ describe("LibsecretVault.listKeys", () => {
     expect(result).not.toContain("auth-token");
   });
 
-  it("does NOT return secret values — only attribute.key lines", () => {
-    mockExecSync.mockReturnValue(SAMPLE_OUTPUT);
+  it("returns [] when SearchItems returns no items", async () => {
+    setupDbusMock([]);
     const vault = new LibsecretVault();
-    const result = vault.listKeys();
-    for (const key of result) {
-      expect(key).not.toContain("secret");
-      expect(key).not.toContain("super-secret-value");
-      expect(key).not.toContain("another-secret-value");
-    }
+    await expect(vault.listKeys()).resolves.toEqual([]);
   });
 
-  it("returns [] when secret-tool exits status 1 (no matches)", () => {
+  it("disconnects the bus after successful enumeration", async () => {
+    setupDbusMock(["auth-token"]);
+    const vault = new LibsecretVault();
+    await vault.listKeys();
+    const bus = mockSessionBus.mock.results[0]!.value;
+    expect(bus.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT invoke secret-tool when D-Bus succeeds", async () => {
+    setupDbusMock(["auth-token"]);
+    const vault = new LibsecretVault();
+    await vault.listKeys();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// secret-tool fallback path
+// ---------------------------------------------------------------------------
+
+describe("LibsecretVault.listKeys — secret-tool fallback", () => {
+  beforeEach(() => {
+    mockSessionBus.mockImplementation(() => {
+      throw new Error("no session bus available");
+    });
+  });
+
+  it("falls back to secret-tool when D-Bus fails", async () => {
+    mockExecSync.mockReturnValue(SAMPLE_SECRET_TOOL_OUTPUT);
+    const vault = new LibsecretVault();
+    const result = await vault.listKeys();
+    expect(result.sort()).toEqual([
+      "auth-token",
+      "soma-anthropic-token1",
+      "soma-anthropic-token2",
+    ]);
+  });
+
+  it("filters by prefix in fallback mode", async () => {
+    mockExecSync.mockReturnValue(SAMPLE_SECRET_TOOL_OUTPUT);
+    const vault = new LibsecretVault();
+    const result = await vault.listKeys("soma-anthropic-");
+    expect(result.sort()).toEqual([
+      "soma-anthropic-token1",
+      "soma-anthropic-token2",
+    ]);
+  });
+
+  it("returns [] when secret-tool exits status 1 (no matches)", async () => {
     mockExecSync.mockImplementation(() => {
       const err = new Error("Command failed") as Error & { status: number };
       err.status = 1;
       throw err;
     });
     const vault = new LibsecretVault();
-    expect(vault.listKeys()).toEqual([]);
+    await expect(vault.listKeys()).resolves.toEqual([]);
   });
 
-  it("returns [] when output is empty", () => {
-    mockExecSync.mockReturnValue("");
-    const vault = new LibsecretVault();
-    expect(vault.listKeys()).toEqual([]);
-  });
-
-  it("propagates other transient failures (status != 1)", () => {
+  it("propagates other transient failures from secret-tool (status != 1)", async () => {
     mockExecSync.mockImplementation(() => {
-      const err = new Error("secret-tool: cannot connect to dbus") as Error & {
-        status: number;
-      };
+      const err = new Error("secret-tool: timeout") as Error & { status: number };
       err.status = 127;
       throw err;
     });
     const vault = new LibsecretVault();
-    expect(() => vault.listKeys()).toThrow(/cannot connect to dbus/);
+    await expect(vault.listKeys()).rejects.toThrow(/timeout/);
   });
 
-  it("ignores malformed lines without an attribute.key prefix", () => {
-    mockExecSync.mockReturnValue(
-      [
-        "label = centient-auth",
-        "secret = value",
-        "attribute.service = centient",
-        "attribute.key = valid-key",
-        "attribute.other = ignored",
-        "random garbage line",
-      ].join("\n"),
-    );
+  it("does NOT return secret values from secret-tool output", async () => {
+    mockExecSync.mockReturnValue(SAMPLE_SECRET_TOOL_OUTPUT);
     const vault = new LibsecretVault();
-    expect(vault.listKeys()).toEqual(["valid-key"]);
+    const result = await vault.listKeys();
+    for (const key of result) {
+      expect(key).not.toContain("secret");
+      expect(key).not.toContain("super-secret-value");
+    }
   });
 });

--- a/packages/secrets/tests/vault-windows.test.ts
+++ b/packages/secrets/tests/vault-windows.test.ts
@@ -45,12 +45,12 @@ beforeEach(() => {
 });
 
 describe("WindowsVault.listKeys", () => {
-  it("returns every UserName emitted by FindAllByResource", () => {
+  it("returns every UserName emitted by FindAllByResource", async () => {
     mockSpawnSync.mockReturnValue(
       okResult("auth-token\nrefresh-token\nsoma-anthropic-token1\n"),
     );
     const vault = new WindowsVault();
-    const result = vault.listKeys();
+    const result = await vault.listKeys();
     expect(result.sort()).toEqual([
       "auth-token",
       "refresh-token",
@@ -58,14 +58,14 @@ describe("WindowsVault.listKeys", () => {
     ]);
   });
 
-  it("filters by prefix", () => {
+  it("filters by prefix", async () => {
     mockSpawnSync.mockReturnValue(
       okResult(
         "auth-token\nsoma-anthropic-token1\nsoma-anthropic-token2\nrefresh-token\n",
       ),
     );
     const vault = new WindowsVault();
-    const result = vault.listKeys("soma-anthropic-");
+    const result = await vault.listKeys("soma-anthropic-");
     expect(result.sort()).toEqual([
       "soma-anthropic-token1",
       "soma-anthropic-token2",
@@ -73,29 +73,27 @@ describe("WindowsVault.listKeys", () => {
     expect(result).not.toContain("auth-token");
   });
 
-  it("returns [] when the PowerShell block emits no output (empty resource)", () => {
-    // FindAllByResource throws in PowerShell when no matches exist; our
-    // inline `try {} catch {}` swallows that and the command prints nothing.
+  it("returns [] when the PowerShell block emits no output (empty resource)", async () => {
     mockSpawnSync.mockReturnValue(okResult(""));
     const vault = new WindowsVault();
-    expect(vault.listKeys()).toEqual([]);
+    await expect(vault.listKeys()).resolves.toEqual([]);
   });
 
-  it("ignores blank lines in the output", () => {
+  it("ignores blank lines in the output", async () => {
     mockSpawnSync.mockReturnValue(
       okResult("auth-token\n\n\nsoma-anthropic-token1\n"),
     );
     const vault = new WindowsVault();
-    const result = vault.listKeys();
+    const result = await vault.listKeys();
     expect(result.sort()).toEqual(["auth-token", "soma-anthropic-token1"]);
   });
 
-  it("handles CRLF line endings from powershell.exe", () => {
+  it("handles CRLF line endings from powershell.exe", async () => {
     mockSpawnSync.mockReturnValue(
       okResult("auth-token\r\nrefresh-token\r\nsoma-anthropic-token1\r\n"),
     );
     const vault = new WindowsVault();
-    const result = vault.listKeys();
+    const result = await vault.listKeys();
     expect(result.sort()).toEqual([
       "auth-token",
       "refresh-token",
@@ -103,10 +101,10 @@ describe("WindowsVault.listKeys", () => {
     ]);
   });
 
-  it("throws when powershell.exe itself fails to run", () => {
+  it("throws when powershell.exe itself fails to run", async () => {
     mockSpawnSync.mockReturnValue(psFailure());
     const vault = new WindowsVault();
-    expect(() => vault.listKeys()).toThrow(
+    await expect(vault.listKeys()).rejects.toThrow(
       /Windows Credential Manager enumeration failed/,
     );
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,10 @@ importers:
         version: 4.1.2(@types/node@20.19.37)(vite@8.0.3(@types/node@20.19.37))
 
   packages/secrets:
+    dependencies:
+      dbus-next:
+        specifier: ^0.10.2
+        version: 0.10.2
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -225,6 +229,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nornagon/put@0.0.8':
+    resolution: {integrity: sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==}
+    engines: {node: '>=0.3.0'}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -410,13 +418,30 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-regex@2.1.1:
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
+    engines: {node: '>=0.10.0'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  aproba@1.2.0:
+    resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
+
+  are-we-there-yet@1.1.7:
+    resolution: {integrity: sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==}
+    deprecated: This package is no longer supported.
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -428,6 +453,13 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -435,13 +467,37 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -450,12 +506,50 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  code-point-at@1.1.0:
+    resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
+    engines: {node: '>=0.10.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
+  dbus-next@0.10.2:
+    resolution: {integrity: sha512-kLNQoadPstLgKKGIXKrnRsMgtAK/o+ix3ZmcfTfvBHzghiO9yHXpoKImGnB50EXwnfSFaSAullW/7UrSkAISSQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -469,9 +563,19 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -484,16 +588,32 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-stream@3.3.4:
+    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -507,6 +627,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -514,6 +637,16 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -523,14 +656,32 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  gauge@2.7.4:
+    resolution: {integrity: sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==}
+    deprecated: This package is no longer supported.
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -539,12 +690,32 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hexy@0.2.11:
+    resolution: {integrity: sha512-ciq6hFsSG/Bpt2DmrZJtv+56zpPdnq+NQ4ijEFrveKN0ZG1mhl/LdT1NQZ9se6ty1fACcI4d4vYqC9v8EYpH2A==}
+    hasBin: true
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -558,8 +729,19 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@1.0.0:
+    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
     engines: {node: '>=0.10.0'}
 
   is-glob@4.0.3:
@@ -574,12 +756,21 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -604,8 +795,27 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsbi@2.0.5:
+    resolution: {integrity: sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ==}
+
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -684,6 +894,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -694,6 +907,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  map-stream@0.1.0:
+    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -702,17 +918,76 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-gyp@7.1.2:
+    resolution: {integrity: sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@4.1.2:
+    resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
+    deprecated: This package is no longer supported.
+
+  number-is-nan@1.0.1:
+    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
+    engines: {node: '>=0.10.0'}
+
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -744,6 +1019,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -754,6 +1033,12 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -779,6 +1064,20 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -789,6 +1088,14 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -796,6 +1103,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
@@ -805,13 +1117,26 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -823,6 +1148,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -839,14 +1167,36 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split@0.3.3:
+    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  stream-combiner@0.0.4:
+    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
+
+  string-width@1.0.2:
+    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
+    engines: {node: '>=0.10.0'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-ansi@3.0.1:
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
+    engines: {node: '>=0.10.0'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -860,9 +1210,17 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -883,12 +1241,22 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.8.20:
     resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
     hasBin: true
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -901,6 +1269,24 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  usocket@0.3.0:
+    resolution: {integrity: sha512-V/H02RNiaOCJZuPoKont/y12VJaImC6C5xW7OzPFjYu9qnig0yv9hyp9E7Wqjm6d8yZuZouH3NAfDATVMgh2SQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
@@ -989,6 +1375,23 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml2js@0.4.23:
+    resolution: {integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
 snapshots:
 
@@ -1219,6 +1622,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@nornagon/put@0.0.8': {}
+
   '@oxc-project/types@0.122.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
@@ -1365,9 +1770,32 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abbrev@1.1.1:
+    optional: true
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    optional: true
+
   ansi-colors@4.1.3: {}
 
+  ansi-regex@2.1.1:
+    optional: true
+
   ansi-regex@5.0.1: {}
+
+  aproba@1.2.0:
+    optional: true
+
+  are-we-there-yet@1.1.7:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 2.3.8
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -1377,6 +1805,14 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
+  assert-plus@1.0.0:
+    optional: true
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -1385,25 +1821,102 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  asynckit@0.4.0:
+    optional: true
+
+  aws-sign2@0.7.0:
+    optional: true
+
+  aws4@1.13.2:
+    optional: true
+
+  balanced-match@1.0.2:
+    optional: true
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+    optional: true
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+    optional: true
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    optional: true
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
+  caseless@0.12.0:
+    optional: true
+
   chai@6.2.2: {}
 
   chardet@2.1.1: {}
 
+  chownr@2.0.0:
+    optional: true
+
+  code-point-at@1.1.0:
+    optional: true
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+    optional: true
+
+  concat-map@0.0.1:
+    optional: true
+
+  console-control-strings@1.1.0:
+    optional: true
+
   convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.2:
+    optional: true
+
+  core-util-is@1.0.3:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+    optional: true
+
+  dbus-next@0.10.2:
+    dependencies:
+      '@nornagon/put': 0.0.8
+      event-stream: 3.3.4
+      hexy: 0.2.11
+      jsbi: 2.0.5
+      long: 4.0.0
+      safe-buffer: 5.2.1
+      xml2js: 0.4.23
+    optionalDependencies:
+      usocket: 0.3.0
+
+  delayed-stream@1.0.0:
+    optional: true
+
+  delegates@1.0.0:
+    optional: true
 
   detect-indent@6.1.0: {}
 
@@ -1413,10 +1926,21 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  duplexer@0.1.2: {}
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+    optional: true
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  env-paths@2.2.1:
+    optional: true
 
   es-module-lexer@2.0.0: {}
 
@@ -1426,9 +1950,28 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-stream@3.3.4:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
+
   expect-type@1.3.0: {}
 
+  extend@3.0.2:
+    optional: true
+
   extendable-error@0.1.7: {}
+
+  extsprintf@1.3.0:
+    optional: true
+
+  fast-deep-equal@3.1.3:
+    optional: true
 
   fast-glob@3.3.3:
     dependencies:
@@ -1438,6 +1981,9 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0:
+    optional: true
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -1445,6 +1991,9 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-uri-to-path@1.0.0:
+    optional: true
 
   fill-range@7.1.1:
     dependencies:
@@ -1454,6 +2003,18 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  forever-agent@0.6.1:
+    optional: true
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    optional: true
+
+  from@0.1.7: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -1467,12 +2028,47 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  fs.realpath@1.0.0:
+    optional: true
+
   fsevents@2.3.3:
+    optional: true
+
+  gauge@2.7.4:
+    dependencies:
+      aproba: 1.2.0
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 1.0.2
+      strip-ansi: 3.0.1
+      wide-align: 1.1.5
+    optional: true
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
     optional: true
 
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    optional: true
 
   globby@11.1.0:
     dependencies:
@@ -1485,9 +2081,30 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  har-schema@2.0.0:
+    optional: true
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.14.0
+      har-schema: 2.0.0
+    optional: true
+
   has-flag@4.0.0: {}
 
+  has-unicode@2.0.1:
+    optional: true
+
+  hexy@0.2.11: {}
+
   html-escaper@2.0.2: {}
+
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+    optional: true
 
   human-id@4.1.3: {}
 
@@ -1497,7 +2114,21 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    optional: true
+
+  inherits@2.0.4:
+    optional: true
+
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@1.0.0:
+    dependencies:
+      number-is-nan: 1.0.1
+    optional: true
 
   is-glob@4.0.3:
     dependencies:
@@ -1509,9 +2140,18 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-typedarray@1.0.0:
+    optional: true
+
   is-windows@1.0.2: {}
 
+  isarray@1.0.0:
+    optional: true
+
   isexe@2.0.0: {}
+
+  isstream@0.1.2:
+    optional: true
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -1537,9 +2177,31 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbi@2.0.5: {}
+
+  jsbn@0.1.1:
+    optional: true
+
+  json-schema-traverse@0.4.1:
+    optional: true
+
+  json-schema@0.4.0:
+    optional: true
+
+  json-stringify-safe@5.0.1:
+    optional: true
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1596,6 +2258,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  long@4.0.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1610,6 +2274,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  map-stream@0.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -1617,11 +2283,85 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0:
+    optional: true
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+    optional: true
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
+  minipass@5.0.0:
+    optional: true
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+    optional: true
+
+  mkdirp@1.0.4:
+    optional: true
+
   mri@1.2.0: {}
+
+  nan@2.26.2:
+    optional: true
 
   nanoid@3.3.11: {}
 
+  node-gyp@7.1.2:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      nopt: 5.0.0
+      npmlog: 4.1.2
+      request: 2.88.2
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    optional: true
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
+  npmlog@4.1.2:
+    dependencies:
+      are-we-there-yet: 1.1.7
+      console-control-strings: 1.1.0
+      gauge: 2.7.4
+      set-blocking: 2.0.0
+    optional: true
+
+  number-is-nan@1.0.1:
+    optional: true
+
+  oauth-sign@0.9.0:
+    optional: true
+
+  object-assign@4.1.1:
+    optional: true
+
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
 
   outdent@0.5.0: {}
 
@@ -1647,11 +2387,21 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-is-absolute@1.0.1:
+    optional: true
+
   path-key@3.1.1: {}
 
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -1669,6 +2419,20 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  process-nextick-args@2.0.1:
+    optional: true
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+    optional: true
+
+  punycode@2.3.1:
+    optional: true
+
+  qs@6.5.5:
+    optional: true
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -1680,9 +2444,49 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    optional: true
+
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+    optional: true
+
   resolve-from@5.0.0: {}
 
   reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+    optional: true
 
   rolldown@1.0.0-rc.12:
     dependencies:
@@ -1709,9 +2513,19 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2:
+    optional: true
+
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
+  sax@1.6.0: {}
+
   semver@7.7.4: {}
+
+  set-blocking@2.0.0:
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -1720,6 +2534,9 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7:
+    optional: true
 
   signal-exit@4.1.0: {}
 
@@ -1732,11 +2549,49 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split@0.3.3:
+    dependencies:
+      through: 2.3.8
+
   sprintf-js@1.0.3: {}
+
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+    optional: true
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  stream-combiner@0.0.4:
+    dependencies:
+      duplexer: 0.1.2
+
+  string-width@1.0.2:
+    dependencies:
+      code-point-at: 1.1.0
+      is-fullwidth-code-point: 1.0.0
+      strip-ansi: 3.0.1
+    optional: true
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+    optional: true
+
+  strip-ansi@3.0.1:
+    dependencies:
+      ansi-regex: 2.1.1
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -1748,7 +2603,19 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+    optional: true
+
   term-size@2.2.1: {}
+
+  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -1765,7 +2632,18 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+    optional: true
+
   tslib@2.8.1:
+    optional: true
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
     optional: true
 
   turbo@2.8.20:
@@ -1777,11 +2655,39 @@ snapshots:
       '@turbo/windows-64': 2.8.20
       '@turbo/windows-arm64': 2.8.20
 
+  tweetnacl@0.14.5:
+    optional: true
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
   universalify@0.1.2: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+    optional: true
+
+  usocket@0.3.0:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
+      node-gyp: 7.1.2
+    optional: true
+
+  util-deprecate@1.0.2:
+    optional: true
+
+  uuid@3.4.0:
+    optional: true
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+    optional: true
 
   vite@8.0.3(@types/node@20.19.37):
     dependencies:
@@ -1829,3 +2735,21 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 1.0.2
+    optional: true
+
+  wrappy@1.0.2:
+    optional: true
+
+  xml2js@0.4.23:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  yallist@4.0.0:
+    optional: true


### PR DESCRIPTION
## Summary

The biggest PR in the 0.5.0 train. Two changes:

1. **`VaultBackend.listKeys` is now async** (`Promise<string[]>`). All 5 backends updated. Keychain, Windows, GPG, and EnvVault trivially wrap their sync returns; libsecret gets a real async implementation.

2. **Libsecret enumeration now uses D-Bus** (via `dbus-next`) instead of `secret-tool search --all`. The `secret-tool` CLI emitted every stored credential's decrypted value on stdout, briefly materializing all secrets in the Node string buffer even though we only parsed `attribute.key` lines. The D-Bus path calls `org.freedesktop.secrets.Service.SearchItems`, which returns item object paths without decrypting — **secret material never enters process memory during enumeration**.

Falls back to the `secret-tool` CLI parser automatically when the D-Bus session bus is unavailable (SSH without `DBUS_SESSION_BUS_ADDRESS`, headless servers). The fallback carries the same transient-exposure trade-off as before; documented in JSDoc.

## Breaking change (0.x minor)

`VaultBackend.listKeys(prefix?)` returns `Promise<string[]>` instead of `string[]`. Anyone implementing `VaultBackend` externally needs to mark their `listKeys` as async. No external implementations are known. Accepted as a minor bump under 0.x semver per ADR-002 (#22) §0.5.0.

The public `listCredentials` function was already async — its signature and behavior are unchanged for callers.

## New dependency

`dbus-next@^0.10.2` — pure JavaScript, no native bindings, ~150KB installed. Dynamically imported inside `listKeysViaDbus` so it is only loaded on Linux when the libsecret backend is active and D-Bus is reachable. First runtime dependency on `@centient/secrets`.

## Test plan

- [x] `pnpm -F @centient/secrets build` — clean
- [x] `pnpm -F @centient/secrets test` — 93/93 passing (was 90)
- [x] `pnpm -F @centient/secrets lint` — clean
- [x] `pnpm build` — all 5 packages build
- [x] `pnpm test` — all 10 suites pass
- [x] Libsecret D-Bus path: 5 new tests with full mock of `SearchItems` + `Properties` API
- [x] Libsecret fallback path: 5 tests verifying secret-tool parser still works when D-Bus is down
- [x] EnvVault, GPG, Windows: all `listKeys` tests updated for async (`await` / `.resolves`)
- [ ] CI green

## Release context

PR **C of 6** in the 0.5.0 train. See ADR-002 (#22) for the full architecture and phasing.

| PR | Status | Items |
|---|---|---|
| #21 / A — allow dots in keys | merged | 1 |
| #22 / F — ADR-002 architecture | merged | — |
| #23 / E — RELEASING.md + drift check | merged | 6, 7 |
| #24 / B — Keychain cache + --json | merged | 2, 3 |
| **#? / C — async listKeys + dbus** | **this PR** | **4** |
| D — SecretsPolicy + auditTrail | next | 8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)