### PR TITLE
fix(events,wal,logger): close P2 silent-degradation gaps

### DIFF
--- a/.changeset/harden-events-p2.md
+++ b/.changeset/harden-events-p2.md
@@ -1,0 +1,10 @@
+---
+"@centient/events": patch
+---
+
+Harden JSONL subscriber and follow-mode reader against silent degradation (P2):
+
+- **JSONL subscriber**: `onEvent` now catches `JSON.stringify` failures (circular refs, BigInt, etc.) and drops the single offending event instead of letting the exception escape and crash the subscriber. `onClose` performs a best-effort final flush so events buffered since the last interval tick aren't lost when a stream closes quickly; callers needing a durability guarantee should still await the returned `flush()` function.
+- **Follow-mode reader**: `init()` is now single-flight — concurrent `next()` calls at cold start share one init attempt, preventing a race that could leak file handles and watchers from the loser.
+- **Follow-mode reader**: lines exceeding `MAX_LINE_BYTES` (1 MiB) now surface as an iterator error instead of being silently discarded.
+- **README**: removed the `"block"` backpressure policy row from the `BackpressurePolicy` table — the policy was removed from the types but left in docs.

--- a/.changeset/harden-logger-write-errors.md
+++ b/.changeset/harden-logger-write-errors.md
@@ -1,0 +1,5 @@
+---
+"@centient/logger": patch
+---
+
+`FileTransport` write-stream errors are no longer silently swallowed. Disk-full, EACCES, and other stream-level failures now surface to stderr with a `[FileTransport]` prefix so operators have a signal that logs are being lost. The process is not taken down; the transport behaves as before otherwise. This is the logger-of-last-resort path — writing to stderr avoids depending on the very transport that just failed.

--- a/.changeset/harden-wal-fsync.md
+++ b/.changeset/harden-wal-fsync.md
@@ -1,0 +1,10 @@
+---
+"@centient/wal": patch
+---
+
+Add explicit `fsync` to the WAL durability path. The WAL's purpose is crash recovery, so a `success: true` return must mean the bytes are on disk — not buffered in the page cache where an immediate OS crash can lose them.
+
+- `appendEntry` now opens the WAL file with `O_APPEND`, writes the entry, calls `fh.sync()`, and closes the handle before returning success. The public API is unchanged.
+- `atomicWriteFile` (used by `confirmEntry` and `compactWal`) now `fsync`s the temp file before the `rename` commits it. Without this, an OS crash after the rename but before the temp file's data pages flushed would leave the target file pointing at an inode with stale content.
+
+No behavior change under normal operation; measurable only on crash scenarios.

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -67,7 +67,6 @@ Returns an `EventStream<T>`.
 |-------|----------|
 | `"drop-oldest"` | Drop the oldest buffered event to make room (default) |
 | `"drop-newest"` | Reject the incoming event; keep the buffer intact |
-| `"block"` | Block `emit()` until buffer space is available — use carefully |
 
 ### `EventSubscriber<T>`
 

