### PR TITLE
feat(secrets): SecretsPolicy middleware layer + auditTrail policy

### DIFF
--- a/.changeset/secrets-policy-audit-trail.md
+++ b/.changeset/secrets-policy-audit-trail.md
@@ -1,0 +1,27 @@
+---
+"@centient/secrets": minor
+---
+
+Introduce the `SecretsPolicy` middleware layer and ship `auditTrail` as the first built-in policy.
+
+**New API surface:**
+
+- `SecretsPolicy` interface — `{ name, before?(op), after?(event) }`. Policies are cross-cutting concerns (audit, rate limiting, access control) applied to every credential operation. `before` hooks run top-to-bottom before the backend operation (can reject by throwing); `after` hooks run bottom-to-top with a structured event (exceptions swallowed with one-time stderr warning).
+- `setSecretsPolicies(policies: SecretsPolicy[])` — configure the active policy stack. Default: empty (no policies, zero overhead). Names and shapes are designed to fit the 1.0 `createSecretsClient({ policies })` factory without renaming.
+- `getActivePolicies()` — read the current policy list (useful for diagnostics).
+- `auditTrail({ sink, includeReads? })` — factory for an audit-only policy that forwards `SecretsEvent` objects to a caller-provided sink function. `includeReads` defaults to `true`; set to `false` to suppress `credential_read` and `credential_read_missing` events in hot-path scenarios.
+
+**Event shape (`SecretsEvent`):**
+
+- `type` — one of 9 event types: `credential_read`, `credential_read_missing`, `credential_read_failed`, `credential_written`, `credential_write_failed`, `credential_deleted`, `credential_delete_failed`, `credential_enumerated`, `credential_enumerate_failed`.
+- `timestamp` — ISO-8601 string.
+- `backend` — which vault backend handled the operation.
+- `key` / `prefix` / `keyCount` — operation-specific context.
+- `error` — error message on `*_failed` events (never stack trace).
+- `durationMs` — wall-clock time of the operation.
+
+**Integration:** all four public functions (`storeCredential`, `getCredential`, `deleteCredential`, `listCredentials`) now run through the policy stack. No changes to their signatures or return types — existing consumers are unaffected.
+
+**Designed for growth:** the `SecretsPolicy` interface, `setSecretsPolicies` array, and `SecretsOperation` descriptor are the same shapes that ADR-002's 1.0 `createSecretsClient({ provider, policies })` factory will use. The 0.5.0 global setter is a stepping stone, not a dead end.
+
+Motivation: per ADR-002, regulated consumers (SOC 2 target) need an auditable trail of credential operations. This is the first middleware seam in `@centient/secrets`, enabling audit now and rate limiting / access control / attestation in 1.0.

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -28,3 +28,7 @@ export { resolveKeyProvider, getProviderByType, loadConfig, saveSecretsConfig } 
 
 // Validation
 export { isValidKey } from "./vault/vault-utils.js";
+
+// Policy
+export { setSecretsPolicies, getActivePolicies, auditTrail } from "./vault/policy.js";
+export type { SecretsPolicy, SecretsEvent, SecretsEventType, SecretsOperation, AuditTrailOptions } from "./vault/policy.js";

