### PR TITLE
fix(turbo): lint depends on ^build so sibling types are present

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
       "inputs": ["src/**", "tests/**", "vitest.config.ts"]
     },
     "lint": {
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "clean": {


### PR DESCRIPTION
## Failure

Maintainer bot v0.8.3 has been failing \`make check\` on every PR that touches workspace packages. Example from PRs #28 and #30:

\`\`\`
packages/wal:
  src/replay.ts(14,39): error TS2307: Cannot find module '@centient/logger'
  src/wal.ts(18,39):    error TS2307: Cannot find module '@centient/logger'
\`\`\`

Workspace symlinks are correct (\`packages/wal/node_modules/@centient/logger -> ../../../logger\`), and every package's \`exports\`/\`types\` point at emitted files (\`dist/index.d.ts\`). The failure mode is a **task-graph ordering bug**: turbo was parallelizing \`lint\` (= \`tsc --noEmit\`) across all workspace packages, so \`wal:lint\` ran before \`logger:build\` had emitted its \`.d.ts\` — tsc had nothing to resolve \`@centient/logger\` against.

## Fix

One-line change to \`turbo.json\`:

\`\`\`diff
  "lint": {
+   "dependsOn": ["^build"],
    "outputs": []
  },
\`\`\`

The \`^build\` (with caret) tells turbo: before running \`lint\` in a package, run \`build\` in every **upstream workspace dep** first. Since every package's type-entry points at \`dist/\`, this guarantees sibling \`.d.ts\` files exist by the time \`tsc --noEmit\` runs.

\`build\` and \`test\` already had correct ordering; only \`lint\` was missing the upstream-build dep.

## Verification

From a clean state:

\`\`\`
pnpm -r clean                   # wipes all packages/*/dist
pnpm install
pnpm run lint
\`\`\`

Result:
\`\`\`
Tasks:    6 successful, 6 total
Cached:    4 cached, 6 total
  Time:    933ms
\`\`\`

Turbo correctly restored \`logger/dist/index.d.ts\` via the \`^build\` dep before running \`wal:lint\` and \`events:lint\` — both passed, no TS2307 errors.

## Scope

- Only \`turbo.json\` is changed. No package sources, no \`package.json\`, no version bumps.
- No changesets added — this is a build-config fix with no runtime surface change.
- \`test\` task already had correct ordering (\`dependsOn: ["build"]\` → transitively \`^build\` via build's own deps).
- \`packages/sdk-python\` has no \`package.json\` — pnpm skips it; unaffected.

## Impact

Unblocks maintainer bot reviews on PRs #28 and #30 (and any future workspace-touching PR). The bot's AI code-review + ADR-review phases have been skipped on every run with "Infrastructure error" — this root-causes that to the deterministic-check step failing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)