--- a/packages/events/src/jsonl.ts
+++ b/packages/events/src/jsonl.ts
@@ -128,7 +128,15 @@ export function createJsonlSubscriber<T>(filePath: string): {
 
   const subscriber: EventSubscriber<T> = {
     onEvent(event: T): void {
-      const line = JSON.stringify({ _ts: new Date().toISOString(), event }) + "\n";
+      let line: string;
+      try {
+        line = JSON.stringify({ _ts: new Date().toISOString(), event }) + "\n";
+      } catch (err) {
+        // Circular refs, BigInt, etc. would crash the stream if we let this bubble.
+        // Log and drop the single event; don't take down the subscriber.
+        logger.error(errorContext(err, filePath), "JSONL serialization failed; event dropped");
+        return;
+      }
       buffer.push(line);
       if (!flushTimer) startTimer();
 
@@ -145,7 +153,12 @@ export function createJsonlSubscriber<T>(filePath: string): {
     },
 
     onClose(): void {
+      // Best-effort final flush so data buffered since the last interval tick isn't lost.
+      // Fire-and-forget — callers needing a durability guarantee should await the returned flush().
       stopTimer();
+      flush().catch((err) => {
+        logger.error(errorContext(err, filePath), "JSONL close-time flush error");
+      });
     },
   };
 

--- a/packages/events/src/replay.ts
+++ b/packages/events/src/replay.ts
@@ -179,47 +179,60 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
   const buffer: T[] = [];
   let closed = false;
   let waiting: ((result: IteratorResult<T>) => void) | null = null;
-  let initialized = false;
+  let waitingReject: ((error: Error) => void) | null = null;
+  let initPromise: Promise<void> | null = null;
   let initError: Error | null = null;
+  let pendingError: Error | null = null;
 
   const readBuf = Buffer.allocUnsafe(READ_BUFFER_SIZE);
 
-  async function init(): Promise<void> {
-    if (initialized) return;
-    try {
-      fh = await open(path, "r");
+  function init(): Promise<void> {
+    // Single-flight: concurrent next() calls share one init attempt and must not
+    // both run the open()/watch() code path — doing so leaks the file handle and
+    // watcher from whichever attempt loses the race.
+    if (initPromise) return initPromise;
+    initPromise = (async () => {
+      try {
+        fh = await open(path, "r");
 
-      // Read initial content
-      await readNewContent();
+        // Read initial content
+        await readNewContent();
 
-      // Watch for changes
-      watcher = watch(path, () => {
-        readNewContent().catch((err) => {
-          logger.error(
-            { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined, path },
-            "follow mode read error",
-          );
-          closed = true;
-          if (waiting) {
-            const resolve = waiting;
-            waiting = null;
-            resolve({ done: true, value: undefined });
-          }
+        // Watch for changes
+        watcher = watch(path, () => {
+          readNewContent().catch((err) => {
+            logger.error(
+              { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined, path },
+              "follow mode read error",
+            );
+            closed = true;
+            if (waiting) {
+              const resolve = waiting;
+              waiting = null;
+              waitingReject = null;
+              resolve({ done: true, value: undefined });
+            }
+          });
         });
-      });
-      watcher.unref();
-      initialized = true;
-      logger.info({ path }, "follow mode reader opened");
-    } catch (err) {
-      closed = true;
-      initError = err instanceof Error ? err : new Error(String(err));
-      logger.error({ error: initError.message, stack: initError.stack, path }, "follow mode init failed");
-      if (waiting) {
-        const resolve = waiting;
-        waiting = null;
-        resolve({ done: true, value: undefined });
+        watcher.unref();
+        logger.info({ path }, "follow mode reader opened");
+      } catch (err) {
+        closed = true;
+        initError = err instanceof Error ? err : new Error(String(err));
+        logger.error({ error: initError.message, stack: initError.stack, path }, "follow mode init failed");
+        if (waitingReject) {
+          const reject = waitingReject;
+          waiting = null;
+          waitingReject = null;
+          reject(initError);
+        } else if (waiting) {
+          const resolve = waiting;
+          waiting = null;
+          resolve({ done: true, value: undefined });
+        }
       }
-    }
+    })();
+    return initPromise;
   }
 
   async function readNewContent(): Promise<void> {
@@ -252,10 +265,23 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
     // Last element may be incomplete — save for next read
     remainder = lines.pop() ?? "";
 
-    // Guard against unbounded remainder growth
+    // Guard against unbounded remainder growth. Surface as an error to the
+    // iterator — silently dropping means the consumer sees a missing event
+    // with no signal, which is exactly the failure mode callers can't detect.
     if (remainder.length > MAX_LINE_BYTES) {
-      logger.warn({ path }, "follow mode: oversized line discarded");
+      const err = new Error(
+        `JSONL line exceeds ${MAX_LINE_BYTES} bytes (file: ${path}); discarding pending remainder`,
+      );
+      logger.error({ path, remainderBytes: remainder.length }, "follow mode: oversized line");
       remainder = "";
+      if (waitingReject) {
+        const reject = waitingReject;
+        waiting = null;
+        waitingReject = null;
+        reject(err);
+      } else {
+        pendingError = err;
+      }
     }
 
     for (const line of lines) {
@@ -281,6 +307,13 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
         return Promise.reject(initError);
       }
 
+      // Surface any error accumulated between next() calls (e.g., oversized line)
+      if (pendingError) {
+        const err = pendingError;
+        pendingError = null;
+        return Promise.reject(err);
+      }
+
       // Return buffered item if available
       if (buffer.length > 0) {
         return { done: false, value: buffer.shift()! };
@@ -291,8 +324,9 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
       }
 
       // Wait for the next event from the file watcher
-      return new Promise<IteratorResult<T>>((resolve) => {
+      return new Promise<IteratorResult<T>>((resolve, reject) => {
         waiting = resolve;
+        waitingReject = reject;
       });
     },
 
@@ -309,6 +343,7 @@ function createFollowIterator<T>(path: string, keepMeta: boolean): AsyncIterator
       if (waiting) {
         const resolve = waiting;
         waiting = null;
+        waitingReject = null;
         resolve({ done: true, value: undefined });
       }
       return { done: true, value: undefined };

--- a/packages/events/tests/hardening.test.ts
+++ b/packages/events/tests/hardening.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Hardening Tests (P2: no silent degradation)
+ *
+ * Covers the three fixes bundled with the wal/logger hardening pass:
+ *   - JSONL serialization failure (circular ref) does NOT crash the subscriber
+ *   - Follow-mode init is single-flight under concurrent next() calls
+ *   - Follow-mode oversized-line overflow surfaces as an iterator error,
+ *     not a silent drop
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createJsonlSubscriber, fromJsonl } from "../src/index.js";
+
+let tmpDir: string | null = null;
+
+function makeTmpDir(): string {
+  tmpDir = mkdtempSync(join(tmpdir(), "events-harden-"));
+  return tmpDir;
+}
+
+function tick(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterEach(() => {
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  }
+});
+
+describe("jsonl subscriber — serialization failure isolation", () => {
+  it("drops events that cannot be serialized without crashing the subscriber", async () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "events.jsonl");
+
+    const { subscriber, flush } = createJsonlSubscriber<{ payload: unknown }>(path);
+
+    const circular: Record<string, unknown> = { type: "bad" };
+    circular["self"] = circular;
+
+    // Before fix: JSON.stringify throws and the exception escapes onEvent.
+    // After fix: the single event is logged and dropped; subscriber keeps working.
+    expect(() => subscriber.onEvent({ payload: circular })).not.toThrow();
+    subscriber.onEvent({ payload: { type: "good" } });
+
+    await flush();
+
+    const contents = readFileSync(path, "utf-8");
+    expect(contents).toContain('"type":"good"');
+    expect(contents).not.toContain('"type":"bad"');
+  });
+});
+
+describe("fromJsonl follow mode — single-flight init", () => {
+  it("serves concurrent next() calls from a single init pass", async () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "events.jsonl");
+
+    // Seed two events so two concurrent next() calls can both resolve from
+    // the initial readNewContent() without waiting for a file-watch event.
+    // Before fix: each concurrent call could enter init() and race to open
+    // the file + install a watcher, leaking the loser's handle.
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ _ts: "t1", event: { n: 1 } }),
+        JSON.stringify({ _ts: "t2", event: { n: 2 } }),
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const iter = fromJsonl<{ n: number }>(path, { follow: true })[Symbol.asyncIterator]();
+
+    const [a, b] = await Promise.all([iter.next(), iter.next()]);
+    expect(a.done).toBe(false);
+    expect(b.done).toBe(false);
+    const values = [a.value?.n, b.value?.n].sort();
+    expect(values).toEqual([1, 2]);
+
+    await iter.return?.();
+  });
+});
+
+describe("fromJsonl follow mode — oversized line surfaces as error", () => {
+  it("rejects the iterator when a line exceeds MAX_LINE_BYTES", async () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "events.jsonl");
+    // Seed a valid event so init succeeds
+    writeFileSync(path, JSON.stringify({ _ts: "t", event: { n: 0 } }) + "\n", "utf-8");
+
+    const iter = fromJsonl<{ n: number }>(path, { follow: true })[Symbol.asyncIterator]();
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+
+    // Park a next() call, then append a 2 MiB chunk with no newline. The
+    // watcher fires, readNewContent accumulates the chunk as `remainder`,
+    // the overflow guard triggers, and the pending next() must reject.
+    const pending = iter.next();
+
+    await tick(50);
+    appendFileSync(path, "x".repeat(2 * 1024 * 1024), "utf-8");
+
+    await expect(
+      Promise.race([
+        pending,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("no error raised")), 4000)),
+      ]),
+    ).rejects.toThrow(/exceeds/);
+
+    await iter.return?.();
+  }, 10000);
+});

