### PR TITLE
feat(logger)!: unreserve the `version` field; user context flows through (closes #36)

### DIFF
--- a/.changeset/logger-unreserve-version.md
+++ b/.changeset/logger-unreserve-version.md
@@ -1,0 +1,45 @@
+---
+"@centient/logger": major
+---
+
+**BREAKING:** Unreserve the `version` field name. Removes the `version` option on `LoggerOptions` and the `version` slot on `LogEntry`. User-supplied `version` in log context now flows through to the emitted entry instead of being silently stripped. Closes #36.
+
+### What changed
+
+Previously, `@centient/logger` reserved `version` as a logger-instance meta-field. Two problems:
+
+1. **`Logger.ts::buildEntry`** destructured `version` out of user context and replaced it with `this.version` (defaulting to `"0.0.0"` when no option was supplied).
+2. **`format.ts::formatPretty`** stripped `version` from pretty-mode output before rendering the tail.
+
+Net effect: `logger.info({ version: "1.2.3" }, "...")` silently dropped the user's value and emitted nothing (pretty) or `"0.0.0"` (JSON). Observed on `@centient-labs/daemon@0.6.0` during the maintainer v0.8.1 incident (log lines with no attributable version).
+
+### The fix
+
+- Remove `LoggerOptions.version?: string`
+- Remove `LogEntry.version: string`
+- Remove the `version: _v` destructure in `Logger.ts::buildEntry`
+- Remove the `version: _v` destructure in `format.ts::formatPretty`
+- Remove `this.version` internal storage
+- `createTestLogger` no longer injects a `version: "0.0.0-test"` default
+
+Only `service`, `component`, and `tool` remain reserved. Everything else (including `version`) is yours.
+
+### Why major
+
+Zero callers in the centient-labs ecosystem passed the `version` option — verified via cross-org grep across `centient-sdk`, `daemon`, `crucible`, `centient`, `soma`, `test-kit`. Per the review discussion on #36, "zero callers" resolves to clean removal and a major bump rather than a deprecation shim.
+
+The log-output shape also changes: JSON entries no longer carry a top-level `version` field, and pretty-mode output no longer contains the useless `version=0.0.0` tail (it was being stripped, but any downstream parser that expected the JSON field is affected).
+
+### Migration
+
+- If you were passing `{ version: "..." }` to `createLogger` / `createComponentLogger` / etc.: remove it. The value wasn't useful in logs anyway. If you want per-line service version, pass it in context: `logger.info({ appVersion: "1.2.3", ... }, "...")`.
+- If you were relying on `entry.version` being populated in a log consumer: the field is gone. Use `service` (unchanged) to identify the emitter, or have the emitter put its version into context explicitly.
+- If your code reads `entry.version` on a captured log entry: the field is now `undefined` unless the caller put it in context.
+
+### Convention
+
+`@centient-labs/daemon` uses `appVersion` for the consuming app's semver. The centient-sdk README suggests following that convention unless your domain has a better-fitting name. See `packages/logger/README.md` §"Reserved top-level fields".
+
+### Scope
+
+This PR addresses the bug in `@centient/logger` only. `@centient/logger::AuditWriter` has a similar internal `this.version` on audit events — that's a separate schema-versioning concern for audit payloads, not a user-context field, so it's intentionally not touched here.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -39,6 +39,8 @@ The logger reserves these field names for its own top-level entry shape and stri
 
 > Prior to v1.0.0, `version` was silently reserved by the logger — any `version` in your context would be replaced with the logger-instance version (usually `"0.0.0"`). That reservation has been removed. See [issue #36](https://github.com/centient-labs/centient-sdk/issues/36).
 
+> **AuditWriter note:** `AuditWriter` (also exported from this package) emits its own top-level `version` field on emitted audit events. That value is the **audit-event schema version** maintained internally by the writer, not a user context field — distinct from the `Logger` reservation policy above. If you're reading raw audit records and see a `version` key, it's the audit schema, not anything the caller passed.
+
 ## API
 
 ### Logger

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -19,10 +19,7 @@ pnpm add @centient/logger
 ```typescript
 import { createLogger, ConsoleTransport } from "@centient/logger";
 
-const logger = createLogger({
-  service: "my-service",
-  version: "1.0.0",
-});
+const logger = createLogger({ service: "my-service" });
 
 // Simple message
 logger.info("Application started");
@@ -33,6 +30,14 @@ logger.info({ userId: "123", action: "login" }, "User logged in");
 // Error logging
 logger.error({ err: new Error("Connection failed") }, "Database error");
 ```
+
+### Reserved top-level fields
+
+The logger reserves these field names for its own top-level entry shape and strips them if you pass them in context: `service`, `component`, `tool`, plus the always-computed `timestamp` / `level` / `message` / `pid` / `hostname`.
+
+**Every other field name — including `version` — is yours.** Pass whatever makes sense for your domain. When you want per-line service version in logs, a common convention in the centient-labs ecosystem is `appVersion` (used by `@centient-labs/daemon`); `version`, `schemaVersion`, `buildSha` etc. are all valid too. Pick the name that's unambiguous to your log consumer.
+
+> Prior to v1.0.0, `version` was silently reserved by the logger — any `version` in your context would be replaced with the logger-instance version (usually `"0.0.0"`). That reservation has been removed. See [issue #36](https://github.com/centient-labs/centient-sdk/issues/36).
 
 ## API
 
@@ -49,7 +54,6 @@ import { createLogger } from "@centient/logger";
 
 const logger = createLogger({
   service: "my-service",      // Required: service name
-  version: "1.0.0",           // Optional: service version
   level: "info",              // Optional: minimum level (default from LOG_LEVEL env)
   transport: new ConsoleTransport(), // Optional: output transport
   context: { env: "prod" },   // Optional: base context for all entries

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -124,13 +124,21 @@ export class Logger implements ILogger {
       ...context,
     });
 
-    // Remove component/tool/service from context since they're reserved top-level
-    // fields. `version` is NOT reserved — callers are free to include it in
-    // context and it will appear in the emitted entry.
+    // Strip reserved top-level field names from user context so they can't
+    // override the logger-computed values. The spread order below (computed
+    // fields first, ...restContext last) means any key left in restContext
+    // would silently overwrite the computed value — this destructure enforces
+    // the reservation boundary. `version` is intentionally NOT reserved;
+    // callers own it.
     const {
       component: _c,
       tool: _t,
       service: _s,
+      timestamp: _ts,
+      level: _lv,
+      message: _msg,
+      pid: _p,
+      hostname: _h,
       ...restContext
     } = sanitizedContext;
 

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -36,13 +36,11 @@ export class Logger implements ILogger {
   private transport: Transport;
   private component: string;
   private service: string;
-  private version: string;
   private pid: number;
   private host: string;
 
   constructor(options: LoggerOptions) {
     this.service = options.service;
-    this.version = options.version ?? "0.0.0";
     this.level = LOG_LEVELS[options.level ?? getConfiguredLevel()];
     this.baseContext = options.context ?? {};
     this.transport = options.transport ?? new ConsoleTransport();
@@ -126,12 +124,13 @@ export class Logger implements ILogger {
       ...context,
     });
 
-    // Remove component/tool from context since they're now top-level
+    // Remove component/tool/service from context since they're reserved top-level
+    // fields. `version` is NOT reserved — callers are free to include it in
+    // context and it will appear in the emitted entry.
     const {
       component: _c,
       tool: _t,
       service: _s,
-      version: _v,
       ...restContext
     } = sanitizedContext;
 
@@ -141,7 +140,6 @@ export class Logger implements ILogger {
       component: this.component,
       message,
       service: this.service,
-      version: this.version,
       pid: this.pid,
       hostname: this.host,
       ...restContext,
@@ -206,7 +204,6 @@ export class Logger implements ILogger {
 
     return new Logger({
       service: this.service,
-      version: this.version,
       transport: this.transport,
       level: (Object.entries(LOG_LEVELS).find(
         ([, v]) => v === this.level
@@ -231,11 +228,8 @@ export class Logger implements ILogger {
  * @returns A new Logger instance
  *
  * @example
- * const logger = createLogger({
- *   service: "my-app",
- *   version: "1.0.0",
- * });
- * logger.info("Application started");
+ * const logger = createLogger({ service: "my-app" });
+ * logger.info({ appVersion: "1.0.0" }, "Application started");
  */
 export function createLogger(options: LoggerOptions): Logger {
   return new Logger(options);

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -39,14 +39,15 @@ export function formatPretty(entry: LogEntry): string {
   const time = entry.timestamp.slice(11, 23);
   const color = LEVEL_COLORS[entry.level];
 
-  // Extract standard fields to avoid duplication in context display
+  // Extract standard fields to avoid duplication in context display.
+  // `version` is intentionally NOT stripped — if the caller put it in context,
+  // it belongs in the rendered tail like any other user field.
   const {
     level: _l,
     timestamp: _t,
     message,
     component,
     service: _s,
-    version: _v,
     pid: _p,
     hostname: _h,
     ...rest

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -14,12 +14,10 @@
  * @example
  * import { createLogger, ConsoleTransport } from "@centient/logger";
  *
- * const logger = createLogger({
- *   service: "my-service",
- *   version: "1.0.0",
- * });
+ * const logger = createLogger({ service: "my-service" });
  *
- * logger.info({ action: "start" }, "Service started");
+ * // `version` is yours — include it in context where it makes sense
+ * logger.info({ action: "start", appVersion: "1.0.0" }, "Service started");
  * logger.error({ err: error }, "Operation failed");
  */
 

--- a/packages/logger/src/testing.ts
+++ b/packages/logger/src/testing.ts
@@ -113,7 +113,6 @@ export function createTestLogger(
   const transport = new CaptureTransport();
   const logger = new LoggerImpl({
     service: "test-service",
-    version: "0.0.0-test",
     transport,
     level: "trace", // Capture all levels in tests
     context: {

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -56,7 +56,6 @@ export interface LogEntry {
   component: string;
   message: string;
   service: string;
-  version: string;
   pid: number;
   hostname: string;
   [key: string]: unknown;
@@ -92,8 +91,6 @@ export interface Logger {
 export interface LoggerOptions {
   /** Service name for log entries */
   service: string;
-  /** Service version for log entries */
-  version?: string;
   /** Transport to use for output */
   transport?: Transport;
   /** Minimum log level to output */

--- a/packages/logger/tests/Logger.test.ts
+++ b/packages/logger/tests/Logger.test.ts
@@ -116,6 +116,75 @@ describe("Logger", () => {
       const entry = transport.getEntries()[0];
       expect(entry.version).toBe("1.2.3");
     });
+
+    it("should pass `version` in baseContext through to every emitted entry", () => {
+      // Baked-in version via constructor context — a distinct code path from
+      // per-call context. Must flow through identically.
+      const t = new CaptureTransport();
+      const l = new Logger({
+        service: "svc",
+        transport: t,
+        level: "trace",
+        context: { version: "3.0.0" },
+      });
+      l.info("hello");
+      expect(t.getEntries()[0].version).toBe("3.0.0");
+    });
+
+    it("should merge per-call `version` over baseContext (per-call wins)", () => {
+      // Pin the merge precedence: per-call context merges on top of baseContext
+      // via Object.assign({}, baseContext, context). Accidentally reversing the
+      // order in a future refactor would silently flip this contract.
+      const t = new CaptureTransport();
+      const l = new Logger({
+        service: "svc",
+        transport: t,
+        level: "trace",
+        context: { version: "base" },
+      });
+      l.info({ version: "call" }, "hello");
+      expect(t.getEntries()[0].version).toBe("call");
+    });
+
+    it("reserved top-level fields in user context do NOT override computed values", () => {
+      // Regression for finding #1 on PR #38: without an explicit strip,
+      // `...restContext` spread at the end of the entry literal would let
+      // caller-supplied `level` / `timestamp` / `pid` / `hostname` clobber
+      // the computed values. The buildEntry destructure must strip all of
+      // them from sanitizedContext.
+      logger.info(
+        {
+          level: "fake-level",
+          timestamp: "not-a-real-time",
+          message: "caller-message-override",
+          pid: 0,
+          hostname: "attacker-host",
+        },
+        "the real message",
+      );
+      const entry = transport.getEntries()[0];
+      expect(entry.level).toBe("info");
+      expect(entry.message).toBe("the real message");
+      expect(entry.timestamp).not.toBe("not-a-real-time");
+      expect(entry.pid).toBe(process.pid);
+      expect(entry.hostname).not.toBe("attacker-host");
+    });
+  });
+
+  // ============================================================================
+  // Child Logger — `version` flow-through
+  // ============================================================================
+
+  describe("child logger — version flow-through (regression for #36)", () => {
+    it("should emit user-supplied `version` through a child logger", () => {
+      const t = new CaptureTransport();
+      const parent = new Logger({ service: "svc", transport: t, level: "trace" });
+      const child = parent.child({ component: "worker" });
+      child.info({ version: "2.0.0" }, "child says hi");
+      const entry = t.getEntries()[0];
+      expect(entry.component).toBe("worker");
+      expect(entry.version).toBe("2.0.0");
+    });
   });
 
   // ============================================================================

--- a/packages/logger/tests/Logger.test.ts
+++ b/packages/logger/tests/Logger.test.ts
@@ -26,7 +26,6 @@ describe("Logger", () => {
     transport = new CaptureTransport();
     logger = new Logger({
       service: "test-service",
-      version: "1.0.0",
       transport,
       level: "trace", // Enable all levels
     });
@@ -100,11 +99,22 @@ describe("Logger", () => {
 
       const entry = transport.getEntries()[0];
       expect(entry.service).toBe("test-service");
-      expect(entry.version).toBe("1.0.0");
       expect(entry.component).toBe("main");
       expect(typeof entry.timestamp).toBe("string");
       expect(typeof entry.pid).toBe("number");
       expect(typeof entry.hostname).toBe("string");
+      // `version` is no longer a reserved top-level field (v1.0.0, issue #36)
+      expect(entry.version).toBeUndefined();
+    });
+
+    it("should pass user-supplied `version` through context to the emitted entry", () => {
+      // Regression test for #36: `version` was silently stripped from context
+      // and replaced with the logger-instance version. As of v1.0.0 the field
+      // is no longer reserved; whatever the caller passes flows through.
+      logger.info({ version: "1.2.3" }, "starting");
+
+      const entry = transport.getEntries()[0];
+      expect(entry.version).toBe("1.2.3");
     });
   });
 
@@ -720,7 +730,6 @@ describe("Factory Functions", () => {
     it("should create a logger with specified options", () => {
       const logger = createLogger({
         service: "my-service",
-        version: "2.0.0",
         transport,
         level: "trace",
       });
@@ -729,10 +738,9 @@ describe("Factory Functions", () => {
 
       const entry = transport.getEntries()[0];
       expect(entry.service).toBe("my-service");
-      expect(entry.version).toBe("2.0.0");
     });
 
-    it("should use default version when not specified", () => {
+    it("should not emit a top-level `version` field (unreserved in v1.0.0, issue #36)", () => {
       const logger = createLogger({
         service: "my-service",
         transport,
@@ -742,7 +750,7 @@ describe("Factory Functions", () => {
       logger.info("Test message");
 
       const entry = transport.getEntries()[0];
-      expect(entry.version).toBe("0.0.0");
+      expect(entry.version).toBeUndefined();
     });
 
     it("should accept initial context", () => {

--- a/packages/logger/tests/format.test.ts
+++ b/packages/logger/tests/format.test.ts
@@ -285,7 +285,7 @@ describe("formatPretty", () => {
 
     it("should render user-supplied `version` in the tail (unreserved in v1.0.0)", () => {
       // `version` is a user context field now, not a stripped top-level.
-      const entry = createTestEntry({ version: "2.3.4" } as Partial<LogEntry>);
+      const entry = createTestEntry({ version: "2.3.4" });
       const result = formatPretty(entry);
       expect(result).toContain("version=2.3.4");
     });

--- a/packages/logger/tests/format.test.ts
+++ b/packages/logger/tests/format.test.ts
@@ -29,7 +29,6 @@ function createTestEntry(overrides: Partial<LogEntry> = {}): LogEntry {
     component: "test-component",
     message: "Test message",
     service: "test-service",
-    version: "1.0.0",
     pid: 12345,
     hostname: "test-host",
     ...overrides,
@@ -279,10 +278,16 @@ describe("formatPretty", () => {
       expect(result).not.toContain("level=info");
       expect(result).not.toContain("timestamp=");
       expect(result).not.toContain("service=test-service");
-      expect(result).not.toContain("version=1.0.0");
       expect(result).not.toContain("pid=12345");
       expect(result).not.toContain("hostname=test-host");
       expect(result).not.toContain("component=test-component");
+    });
+
+    it("should render user-supplied `version` in the tail (unreserved in v1.0.0)", () => {
+      // `version` is a user context field now, not a stripped top-level.
+      const entry = createTestEntry({ version: "2.3.4" } as Partial<LogEntry>);
+      const result = formatPretty(entry);
+      expect(result).toContain("version=2.3.4");
     });
 
     it("should handle empty context (no extra fields)", () => {
@@ -383,7 +388,7 @@ describe("formatJson", () => {
     expect(parsed.component).toBe("test-component");
     expect(parsed.message).toBe("Test message");
     expect(parsed.service).toBe("test-service");
-    expect(parsed.version).toBe("1.0.0");
+    expect(parsed.version).toBeUndefined();
     expect(parsed.pid).toBe(12345);
     expect(parsed.hostname).toBe("test-host");
     expect(parsed.userId).toBe("user123");

--- a/packages/logger/tests/integration/log-format-validation.test.ts
+++ b/packages/logger/tests/integration/log-format-validation.test.ts
@@ -58,10 +58,6 @@ function validateLogEntry(entry: LogEntry): { valid: boolean; errors: string[] }
     errors.push("service must be a string");
   }
 
-  if (typeof entry.version !== "string") {
-    errors.push("version must be a string");
-  }
-
   if (typeof entry.pid !== "number") {
     errors.push("pid must be a number");
   }

--- a/packages/logger/tests/testing.test.ts
+++ b/packages/logger/tests/testing.test.ts
@@ -41,7 +41,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Test message",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       };
@@ -60,7 +59,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "First",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       };
@@ -71,7 +69,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Second",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       };
@@ -92,7 +89,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "JSON test",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       };
@@ -163,7 +159,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Test",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       };
@@ -199,7 +194,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Test",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       };
@@ -232,7 +226,6 @@ describe("CaptureTransport", () => {
           component: "test",
           message: `${level} message`,
           service: "test-service",
-          version: "1.0.0",
           pid: 12345,
           hostname: "test-host",
         });
@@ -287,7 +280,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "second info message",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -309,7 +301,6 @@ describe("CaptureTransport", () => {
         component: "auth",
         message: "Auth message",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -319,7 +310,6 @@ describe("CaptureTransport", () => {
         component: "database",
         message: "Database message",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -329,7 +319,6 @@ describe("CaptureTransport", () => {
         component: "auth",
         message: "Auth warning",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -365,7 +354,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Hello world",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -375,7 +363,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Operation failed",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -417,7 +404,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Test",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -436,7 +422,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Test",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -459,7 +444,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "Before clear",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -472,7 +456,6 @@ describe("CaptureTransport", () => {
         component: "test",
         message: "After clear",
         service: "test-service",
-        version: "1.0.0",
         pid: 12345,
         hostname: "test-host",
       });
@@ -519,13 +502,13 @@ describe("createTestLogger", () => {
       expect(entries[0].service).toBe("test-service");
     });
 
-    it("should use 0.0.0-test as the default version", () => {
+    it("should not emit a top-level `version` field (unreserved in v1.0.0, issue #36)", () => {
       const { logger, getEntries } = createTestLogger();
 
       logger.info("Test message");
 
       const entries = getEntries();
-      expect(entries[0].version).toBe("0.0.0-test");
+      expect(entries[0].version).toBeUndefined();
     });
   });
 

--- a/packages/logger/tests/transports.test.ts
+++ b/packages/logger/tests/transports.test.ts
@@ -24,7 +24,6 @@ function createMockEntry(overrides: Partial<LogEntry> = {}): LogEntry {
     component: "test-component",
     message: "Test message",
     service: "test-service",
-    version: "1.0.0",
     pid: 12345,
     hostname: "test-host",
     ...overrides,


### PR DESCRIPTION
Closes #36.

## Summary

\`@centient/logger\` was silently reserving \`version\` as a logger-instance meta-field and stripping any user-supplied \`version\` from log context — replacing it with \`this.version\` (defaulting to \`\"0.0.0\"\`). This PR removes the reservation. Callers who put \`version\` in context now see it flow through to the emitted entry like any other field.

Only \`service\`, \`component\`, and \`tool\` remain reserved. Everything else — including \`version\` — is caller-owned.

## Why this is safe as a clean removal

**Grep audit: zero callers.** I searched the entire \`centient-labs\` ecosystem for any consumer passing the \`version\` option to the logger factories. Result:

| Repo | Usages of \`createComponentLogger\`/\`createLogger\` | Passing \`version:\` | 
|---|---|---|
| \`centient-labs/centient-sdk\` | 5 internal (events, wal) + tests | 0 |
| \`centient-labs/daemon\` | 5 (cli, client, rate-limiter, web, core) | 0 |
| \`centient-labs/crucible\` | 6 (audit, benchmark, pipeline, discovery, roadmap, paginated-list) | 0 |
| \`centient-labs/centient\` | 5 (entry, Config, SessionBase, promotion-scorer, MetaKnowledgeEncryption) | 0 |
| \`centient-labs/soma\` | 1 (daemon logger singleton) | 0 |
| \`centient-labs/test-kit\` | 3 (mcp, http, containers) | 0 |

Every call is the default 2-arg form \`createComponentLogger(service, component)\`. Per the review discussion on #36, \"zero callers\" resolves to clean removal and a major bump rather than a deprecation shim.

## API changes

### Removed
- \`LoggerOptions.version?: string\` (option no longer accepted)
- \`LogEntry.version: string\` (field no longer emitted)
- \`createTestLogger\`'s internal \`version: \"0.0.0-test\"\` default

### Behavior changes
- \`Logger.ts::buildEntry\` no longer strips \`version\` from sanitized context.
- \`format.ts::formatPretty\` no longer strips \`version\` from pretty-mode output — if you pass it in context, it appears in the tail like \`version=1.2.3\`.
- Child loggers no longer propagate the defunct \`this.version\`.

### Unchanged
- \`service\`, \`component\`, \`tool\` still reserved (they're genuinely logger-level identity and nobody complained about them).
- \`timestamp\`, \`level\`, \`message\`, \`pid\`, \`hostname\` still always-computed top-level fields.

## Migration

- Passing \`{ version: \"...\" }\` to any factory: **remove it.** The value wasn't appearing usefully in logs anyway. If you want per-line service version, put it in context: \`logger.info({ appVersion: \"1.2.3\" }, \"...\")\`.
- Reading \`entry.version\` on a captured \`LogEntry\`: the field is now \`undefined\` unless the caller explicitly put it in context. Use \`entry.service\` for emitter identity.
- Log-output parsers that expect a top-level JSON \`version\` field: adjust them. Nobody was parsing \`version=0.0.0\` usefully, but it's worth signaling.

## Scope

\`@centient/logger::AuditWriter\` has an equivalent \`this.version\` field on audit events (AuditWriter.ts:45, 57, 288). That's a **different concern**: audit events are a versioned schema payload, not a user-context field — callers don't pass \`version\` into audit events the same way they pass it into log context. I'm leaving AuditWriter alone here; if we want to re-examine it, that's a separate issue.

## Convention

The README now suggests \`appVersion\` as the centient-labs ecosystem convention (matches what \`@centient-labs/daemon\` already uses), but makes clear the logger doesn't enforce anything — pick whatever name is unambiguous to your log consumer.

## Verification

- Build: ✅ (workspace-wide)
- Lint: ✅ (tsc \`--noEmit\` across all packages)
- Tests: ✅ **481 pass, 14 skipped** (14 skipped are perf-gated per #32)
- Zero downstream compile breaks — the \`LogEntry\` type change is absorbed by the existing \`[key: string]: unknown\` index signature in consumer code.

## Post-merge

After this lands, the \`@centient-labs/daemon\` agent will bump its \`@centient/logger\` dep in a follow-up patch. The daemon is keeping \`appVersion\` as its field name (not reverting to \`version\`) — agreed in review: the constraint produced a more semantically-precise name, worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)