--- a/packages/secrets/src/vault/policy.ts
+++ b/packages/secrets/src/vault/policy.ts
@@ -1,0 +1,133 @@
+/**
+ * SecretsPolicy — Middleware layer for credential operations.
+ *
+ * Policies are cross-cutting concerns (audit, rate limiting, access
+ * control, attestation) applied to every credential operation via
+ * `setSecretsPolicies([...])`. In 0.5.0 only the audit policy is
+ * shipped; the API shape is designed to grow into the full policy
+ * stack described in ADR-002.
+ *
+ * Execution model:
+ *   1. `before` hooks run top-to-bottom. If any throws, the operation
+ *      is aborted and the error propagates to the caller.
+ *   2. The backend operation executes.
+ *   3. `after` hooks run bottom-to-top with a structured event
+ *      describing the outcome. Exceptions in `after` hooks are
+ *      swallowed with a one-time stderr warning — audit infrastructure
+ *      failures must never break credential operations.
+ */
+
+import type { VaultType } from "./types.js";
+
+// =============================================================================
+// Event types
+// =============================================================================
+
+export type SecretsEventType =
+  | "credential_read"
+  | "credential_read_missing"
+  | "credential_read_failed"
+  | "credential_written"
+  | "credential_write_failed"
+  | "credential_deleted"
+  | "credential_delete_failed"
+  | "credential_enumerated"
+  | "credential_enumerate_failed";
+
+export interface SecretsEvent {
+  type: SecretsEventType;
+  timestamp: string;
+  backend: VaultType;
+  key?: string;
+  keyCount?: number;
+  prefix?: string;
+  error?: string;
+  durationMs: number;
+}
+
+// =============================================================================
+// Operation type (what `before` hooks receive)
+// =============================================================================
+
+export interface SecretsOperation {
+  type: "read" | "write" | "delete" | "enumerate";
+  key?: string;
+  prefix?: string;
+}
+
+// =============================================================================
+// Policy interface
+// =============================================================================
+
+export interface SecretsPolicy {
+  readonly name: string;
+  before?(op: SecretsOperation): void | Promise<void>;
+  after?(event: SecretsEvent): void;
+}
+
+// =============================================================================
+// Policy registry
+// =============================================================================
+
+let activePolicies: SecretsPolicy[] = [];
+let afterWarningEmitted = false;
+
+export function setSecretsPolicies(policies: SecretsPolicy[]): void {
+  activePolicies = [...policies];
+  afterWarningEmitted = false;
+}
+
+export function getActivePolicies(): readonly SecretsPolicy[] {
+  return activePolicies;
+}
+
+export async function runBeforeHooks(op: SecretsOperation): Promise<void> {
+  for (const policy of activePolicies) {
+    if (policy.before) await policy.before(op);
+  }
+}
+
+export function runAfterHooks(event: SecretsEvent): void {
+  for (let i = activePolicies.length - 1; i >= 0; i--) {
+    const policy = activePolicies[i]!;
+    if (policy.after) {
+      try {
+        policy.after(event);
+      } catch (err) {
+        if (!afterWarningEmitted) {
+          afterWarningEmitted = true;
+          const msg = err instanceof Error ? err.message : String(err);
+          process.stderr.write(
+            `[secrets] policy "${policy.name}" after-hook threw (swallowed): ${msg}\n`,
+          );
+        }
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Built-in policies
+// =============================================================================
+
+export interface AuditTrailOptions {
+  sink: (event: SecretsEvent) => void;
+  includeReads?: boolean;
+}
+
+export function auditTrail(opts: AuditTrailOptions): SecretsPolicy {
+  const includeReads = opts.includeReads ?? true;
+  return {
+    name: "auditTrail",
+    after(event: SecretsEvent): void {
+      if (
+        !includeReads &&
+        (event.type === "credential_read" ||
+          event.type === "credential_read_missing")
+      ) {
+        return;
+      }
+      opts.sink(event);
+    },
+  };
+}

--- a/packages/secrets/src/vault/vault-libsecret.ts
+++ b/packages/secrets/src/vault/vault-libsecret.ts
@@ -167,7 +167,7 @@ export class LibsecretVault implements VaultBackend {
       );
       // dbus-next generates method stubs dynamically from introspection —
       // TypeScript cannot know about SearchItems / Get at compile time.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- typed wrapper tracked for 1.0
       const service = serviceObj.getInterface("org.freedesktop.Secret.Service") as any;
 
       const [unlocked, locked] = await service.SearchItems(
@@ -182,17 +182,23 @@ export class LibsecretVault implements VaultBackend {
           "org.freedesktop.secrets",
           itemPath,
         );
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dbus-next proxy; typed wrapper tracked for 1.0
         const props = itemObj.getInterface("org.freedesktop.DBus.Properties") as any;
         const attrs = await props.Get(
           "org.freedesktop.Secret.Item",
           "Attributes",
-        ) as { value: Array<[{ value: string }, { value: string }]> };
+        ) as { value?: Array<[{ value: string }, { value: string }]> };
+
+        // Guard: variant encoding can differ between implementations
+        // (GNOME Keyring vs KDE KWallet vs KeePassXC). Skip items whose
+        // Attributes property doesn't match the expected shape rather
+        // than silently producing undefined values.
+        if (!attrs?.value || !Array.isArray(attrs.value)) continue;
 
         let keyVal: string | undefined;
         for (const [attrName, attrValue] of attrs.value) {
-          if (attrName.value === "key") {
-            keyVal = attrValue.value;
+          if (attrName?.value === "key") {
+            keyVal = attrValue?.value;
             break;
           }
         }

--- a/packages/secrets/src/vault/vault.ts
+++ b/packages/secrets/src/vault/vault.ts
@@ -27,6 +27,7 @@ import { LibsecretVault } from "./vault-libsecret.js";
 import { GpgVault } from "./vault-gpg.js";
 import { EnvVault } from "./vault-env.js";
 import type { VaultBackend, VaultType } from "./types.js";
+import { runBeforeHooks, runAfterHooks } from "./policy.js";
 
 // =============================================================================
 // Constants
@@ -129,8 +130,17 @@ export async function storeCredential(
   key: string,
   value: string,
 ): Promise<boolean> {
+  const start = performance.now();
+  await runBeforeHooks({ type: "write", key });
   const success = activeBackend.store(key, value);
   if (success) touchSession();
+  runAfterHooks({
+    type: success ? "credential_written" : "credential_write_failed",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    key,
+    durationMs: performance.now() - start,
+  });
   return success;
 }
 
@@ -141,8 +151,30 @@ export async function storeCredential(
  * @returns The stored value, or null if not found / backend unavailable
  */
 export async function getCredential(key: string): Promise<string | null> {
-  const value = activeBackend.retrieve(key);
+  const start = performance.now();
+  await runBeforeHooks({ type: "read", key });
+  let value: string | null;
+  try {
+    value = activeBackend.retrieve(key);
+  } catch (err) {
+    runAfterHooks({
+      type: "credential_read_failed",
+      timestamp: new Date().toISOString(),
+      backend: activeVaultType,
+      key,
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: performance.now() - start,
+    });
+    throw err;
+  }
   if (value !== null) touchSession();
+  runAfterHooks({
+    type: value !== null ? "credential_read" : "credential_read_missing",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    key,
+    durationMs: performance.now() - start,
+  });
   return value;
 }
 
@@ -153,7 +185,17 @@ export async function getCredential(key: string): Promise<string | null> {
  * @returns true on success (including "already deleted"), false on unexpected error
  */
 export async function deleteCredential(key: string): Promise<boolean> {
-  return activeBackend.delete(key);
+  const start = performance.now();
+  await runBeforeHooks({ type: "delete", key });
+  const success = activeBackend.delete(key);
+  runAfterHooks({
+    type: success ? "credential_deleted" : "credential_delete_failed",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    key,
+    durationMs: performance.now() - start,
+  });
+  return success;
 }
 
 /**
@@ -181,7 +223,30 @@ export async function deleteCredential(key: string): Promise<boolean> {
  *   }
  */
 export async function listCredentials(prefix?: string): Promise<string[]> {
-  const keys = await activeBackend.listKeys(prefix);
+  const start = performance.now();
+  await runBeforeHooks({ type: "enumerate", prefix });
+  let keys: string[];
+  try {
+    keys = await activeBackend.listKeys(prefix);
+  } catch (err) {
+    runAfterHooks({
+      type: "credential_enumerate_failed",
+      timestamp: new Date().toISOString(),
+      backend: activeVaultType,
+      prefix,
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: performance.now() - start,
+    });
+    throw err;
+  }
   if (keys.length > 0) touchSession();
+  runAfterHooks({
+    type: "credential_enumerated",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    prefix,
+    keyCount: keys.length,
+    durationMs: performance.now() - start,
+  });
   return keys;
 }

--- a/packages/secrets/src/vault/vault.ts
+++ b/packages/secrets/src/vault/vault.ts
@@ -107,6 +107,13 @@ function touchSession(): void {
 
 // =============================================================================
 // Public API
+//
+// Known limitation (0.5.0): when a `before` policy hook rejects an
+// operation by throwing, the rejection propagates to the caller but no
+// `after` event is emitted. This means policy-rejected operations are
+// invisible to the audit trail. The full onion model — where `after`
+// hooks on already-entered policies still fire on abort — ships in 1.0
+// as part of `createSecretsClient`. See ADR-002 §1.0.0.
 // =============================================================================
 
 /**

--- a/packages/secrets/tests/policy.test.ts
+++ b/packages/secrets/tests/policy.test.ts
@@ -1,0 +1,382 @@
+/**
+ * SecretsPolicy — integration tests
+ *
+ * Tests the policy middleware layer by configuring policies via
+ * `setSecretsPolicies` and verifying that `before` / `after` hooks
+ * fire on storeCredential, getCredential, deleteCredential, and
+ * listCredentials. The Keychain backend is mocked (same pattern as
+ * vault.test.ts) so no real keychain access occurs.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
+import type { SecretsEvent, SecretsOperation } from "../src/vault/policy.js";
+
+// =============================================================================
+// Mock vault-common (same pattern as vault.test.ts)
+// =============================================================================
+
+const {
+  mockStoreString,
+  mockGetString,
+  mockDelete,
+  mockListAccounts,
+  _originalPlatform,
+} = vi.hoisted(() => {
+  const _originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  return {
+    mockStoreString: vi.fn(),
+    mockGetString: vi.fn(),
+    mockDelete: vi.fn(),
+    mockListAccounts: vi.fn(),
+    _originalPlatform,
+  };
+});
+
+vi.mock("../src/crypto/vault-common.js", () => ({
+  storeStringInKeychain: mockStoreString,
+  getStringFromKeychain: mockGetString,
+  deleteFromKeychain: mockDelete,
+  listAccountsInKeychain: mockListAccounts,
+  invalidateKeychainListCache: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  encryptObject: vi.fn(),
+  decryptObject: vi.fn(),
+  getKeyFromKeychain: vi.fn(),
+  storeKeyInKeychain: vi.fn(),
+  ALGORITHM: "aes-256-gcm",
+  IV_LENGTH: 12,
+  AUTH_TAG_LENGTH: 16,
+  KEY_LENGTH: 32,
+}));
+
+const {
+  storeCredential,
+  getCredential,
+  deleteCredential,
+  listCredentials,
+} = await import("../src/vault/vault.js");
+
+const {
+  setSecretsPolicies,
+  auditTrail,
+} = await import("../src/vault/policy.js");
+
+// =============================================================================
+// Setup / teardown
+// =============================================================================
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setSecretsPolicies([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setSecretsPolicies([]);
+});
+
+afterAll(() => {
+  Object.defineProperty(process, "platform", { value: _originalPlatform, writable: true });
+});
+
+// =============================================================================
+// after hooks — event emission
+// =============================================================================
+
+describe("policy after hooks", () => {
+  it("emits credential_written on successful store", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockStoreString.mockReturnValue(true);
+
+    await storeCredential("auth-token", "value");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("credential_written");
+    expect(events[0]!.key).toBe("auth-token");
+    expect(events[0]!.backend).toBe("keychain");
+    expect(typeof events[0]!.durationMs).toBe("number");
+    expect(typeof events[0]!.timestamp).toBe("string");
+  });
+
+  it("emits credential_write_failed on failed store", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockStoreString.mockReturnValue(false);
+
+    await storeCredential("auth-token", "value");
+
+    expect(events[0]!.type).toBe("credential_write_failed");
+  });
+
+  it("emits credential_read on successful get", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockGetString.mockReturnValue("secret-value");
+
+    await getCredential("auth-token");
+
+    expect(events[0]!.type).toBe("credential_read");
+    expect(events[0]!.key).toBe("auth-token");
+  });
+
+  it("emits credential_read_missing when key not found", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockGetString.mockReturnValue(null);
+
+    await getCredential("auth-token");
+
+    expect(events[0]!.type).toBe("credential_read_missing");
+  });
+
+  it("emits credential_read_failed when backend throws", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockGetString.mockImplementation(() => { throw new Error("keychain locked"); });
+
+    await expect(getCredential("auth-token")).rejects.toThrow("keychain locked");
+    expect(events[0]!.type).toBe("credential_read_failed");
+    expect(events[0]!.error).toBe("keychain locked");
+  });
+
+  it("emits credential_deleted on successful delete", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockDelete.mockReturnValue(true);
+
+    await deleteCredential("auth-token");
+
+    expect(events[0]!.type).toBe("credential_deleted");
+    expect(events[0]!.key).toBe("auth-token");
+  });
+
+  it("emits credential_enumerated on successful list", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockListAccounts.mockReturnValue(["auth-token", "refresh-token"]);
+
+    await listCredentials();
+
+    expect(events[0]!.type).toBe("credential_enumerated");
+    expect(events[0]!.keyCount).toBe(2);
+  });
+
+  it("emits credential_enumerate_failed when list throws", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([{ name: "test", after: (e) => events.push(e) }]);
+    mockListAccounts.mockImplementation(() => { throw new Error("access denied"); });
+
+    await expect(listCredentials()).rejects.toThrow("access denied");
+    expect(events[0]!.type).toBe("credential_enumerate_failed");
+    expect(events[0]!.error).toBe("access denied");
+  });
+});
+
+// =============================================================================
+// before hooks — operation gating
+// =============================================================================
+
+describe("policy before hooks", () => {
+  it("runs before hooks before the backend operation", async () => {
+    const order: string[] = [];
+    setSecretsPolicies([{
+      name: "test",
+      before: () => { order.push("before"); },
+      after: () => { order.push("after"); },
+    }]);
+    mockGetString.mockImplementation(() => {
+      order.push("backend");
+      return "value";
+    });
+
+    await getCredential("auth-token");
+
+    expect(order).toEqual(["before", "backend", "after"]);
+  });
+
+  it("aborts the operation when a before hook throws", async () => {
+    setSecretsPolicies([{
+      name: "acl",
+      before: () => { throw new Error("access denied by policy"); },
+    }]);
+
+    await expect(getCredential("auth-token")).rejects.toThrow("access denied by policy");
+    expect(mockGetString).not.toHaveBeenCalled();
+  });
+
+  it("receives the correct operation descriptor", async () => {
+    const ops: SecretsOperation[] = [];
+    setSecretsPolicies([{
+      name: "test",
+      before: (op) => { ops.push({ ...op }); },
+    }]);
+
+    mockStoreString.mockReturnValue(true);
+    mockGetString.mockReturnValue(null);
+    mockDelete.mockReturnValue(true);
+    mockListAccounts.mockReturnValue([]);
+
+    await storeCredential("key1", "val");
+    await getCredential("key2");
+    await deleteCredential("key3");
+    await listCredentials("prefix.");
+
+    expect(ops).toEqual([
+      { type: "write", key: "key1" },
+      { type: "read", key: "key2" },
+      { type: "delete", key: "key3" },
+      { type: "enumerate", prefix: "prefix." },
+    ]);
+  });
+});
+
+// =============================================================================
+// Multiple policies compose
+// =============================================================================
+
+describe("policy composition", () => {
+  it("runs before hooks top-to-bottom and after hooks bottom-to-top", async () => {
+    const order: string[] = [];
+    setSecretsPolicies([
+      { name: "a", before: () => { order.push("a-before"); }, after: () => { order.push("a-after"); } },
+      { name: "b", before: () => { order.push("b-before"); }, after: () => { order.push("b-after"); } },
+    ]);
+    mockGetString.mockReturnValue("val");
+
+    await getCredential("auth-token");
+
+    expect(order).toEqual(["a-before", "b-before", "b-after", "a-after"]);
+  });
+});
+
+// =============================================================================
+// after hook exception handling
+// =============================================================================
+
+describe("after hook exception handling", () => {
+  it("swallows exceptions from after hooks without breaking the operation", async () => {
+    setSecretsPolicies([{
+      name: "broken-auditor",
+      after: () => { throw new Error("disk full"); },
+    }]);
+    mockGetString.mockReturnValue("secret");
+
+    const result = await getCredential("auth-token");
+    expect(result).toBe("secret");
+  });
+
+  it("emits a one-time warning to stderr on first after-hook failure", async () => {
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    setSecretsPolicies([{
+      name: "broken-auditor",
+      after: () => { throw new Error("disk full"); },
+    }]);
+    mockGetString.mockReturnValue("val");
+    mockStoreString.mockReturnValue(true);
+
+    await getCredential("auth-token");
+    await storeCredential("auth-token", "val");
+
+    const warnings = stderrWrite.mock.calls.map(([msg]) => String(msg));
+    const policyWarnings = warnings.filter((w) => w.includes("[secrets] policy"));
+    expect(policyWarnings).toHaveLength(1);
+    expect(policyWarnings[0]).toContain("broken-auditor");
+    expect(policyWarnings[0]).toContain("disk full");
+
+    stderrWrite.mockRestore();
+  });
+});
+
+// =============================================================================
+// auditTrail built-in policy
+// =============================================================================
+
+describe("auditTrail policy", () => {
+  it("emits all events to the sink by default", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([auditTrail({ sink: (e) => events.push(e) })]);
+
+    mockStoreString.mockReturnValue(true);
+    mockGetString.mockReturnValue("val");
+    mockDelete.mockReturnValue(true);
+    mockListAccounts.mockReturnValue(["k1"]);
+
+    await storeCredential("k1", "v1");
+    await getCredential("k1");
+    await deleteCredential("k1");
+    await listCredentials();
+
+    expect(events.map((e) => e.type)).toEqual([
+      "credential_written",
+      "credential_read",
+      "credential_deleted",
+      "credential_enumerated",
+    ]);
+  });
+
+  it("excludes read events when includeReads=false", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([auditTrail({ sink: (e) => events.push(e), includeReads: false })]);
+
+    mockStoreString.mockReturnValue(true);
+    mockGetString.mockReturnValue("val");
+    mockDelete.mockReturnValue(true);
+    mockListAccounts.mockReturnValue(["k1"]);
+
+    await storeCredential("k1", "v1");
+    await getCredential("k1");
+    await deleteCredential("k1");
+    await listCredentials();
+
+    expect(events.map((e) => e.type)).toEqual([
+      "credential_written",
+      "credential_deleted",
+      "credential_enumerated",
+    ]);
+  });
+
+  it("also excludes credential_read_missing when includeReads=false", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([auditTrail({ sink: (e) => events.push(e), includeReads: false })]);
+    mockGetString.mockReturnValue(null);
+
+    await getCredential("auth-token");
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("event objects have the correct shape", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([auditTrail({ sink: (e) => events.push(e) })]);
+    mockStoreString.mockReturnValue(true);
+
+    await storeCredential("soma.anthropic.token1", "val");
+
+    const event = events[0]!;
+    expect(event.type).toBe("credential_written");
+    expect(event.key).toBe("soma.anthropic.token1");
+    expect(event.backend).toBe("keychain");
+    expect(event.durationMs).toBeGreaterThanOrEqual(0);
+    expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(event.error).toBeUndefined();
+    expect(event.keyCount).toBeUndefined();
+    expect(event.prefix).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// No-policy fast path
+// =============================================================================
+
+describe("no policies configured", () => {
+  it("operations work normally with no policies installed", async () => {
+    setSecretsPolicies([]);
+    mockGetString.mockReturnValue("secret");
+
+    const result = await getCredential("auth-token");
+    expect(result).toBe("secret");
+  });
+});

--- a/packages/secrets/tests/policy.test.ts
+++ b/packages/secrets/tests/policy.test.ts
@@ -197,6 +197,26 @@ describe("policy before hooks", () => {
     expect(order).toEqual(["before", "backend", "after"]);
   });
 
+  it("supports async before hooks (Promise-returning)", async () => {
+    const order: string[] = [];
+    setSecretsPolicies([{
+      name: "async-gate",
+      async before() {
+        await new Promise((r) => setTimeout(r, 1));
+        order.push("async-before");
+      },
+      after: () => { order.push("after"); },
+    }]);
+    mockGetString.mockImplementation(() => {
+      order.push("backend");
+      return "value";
+    });
+
+    await getCredential("auth-token");
+
+    expect(order).toEqual(["async-before", "backend", "after"]);
+  });
+
   it("aborts the operation when a before hook throws", async () => {
     setSecretsPolicies([{
       name: "acl",


### PR DESCRIPTION
## Summary

The final PR in the `@centient/secrets@0.5.0` train. Introduces the `SecretsPolicy` middleware layer described in ADR-002 (#22) §0.5.0, with `auditTrail` as the first and only built-in policy.

This is the middleware seam that makes `@centient/secrets` viable for regulated consumers (SOC 2 target): every credential operation now passes through a configurable policy stack where cross-cutting concerns — starting with audit, growing to rate limiting, access control, and attestation in 1.0 — can intercept, observe, or reject operations.

## New API

```ts
import { setSecretsPolicies, auditTrail, type SecretsEvent } from "@centient/secrets";

// Configure audit — one line at process startup
setSecretsPolicies([
  auditTrail({
    sink: (event: SecretsEvent) => auditWriter.write(event),
    includeReads: true, // default; set false on hot paths
  }),
]);

// Every storeCredential / getCredential / deleteCredential / listCredentials
// call now emits structured events to the sink. No caller changes needed.
```

## Architecture

- **`SecretsPolicy`** — `{ name, before?(op), after?(event) }`. Before hooks gate (can throw to reject), after hooks observe.
- **`setSecretsPolicies([...])`** — configures the stack. Empty = no overhead (two empty for-loops).
- **`auditTrail({ sink, includeReads? })`** — factory producing an after-only audit policy.
- **9 event types** — `credential_read`, `credential_read_missing`, `credential_read_failed`, `credential_written`, `credential_write_failed`, `credential_deleted`, `credential_delete_failed`, `credential_enumerated`, `credential_enumerate_failed`.
- **Execution model** — before hooks top-to-bottom, after hooks bottom-to-top (onion). After-hook exceptions swallowed with one-time stderr warning.
- **Forward-compatible** — names, shapes, and the array-based policy list are designed for the 1.0 `createSecretsClient({ provider, policies })` factory. The 0.5.0 global setter is a stepping stone, not technical debt.

## Test plan

- [x] `pnpm -F @centient/secrets build` — clean
- [x] `pnpm -F @centient/secrets test` — 112/112 passing (was 93)
- [x] `pnpm -F @centient/secrets lint` — clean
- [x] `pnpm build` — all 5 packages
- [x] `pnpm test` — all 10 suites
- [x] 19 new tests covering: event emission for all 4 operation types (7), before-hook ordering and rejection (3), multi-policy composition with onion order (1), after-hook exception swallowing with one-time warning (2), auditTrail includeReads filtering (3), event shape validation (1), no-policy baseline (1), operation descriptor correctness (1)
- [ ] CI green

## Release context — the full 0.5.0 train is now complete

| PR | Title | Status | Tests |
|---|---|---|---|
| #21 / A | allow dots in keys | merged | 81 |
| #22 / F | ADR-002 architecture | merged | — |
| #23 / E | RELEASING.md + drift check | merged | — |
| #24 / B | Keychain cache + --json | merged | 90 |
| #25 / C | async listKeys + dbus | merged | 93 |
| **#? / D** | **SecretsPolicy + auditTrail** | **this PR** | **112** |

After this PR merges, `@centient/secrets@0.5.0` is ready for `make publish`. Four changesets will be consumed together:
- `secrets-allow-dots-in-keys.md` (minor)
- `secrets-keychain-cache-json-cli.md` (minor)
- `secrets-async-listkeys-dbus.md` (minor)
- `secrets-policy-audit-trail.md` (minor)

All four are minor → single bump to **0.5.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)