--- a/packages/logger/src/transports/FileTransport.ts
+++ b/packages/logger/src/transports/FileTransport.ts
@@ -76,8 +76,16 @@ export class FileTransport implements Transport {
       flags: "a",
       mode: 0o600,
     });
-    this.writeStream.on("error", () => {
-      // Silently fail if we can't write to log file
+    this.writeStream.on("error", (err) => {
+      // Logger of last resort: write-stream failures (disk full, EACCES, etc.)
+      // must not take down the process, but silently swallowing them means
+      // operators have no signal that logs are being lost. Write directly to
+      // stderr with a clear prefix so the failure is visible without depending
+      // on the very transport that just failed.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[FileTransport] write error on ${this.filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     });
 
     // Set up periodic flush (async to allow rotation checks)

--- a/packages/wal/src/wal.ts
+++ b/packages/wal/src/wal.ts
@@ -11,7 +11,7 @@
  * 4. On crash/restart, `getUnconfirmedEntries()` finds pending operations for replay
  */
 
-import { mkdir, appendFile, readFile, writeFile, rename, unlink, readdir, lstat } from "node:fs/promises";
+import { mkdir, readFile, rename, unlink, readdir, lstat, open } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -39,7 +39,8 @@ const logger = createComponentLogger("engram", "wal");
  *
  * Serializes `confirmEntry` and `compactWal` on the same file path to prevent
  * TOCTOU races from read-modify-write cycles. Different file paths run in
- * parallel. `appendEntry` uses atomic `appendFile` and does not need the mutex.
+ * parallel. `appendEntry` uses an O_APPEND handle with fsync and does not
+ * need the mutex.
  */
 const walMutex = new Map<string, Promise<void>>();
 
@@ -69,7 +70,10 @@ async function withWalMutex<T>(walPath: string, fn: () => Promise<T>): Promise<T
  * Write content to a file atomically via temp-file-then-rename.
  *
  * `rename()` is atomic on the same filesystem, so a crash mid-write leaves
- * the original file intact rather than truncating it.
+ * the original file intact rather than truncating it. We also `fsync()` the
+ * temp file before rename so the data is durably on disk before the rename
+ * commits — without this, an OS crash after rename can leave the target
+ * pointing at an inode whose data pages never flushed.
  *
  * **Requirement:** `filePath` must be on the same filesystem mount.
  * `rename()` fails with EXDEV across mount boundaries.
@@ -77,7 +81,13 @@ async function withWalMutex<T>(walPath: string, fn: () => Promise<T>): Promise<T
 async function atomicWriteFile(filePath: string, content: string): Promise<void> {
   const tmpPath = `${filePath}.${randomUUID()}.tmp`;
   try {
-    await writeFile(tmpPath, content, "utf-8");
+    const fh = await open(tmpPath, "w");
+    try {
+      await fh.writeFile(content, "utf-8");
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
     await rename(tmpPath, filePath);
   } catch (err) {
     try { await unlink(tmpPath); } catch { /* ignore cleanup failure */ }
@@ -172,7 +182,17 @@ export async function appendEntry(
     };
 
     const line = JSON.stringify(entry) + "\n";
-    await appendFile(walPath, line, "utf-8");
+    // Append with explicit fsync: the WAL's whole purpose is crash recovery,
+    // so a successful return must mean the bytes are durably on disk. The
+    // default appendFile buffers through the page cache; an immediate crash
+    // would lose the entry despite success: true.
+    const fh = await open(walPath, "a");
+    try {
+      await fh.writeFile(line, "utf-8");
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
 
     return { success: true, operationId, autoConfirmed };
   } catch (err: unknown) {


### PR DESCRIPTION
**Replaces #28** (same code, conventional-format commit message). Closes the P2 silent-degradation gaps surfaced by a parallel module review across \`@centient/events\`, \`@centient/wal\`, and \`@centient/logger\`.

## Summary

Three isolated hardening fixes. All three violate design-philosophy P2 (no silent degradation) — failures that should be surfaced to callers were being swallowed.

### \`@centient/events\`
- \`jsonl\` subscriber catches \`JSON.stringify\` failures (circular refs, BigInt) and drops the single event instead of crashing the subscriber.
- \`jsonl\` \`onClose\` performs a best-effort final flush so events buffered since the last interval tick aren't lost on fast close.
- Follow-mode \`init()\` is now single-flight — concurrent \`next()\` calls share one init pass, closing the race that could leak the loser's file handle + watcher.
- Follow-mode lines exceeding \`MAX_LINE_BYTES\` surface as iterator errors instead of being silently discarded.
- README drops the stale \`\"block\"\` backpressure policy row.

### \`@centient/wal\`
- \`appendEntry\` opens the WAL with \`O_APPEND\`, writes, \`fsync\`s, then closes — a \`success: true\` return now means the bytes are durably on disk, not just in the page cache.
- \`atomicWriteFile\` \`fsync\`s the temp file before rename, closing the window where an OS crash post-rename could leave the target pointing at an inode with unflushed data.

### \`@centient/logger\`
- \`FileTransport\` write-stream errors (disk full, EACCES) surface to stderr with a \`[FileTransport]\` prefix instead of being silently swallowed. Logger-of-last-resort path — writing to stderr avoids depending on the very transport that just failed.

## Changesets

Three patch-level changesets included (one per package). No breaking changes.

## Test plan

- [x] 3 new \`@centient/events\` hardening tests — 60/60 pass
- [x] \`@centient/wal\` — 63/63 existing tests pass (fsync is non-observable; existing happy-path tests validate semantics unchanged)
- [x] \`@centient/logger\` — 479 pass, 14 perf tests skipped per #32 (new code path is error-only)
- [x] \`pnpm build\` clean across the workspace
- [x] \`pnpm lint\` clean (now ordered correctly per #31)
- [ ] Crash/fault-injection testing for WAL fsync guarantees — out of scope; filed as follow-up

## Follow-ups not in this PR

From the same review, intentionally deferred:
- WAL CRC/SHA per entry + surfaced corruption errors (design decision — needs ADR)
- Events \`onClose\` → \`Promise<void>\` type widening for fully-awaitable close (API shape change)
- Logger \`Transport\` interface-level \`onError\` hook (API shape change)
- \`@centient/sdk\` hardening (AbortSignal plumbing, Idempotency-Key, response validation) — separate track

## History note

#28 had identical code but a non-conventional commit title (\`harden: ...\`) which the maintainer's commit-format gate rejected. Force-push to rewrite the commit is blocked by the local \`claude-guard.sh\` hook, so the cleanest path was to open this replacement. \`/close #28\` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)