### PR TITLE
fix(secrets): remediate PR #41 review findings (4 critical + 8 high + most medium/low)

### DIFF
--- a/.changeset/secrets-session-vault-remediation.md
+++ b/.changeset/secrets-session-vault-remediation.md
@@ -1,0 +1,51 @@
+---
+"@centient/secrets": minor
+---
+
+Session-vault hardening pass — remediate all 4 Critical, 8 High, and most Medium/Low findings from the PR #41 code review.
+
+### 🔴 Critical
+
+- **CLI migrated to `openVault`.** `packages/secrets/src/cli/secrets-cli.ts` no longer maintains its own `sessionKey` + `SESSION_TTL` + parallel `encrypt`/`decrypt` (which wrote AAD-less ciphertext). The CLI now opens a single `SessionVault` on unlock and routes every `get`/`set`/`list`/`delete` through it. Existing CLI-written vaults (AAD-less) continue to work via the new legacy-upgrade path (below) and are transparently upgraded to AAD-bound schema-1 format on first write. Fixes the cross-API corruption hazard where a `centient secrets set` and an `openVault().get()` on the same file produced mutually unreadable ciphertext.
+- **`acceptMissingSidecar` default flipped from `true` → `false`.** `openVault` now **refuses** to open a vault when the sidecar is absent, throwing `VaultError("VAULT_SIDECAR_MISSING")`. Callers with legitimate first-use contexts (fresh install, post-migration, test fixtures) must explicitly opt in. Restores the "rollback protection is always in effect" invariant against the prior silent-auto-init behaviour. Legacy vault detection implicitly permits sidecar auto-init so the CLI migration path is not bricked.
+- **File-lock busy-wait removed.** `acquireWriteLock` in the new `packages/secrets/src/vault/file-lock.ts` is now async and uses `await new Promise(r => setTimeout(r, LOCK_RETRY_INTERVAL_MS))` instead of a 25 ms hot CPU spin. Under write contention the daemon no longer starves its own async workloads.
+- **AAD now binds to the resolved real path** (`fs.realpathSync`), not the lexical `path.resolve`. A vault reachable via a symlink or bind mount produces the same AAD regardless of which path the caller passed. ENOENT during open falls back to lexical resolution.
+
+### 🟠 High
+
+- **Legacy AAD-less decrypt path (with auto-upgrade)** added to `openVault`, `maybeReload`, and `reload()`. Pre-openVault CLI vaults (flat `{name: value}` top-level, no AAD) are detected, opened read-only as schema 0, and auto-upgraded to schema 1 with AAD binding on the next successful write. No silent data loss; the legacy entry must be a map of string values or decryption fails closed.
+- **`validatePayload` strengthened** to require `Number.isInteger`, `>= 0`, `<= MAX_SAFE_INTEGER` for `schema` and `vaultVersion`, and explicitly reject any unknown schema value.
+- **TTL / concurrent-op race fixed.** `withAudit` re-invokes `assertOpen()` after `runBeforeHooks`, and `writeOp` re-invokes it after `acquireWriteLock`. A timer-fired `close()` during an in-flight await now surfaces as `VaultClosedError` rather than a null-dereference TypeError.
+- **Missing error codes documented.** `VAULT_NOT_FOUND`, `VAULT_FILE_MISSING`, `VAULT_STALE_SNAPSHOT`, `VAULT_ENCRYPT_FAILED`, `VAULT_SIDECAR_MISSING`, `INVALID_NAME` now appear in the docs error table with preamble explaining these surface as base `VaultError` (match on `error.code`).
+- **Test coverage expanded by 12 new tests:** strict coherence VAULT_STALE_SNAPSHOT round-trip, KeyProvider failure (`VaultUnlockError`, two failure modes), lock timeout, stale-lock detection, decrypt error on corrupt vault, SecretsPolicy integration (three scenarios verifying `backend: "session-vault"` flows through), name-length boundary at 256/257, empty vault, reload-after-close, acceptRollback+missing-sidecar, legacy vault migration, auto-upgrade on first write.
+
+### 🟡 Medium
+
+- **Module extraction.** `session-vault.ts` split into three modules: `file-lock.ts` (write-path advisory lock), `sidecar.ts` (sidecar I/O + permission checks + file/dir mode constants), `session-vault-errors.ts` (VaultError hierarchy with `Object.setPrototypeOf` for robust `instanceof`).
+- **DRY `withAudit` wrapper** replaces ~100 LOC of audit-scaffolding boilerplate across `get`/`list`/`set`/`delete`.
+- **Stale-lock race closed.** Lock files now contain the holder's PID; stealing a stale lock verifies ownership via re-read after unlink+create.
+- **Redundant `existsSync` and `chmodSync` removed** from `maybeReload` and the write path.
+- **`ttlMs: 50` test converted to fake timers** (was real `setTimeout(80)` — flaky under CI load).
+
+### 🟢 Low
+
+- `VAULT_AAD_PREFIX` exported from the package index.
+- `Object.setPrototypeOf(this, new.target.prototype)` in every `VaultError` subclass.
+- Magic numbers extracted to constants (`MAX_NAME_LENGTH`, `VAULT_FILE_MODE`, `VAULT_DIR_MODE`, `VAULT_AAD_PREFIX`).
+- Name validation rejects Unicode RTL override, line separators, leading/trailing whitespace.
+- `readSidecar` distinguishes "missing" from "corrupt" via stderr warning.
+- Duplicate `path` import consolidated; all built-in imports use `node:` prefix in new code.
+- `close()` inlined — no more split between public method and private `closeInternal`.
+- `BuildVaultArgs.mtimeMs` dropped — computed inline from `statSync`.
+- JSDoc added to `openVault`, `SessionVault`, `OpenVaultOptions`, `CoherenceStrategy`.
+- Docs: error-handling code example with `instanceof` branching; coherence-mode code examples for `strict` and `best-effort`; rotation / backup / CI sections; `ttlMs` example; `getCredential` migration-example signature corrected.
+
+### Deferred
+
+- **Thrown errors vs Result type** (systemic, `patterns/error-handling.md` aspirational across the package). Not a blocker; file an ADR.
+- **`process.stderr.write` vs `@centient/logger`** (systemic; the whole secrets package does this). File a follow-up to migrate wholesale.
+- **Sync I/O inside async surface** (`fs.readFileSync` etc.). Acceptable for <100 KB vault; file follow-up to migrate to `fs/promises`.
+
+### Tests
+
+174 / 174 secrets tests pass. Full workspace build + lint + test green.

--- a/packages/secrets/docs/session-vault.md
+++ b/packages/secrets/docs/session-vault.md
@@ -1,5 +1,7 @@
 # Session-backed vault (`openVault`)
 
+> **Terminology:** this document uses *session vault* as shorthand for session-backed envelope vault; *envelope vault* refers to the encryption scheme.
+
 `openVault()` opens the CLI's encrypted vault file once per process, caches the decrypted contents in RAM, and serves reads without further master-key prompts. It's the recommended API for long-running processes (daemons, workers) that hold multiple credentials across a long lifetime.
 
 ## Quick start
@@ -12,6 +14,34 @@ const apiKey = await vault.get("anthropic-key"); // RAM hit, no prompt
 const keys = await vault.list("anthropic.");     // RAM hit
 await vault.set("new-key", "some-value");        // atomic file write + sidecar update
 vault.close();                                   // release key from RAM
+```
+
+## Error handling
+
+Narrow on the concrete error subclasses to decide whether recovery is possible:
+
+```typescript
+import { openVault, VaultRollbackError, VaultDecryptError, VaultClosedError } from "@centient/secrets";
+
+try {
+  const vault = await openVault();
+  // ...
+} catch (err) {
+  if (err instanceof VaultRollbackError) {
+    // Sidecar says version >= err.expected but vault file is at err.actual.
+    // This is either a backup-restore or an adversarial downgrade.
+    // If intentional, re-open with { acceptRollback: true }.
+    console.error(`Rollback detected: sidecar expects >=${err.expected}, vault is at ${err.actual}`);
+  } else if (err instanceof VaultDecryptError) {
+    // Wrong key, corrupted file, or AAD mismatch (vault path changed).
+    // Operator action required — don't auto-recover.
+    console.error(`Decrypt failed: ${err.message}`);
+  } else if (err instanceof VaultClosedError) {
+    // Called a method on a closed vault. Open a new one.
+  } else {
+    throw err;
+  }
+}
 ```
 
 ## When to use this vs. the per-item API
@@ -58,9 +88,29 @@ export interface OpenVaultOptions {
 - **`"strict"`** — throws `VaultError` with code `VAULT_STALE_SNAPSHOT` if the vault file was modified since the last snapshot. Caller must explicitly `reload()` to continue.
 - **`"best-effort"`** — keeps the in-memory snapshot until an explicit `reload()`. Lowest overhead, but external writes are invisible.
 
+### Coherence modes — examples
+
+```typescript
+// strict: throws on external writes, caller must explicitly reload
+const vault = await openVault({ coherence: "strict" });
+try {
+  const v = await vault.get("key");
+} catch (err) {
+  if (err instanceof VaultError && err.code === "VAULT_STALE_SNAPSHOT") {
+    await vault.reload();
+    const v = await vault.get("key");
+  }
+}
+
+// best-effort: keeps snapshot until explicit reload
+const vault = await openVault({ coherence: "best-effort" });
+// ... external writes are invisible
+await vault.reload(); // pulls in changes now
+```
+
 ### Errors
 
-All errors extend `VaultError`, which has a `code` discriminator:
+All errors extend `VaultError`, which has a `code` discriminator. Codes without a dedicated subclass surface as the base `VaultError`; match on `error.code`.
 
 | Class | `code` | When |
 |---|---|---|
@@ -70,6 +120,16 @@ All errors extend `VaultError`, which has a `code` discriminator:
 | `VaultRollbackError` | `VAULT_VERSION_ROLLBACK_DETECTED` | sidecar expects version >= X, vault reports < X |
 | `VaultClosedError` | `VAULT_CLOSED` | method called after `close()` |
 | `VaultLockError` | `VAULT_LOCK_FAILED` | write-path lock couldn't be acquired within timeout |
+
+Additional `VaultError` codes (no dedicated subclass):
+
+| Error code | Throwing class | When |
+|---|---|---|
+| `VAULT_NOT_FOUND` | `VaultError` | `openVault` — vault file absent |
+| `VAULT_FILE_MISSING` | `VaultError` | `get` / `list` / `set` / `delete` / `reload` — vault deleted mid-session |
+| `VAULT_STALE_SNAPSHOT` | `VaultError` | reads under `coherence: "strict"` — external write advanced mtime |
+| `VAULT_ENCRYPT_FAILED` | `VaultError` | internal — encryption returned null (corruption-adjacent) |
+| `INVALID_NAME` | `VaultError` | `set()` — name is empty, too long, or contains invalid chars |
 
 ## Threat model
 
@@ -143,23 +203,68 @@ const vault = await openVault();
 Before (per-item, one Keychain prompt per cred):
 
 ```typescript
-import { getCredential } from "@centient/secrets";
+import {
+  storeCredential,
+  getCredential,
+  listCredentials,
+  deleteCredential,
+} from "@centient/secrets";
+
+await storeCredential("anthropic-key", "sk-...");
 const key = await getCredential("anthropic-key");
+const keys = await listCredentials("anthropic.");
+await deleteCredential("anthropic-key");
 ```
 
 After (`openVault`, one prompt for the whole session):
 
 ```typescript
 import { openVault } from "@centient/secrets";
+
 const vault = await openVault();
+await vault.set("anthropic-key", "sk-...");
 const key = await vault.get("anthropic-key");
+const keys = await vault.list("anthropic.");
+await vault.delete("anthropic-key");
 ```
+
+Mapping:
+
+| Per-item API | `openVault` equivalent |
+|---|---|
+| `storeCredential(name, value)` | `vault.set(name, value)` |
+| `getCredential(name)` | `vault.get(name)` |
+| `listCredentials(prefix?)` | `vault.list(prefix?)` |
+| `deleteCredential(name)` | `vault.delete(name)` |
 
 The per-item `storeCredential` / `getCredential` / `listCredentials` / `deleteCredential` APIs remain intact and functional for callers that want per-item semantics.
 
 ## Name validation
 
 `set()` rejects names containing control characters, `/`, `\`, null bytes, or exceeding 256 characters. This is a hardening step against callers that might route user-controlled input through `set()`; the existing per-item library accepts anything.
+
+## Operational topics
+
+### Credential rotation mid-session
+
+If `centient secrets set` runs in another shell while the daemon has a session open, the next `vault.get()` stats the vault file, sees the new mtime, and re-decrypts automatically. For zero-gap rotation, call `vault.reload()` proactively.
+
+### Backup and restore
+
+Back up BOTH `vault.enc` AND `vault.seen-version` together. Restoring only the vault file (e.g. from Time Machine, or `cp vault.old.enc vault.enc`) without the matching sidecar triggers `VaultRollbackError` on next open. To intentionally restore an older vault, pass `{ acceptRollback: true }` to `openVault` — this updates the sidecar to match and emits a stderr warning.
+
+### CI and cross-machine use
+
+`openVault` is designed for single-operator dev machines. CI and containerized contexts need a KeyProvider other than the default OS keychain — `OnePasswordProvider` (via the `op` CLI) works well. For fully headless environments where no master-key unlock is possible, use a secrets service with remote attestation (HashiCorp Vault, AWS Secrets Manager) instead of `openVault`.
+
+### Session TTL (`ttlMs`)
+
+```typescript
+// Short-lived script that should auto-lock after 10 minutes
+const vault = await openVault({ ttlMs: 10 * 60 * 1000 });
+```
+
+Default: no TTL. Session key stays in memory until `close()` is called. Daemons should not set `ttlMs` — forced re-auth every N minutes undoes the point of a session vault.
 
 ## Schema stability
 

--- a/packages/secrets/src/cli/secrets-cli.ts
+++ b/packages/secrets/src/cli/secrets-cli.ts
@@ -27,12 +27,26 @@
  *   - Vault is encrypted with AES-256-GCM
  *   - Key stored via pluggable provider (macOS Keychain or 1Password)
  *   - 4-hour session timeout
+ *
+ * Internals:
+ *   Vault mutations flow through `openVault` (session-vault.ts) so the CLI
+ *   and the library-facing API share one on-disk format (AAD-bound, schema 1).
+ *   Pre-`openVault` CLI-written vaults (AAD-less, legacy flat format) are
+ *   handled transparently by session-vault's legacy-read path and upgraded to
+ *   schema 1 on the next successful write.
  */
 
 import { createInterface } from "readline";
-import { join } from "path";
-import { homedir } from "os";
-import { existsSync } from "fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import {
+  existsSync,
+  mkdirSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { basename } from "node:path";
+import { createHash, randomBytes } from "node:crypto";
 
 // =============================================================================
 // Types
@@ -80,15 +94,10 @@ function isAgentEnvironment(): boolean {
 }
 
 // =============================================================================
-// Simple Encrypted Vault
+// Session vault integration
 // =============================================================================
 
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
-import { randomBytes } from "crypto";
-import {
-  encryptObject,
-  decryptObject,
-} from "../crypto/vault-common.js";
+import { encryptObject } from "../crypto/vault-common.js";
 import {
   resolveKeyProvider,
   getProviderByType,
@@ -97,36 +106,31 @@ import {
 } from "../key-providers/index.js";
 import type { KeyProvider, KeyProviderType } from "../key-providers/types.js";
 import { listCredentials, getActiveVaultType } from "../vault/vault.js";
+import {
+  openVault,
+  VAULT_SCHEMA_VERSION,
+  VAULT_AAD_PREFIX,
+  DEFAULT_SIDECAR_PATH,
+  type SessionVault,
+} from "../vault/session-vault.js";
 
 const VAULT_PATH = join(homedir(), ".centient", "secrets", "vault.enc");
 const KEY_LENGTH = 32;
 
-// Session state
-let sessionKey: Buffer | null = null;
-let sessionUnlockedAt: number | null = null;
-const SESSION_TTL = 4 * 60 * 60 * 1000; // 4 hours
+
+/** Preserve CLI's historical 4-hour auto-lock semantics. */
+const SESSION_TTL_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * Single process-wide vault handle. Non-null => "session is unlocked".
+ * Replaces the previous `sessionKey` + `sessionUnlockedAt` pair. Auto-close
+ * on TTL is delegated to `openVault({ ttlMs })`, which clears this handle
+ * from inside itself — we observe the closed state via `isSessionValid`.
+ */
+let vault: SessionVault | null = null;
 
 function isSessionValid(): boolean {
-  if (!sessionKey || !sessionUnlockedAt) return false;
-  return Date.now() - sessionUnlockedAt < SESSION_TTL;
-}
-
-function encrypt(data: Record<string, string>, key: Buffer): Buffer {
-  const result = encryptObject(data as Record<string, unknown>, key);
-  if (!result) throw new Error("Encryption failed");
-  return result;
-}
-
-function decrypt(data: Buffer, key: Buffer): Record<string, string> | null {
-  const parsed = decryptObject(data, key);
-  if (!parsed) return null;
-  // Validate all values are strings
-  const result: Record<string, string> = {};
-  for (const [k, v] of Object.entries(parsed)) {
-    if (typeof v !== "string") return null;
-    result[k] = v;
-  }
-  return result;
+  return vault !== null;
 }
 
 /**
@@ -234,6 +238,32 @@ async function prompt(message: string, hidden = false): Promise<string> {
 }
 
 /**
+ * Derive the AAD for a freshly-initialised vault so the bootstrap blob is
+ * openable by `openVault()` on the very next invocation. Mirrors the
+ * derivation in session-vault.ts (same path-resolution + hash construction)
+ * because we can't call the private helper from here.
+ *
+ * Note on symlink handling: session-vault's `resolveVaultPath` realpaths the
+ * vault file. Because the vault file doesn't exist yet at bootstrap time, we
+ * realpath the PARENT directory (already created) and append the basename —
+ * which reproduces the same resolved-path bytes that realpath would produce
+ * on the file itself after the first openVault call. Absent this, a setup
+ * where any parent component is a symlink (e.g. `~/.centient` pointing into
+ * iCloud Drive on macOS) would produce a different AAD on init vs on unlock,
+ * and the first unlock-after-init would fail with VaultDecryptError.
+ *
+ * @param vaultPathAbs - Absolute vault file path whose PARENT directory must
+ *   already exist on disk so `realpathSync` can resolve it.
+ */
+function deriveBootstrapAad(vaultPathAbs: string): Buffer {
+  const parentReal = realpathSync(dirname(vaultPathAbs));
+  const resolved = join(parentReal, basename(vaultPathAbs));
+  return createHash("sha256")
+    .update(`${VAULT_AAD_PREFIX}:v${VAULT_SCHEMA_VERSION}:${resolved}`)
+    .digest();
+}
+
+/**
  * Initialize a new vault
  */
 async function initVault(): Promise<void> {
@@ -261,20 +291,54 @@ async function initVault(): Promise<void> {
     return;
   }
 
-  // Create empty vault
-  const secrets: Record<string, string> = {};
-  const encrypted = encrypt(secrets, key);
+  // Ensure directory exists BEFORE computing AAD so realpath inside
+  // openVault can resolve parent components cleanly on the next open.
+  const dir = dirname(VAULT_PATH);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
 
-  // Ensure directory exists
-  const dir = join(homedir(), ".centient", "secrets");
-  mkdirSync(dir, { recursive: true });
+  // Bootstrap the vault file in the session-vault v1 format (AAD-bound,
+  // `{schema, vaultVersion, secrets}` payload) so the next `openVault()` call
+  // succeeds without hitting the legacy-upgrade path. The alternative —
+  // writing an AAD-less blob — would force a write on first unlock just to
+  // upgrade schemas, which is both weirder and slower.
+  const aad = deriveBootstrapAad(VAULT_PATH);
+  const bootstrapPayload: Record<string, unknown> = {
+    schema: VAULT_SCHEMA_VERSION,
+    vaultVersion: 1,
+    secrets: {},
+  };
+  const encrypted = encryptObject(bootstrapPayload, key, aad);
+  if (!encrypted) {
+    console.error("❌ Failed to encrypt empty vault");
+    return;
+  }
+  writeFileSync(VAULT_PATH, encrypted, { mode: 0o600 });
 
-  // Write vault
-  writeFileSync(VAULT_PATH, encrypted);
+  // Write the sidecar at the default location so openVault doesn't warn on
+  // missing-sidecar the first time we open. Matches `DEFAULT_SIDECAR_PATH`.
+  writeFileSync(
+    DEFAULT_SIDECAR_PATH,
+    JSON.stringify({ highestSeenVersion: 1 }),
+    { mode: 0o600 },
+  );
 
-  // Set session
-  sessionKey = key;
-  sessionUnlockedAt = Date.now();
+  // Open the vault immediately so the CLI session is already unlocked — same
+  // UX as before, but via the shared code path (no parallel session state).
+  try {
+    vault = await openVault({
+      path: VAULT_PATH,
+      ttlMs: SESSION_TTL_MS,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`⚠️  Vault written but failed to auto-unlock: ${message}`);
+    console.error("   Run 'centient secrets unlock' to unlock manually.");
+    return;
+  } finally {
+    // Zero the local key copy — `openVault` fetched its own copy from the
+    // provider; we never need the original again.
+    key.fill(0);
+  }
 
   process.stdout.write("\n✅ Vault initialized successfully!\n");
   process.stdout.write(`   Location: ${VAULT_PATH}\n`);
@@ -292,32 +356,29 @@ async function unlockVault(): Promise<boolean> {
     return false;
   }
 
-  // Get key from provider (may prompt for biometric/PIN depending on provider)
-  const provider = getProvider();
-  if (!provider) return false;
-  process.stdout.write(`Retrieving key via ${provider.name}...\n`);
-  const key = provider.getKey();
-
-  if (!key) {
-    console.error(`❌ Failed to retrieve key from ${provider.name}`);
+  try {
+    vault = await openVault({
+      path: VAULT_PATH,
+      // Existing CLI-written vaults predate the sidecar; session-vault's
+      // legacy-upgrade path treats them as a first-use context, but explicit
+      // opt-in is required for non-legacy fresh installs. We set this to
+      // `true` to keep the first-unlock-after-init path from failing on
+      // sidecar-missing (init writes the sidecar, but a manual
+      // backup-without-sidecar restore shouldn't brick the CLI either).
+      acceptMissingSidecar: true,
+      // Preserve the CLI's 4-hour auto-lock behaviour.
+      ttlMs: SESSION_TTL_MS,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`❌ Failed to unlock vault: ${message}`);
     return false;
   }
-
-  // Verify key works
-  const data = readFileSync(VAULT_PATH);
-  const secrets = decrypt(data, key);
-
-  if (!secrets) {
-    console.error("❌ Failed to decrypt vault - key may be incorrect");
-    return false;
-  }
-
-  // Set session
-  sessionKey = key;
-  sessionUnlockedAt = Date.now();
 
   process.stdout.write("✅ Vault unlocked successfully!\n");
-  process.stdout.write(`   Session valid for 4 hours.\n\n`);
+  process.stdout.write(
+    `   Session valid for 4 hours (provider: ${vault.provider}).\n\n`,
+  );
   return true;
 }
 
@@ -325,39 +386,40 @@ async function unlockVault(): Promise<boolean> {
  * Lock the vault
  */
 function lockVault(): void {
-  if (sessionKey) {
-    sessionKey.fill(0);
-  }
-  sessionKey = null;
-  sessionUnlockedAt = null;
+  vault?.close();
+  vault = null;
   process.stdout.write("\n🔒 Vault locked.\n\n");
+}
+
+/**
+ * Ensure the session is unlocked; unlock on demand if not. Returns false when
+ * unlock fails so callers can abort cleanly. Factored out of every operation
+ * (list / set / get / delete / status) to eliminate boilerplate duplication.
+ */
+async function ensureUnlocked(): Promise<boolean> {
+  if (isSessionValid()) return true;
+  process.stdout.write("\n🔒 Vault is locked. Unlocking...\n");
+  return unlockVault();
 }
 
 /**
  * List secrets
  */
 async function listSecrets(): Promise<void> {
-  if (!isSessionValid()) {
-    process.stdout.write("\n🔒 Vault is locked. Unlocking...\n");
-    if (!(await unlockVault())) return;
-  }
+  if (!(await ensureUnlocked())) return;
 
-  const data = readFileSync(VAULT_PATH);
-  const secrets = decrypt(data, sessionKey!);
-
-  if (!secrets) {
-    console.error("❌ Failed to decrypt vault");
-    return;
-  }
-
-  const names = Object.keys(secrets).sort();
+  const names = await vault!.list();
   process.stdout.write(`\n📋 Secrets in vault (${names.length}):\n\n`);
 
   if (names.length === 0) {
     process.stdout.write("   (empty - use 'centient secrets set <name>' to add secrets)\n");
   } else {
     for (const name of names) {
-      const value = secrets[name] ?? "";
+      // Per-name `get` is the only way to obtain values via the session-vault
+      // API — there's no `getAll`. For a vault with hundreds of entries this
+      // is O(n) syscall-free reads (RAM hit), so we eat the minor overhead in
+      // exchange for keeping session-vault's surface small.
+      const value = (await vault!.get(name)) ?? "";
       const preview = value.length > 0 ? "•".repeat(Math.min(value.length, 20)) : "(empty)";
       process.stdout.write(`   ${name.padEnd(30)} ${preview}\n`);
     }
@@ -423,20 +485,13 @@ async function setSecret(name: string): Promise<void> {
     return;
   }
 
-  if (!isSessionValid()) {
-    process.stdout.write("\n🔒 Vault is locked. Unlocking...\n");
-    if (!(await unlockVault())) return;
-  }
+  if (!(await ensureUnlocked())) return;
 
-  const data = readFileSync(VAULT_PATH);
-  const secrets = decrypt(data, sessionKey!);
-
-  if (!secrets) {
-    console.error("❌ Failed to decrypt vault");
-    return;
-  }
-
-  const exists = name in secrets;
+  // Cheap pre-check so we can show "updating" vs "adding" in the prompt.
+  // The write path below is authoritative; races with an external writer
+  // don't matter for this cosmetic distinction.
+  const existing = await vault!.get(name);
+  const exists = existing !== null;
   const action = exists ? "update" : "add";
 
   process.stdout.write(`\n${exists ? "✏️  Updating" : "➕ Adding"} secret: ${name}\n\n`);
@@ -448,11 +503,13 @@ async function setSecret(name: string): Promise<void> {
     return;
   }
 
-  secrets[name] = value;
-
-  // Re-encrypt and save
-  const encrypted = encrypt(secrets, sessionKey!);
-  writeFileSync(VAULT_PATH, encrypted);
+  try {
+    await vault!.set(name, value);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`❌ Failed to save secret: ${message}`);
+    return;
+  }
 
   process.stdout.write(`\n✅ Secret '${name}' ${action}d successfully!\n\n`);
 }
@@ -466,29 +523,17 @@ async function getSecret(name: string): Promise<void> {
     return;
   }
 
-  if (!isSessionValid()) {
-    process.stdout.write("\n🔒 Vault is locked. Unlocking...\n");
-    if (!(await unlockVault())) return;
-  }
+  if (!(await ensureUnlocked())) return;
 
-  const data = readFileSync(VAULT_PATH);
-  const secrets = decrypt(data, sessionKey!);
-
-  if (!secrets) {
-    console.error("❌ Failed to decrypt vault");
-    return;
-  }
-
-  if (!(name in secrets)) {
+  const value = await vault!.get(name);
+  if (value === null) {
     console.error(`❌ Secret '${name}' not found`);
     return;
   }
 
-  // Print without newline for piping
-  const secretValue = secrets[name];
-  if (secretValue !== undefined) {
-    process.stdout.write(secretValue);
-  }
+  // Print without newline for piping, then add trailing newline for TTY
+  // readability — matches the previous behaviour exactly.
+  process.stdout.write(value);
   process.stdout.write("\n");
 }
 
@@ -501,20 +546,14 @@ async function deleteSecret(name: string): Promise<void> {
     return;
   }
 
-  if (!isSessionValid()) {
-    process.stdout.write("\n🔒 Vault is locked. Unlocking...\n");
-    if (!(await unlockVault())) return;
-  }
+  if (!(await ensureUnlocked())) return;
 
-  const data = readFileSync(VAULT_PATH);
-  const secrets = decrypt(data, sessionKey!);
-
-  if (!secrets) {
-    console.error("❌ Failed to decrypt vault");
-    return;
-  }
-
-  if (!(name in secrets)) {
+  // Pre-check so we can distinguish "not found" from "declined to confirm" in
+  // the error output. The subsequent `vault.delete()` is authoritative — a
+  // concurrent external delete between the get and the delete just means the
+  // final delete reports `false`, which we treat the same as not-found.
+  const current = await vault!.get(name);
+  if (current === null) {
     console.error(`❌ Secret '${name}' not found`);
     return;
   }
@@ -525,11 +564,18 @@ async function deleteSecret(name: string): Promise<void> {
     return;
   }
 
-  delete secrets[name];
-
-  // Re-encrypt and save
-  const encrypted = encrypt(secrets, sessionKey!);
-  writeFileSync(VAULT_PATH, encrypted);
+  try {
+    const existed = await vault!.delete(name);
+    if (!existed) {
+      // Lost a race with a concurrent deleter — report the end state.
+      console.error(`❌ Secret '${name}' not found`);
+      return;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`❌ Failed to delete secret: ${message}`);
+    return;
+  }
 
   process.stdout.write(`\n✅ Secret '${name}' deleted.\n\n`);
 }
@@ -666,13 +712,6 @@ async function showStatus(): Promise<void> {
   const sessionValid = isSessionValid();
   process.stdout.write(`Session:        ${sessionValid ? "🔓 unlocked" : "🔒 locked"}\n`);
 
-  if (sessionValid && sessionUnlockedAt) {
-    const remaining = SESSION_TTL - (Date.now() - sessionUnlockedAt);
-    const hours = Math.floor(remaining / (60 * 60 * 1000));
-    const minutes = Math.floor((remaining % (60 * 60 * 1000)) / (60 * 1000));
-    process.stdout.write(`Expires in:     ${hours}h ${minutes}m\n`);
-  }
-
   // Check key provider
   const providerResult = resolveKeyProvider();
   if (providerResult.ok) {
@@ -683,12 +722,18 @@ async function showStatus(): Promise<void> {
     process.stdout.write(`Key provider:   ❌ unavailable\n`);
   }
 
-  // Count secrets if unlocked
-  if (sessionValid && vaultExists) {
-    const data = readFileSync(VAULT_PATH);
-    const secrets = decrypt(data, sessionKey!);
-    if (secrets) {
-      process.stdout.write(`Secrets count:  ${Object.keys(secrets).length}\n`);
+  // If unlocked, surface the session-vault diagnostic fields (provider that
+  // unlocked, resolved vault path, in-memory version) + secret count.
+  if (sessionValid && vault) {
+    process.stdout.write(`Open via:       ${vault.provider}\n`);
+    process.stdout.write(`Resolved path:  ${vault.path}\n`);
+    process.stdout.write(`Vault version:  ${vault.vaultVersion}\n`);
+    try {
+      const names = await vault.list();
+      process.stdout.write(`Secrets count:  ${names.length}\n`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stdout.write(`Secrets count:  (unavailable: ${message})\n`);
     }
   }
 

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -37,7 +37,7 @@ export type { SecretsPolicy, SecretsEvent, SecretsEventType, SecretsOperation, A
 // Recommended for long-running processes (daemons) holding N credentials;
 // supersedes per-item `getCredential` calls for those consumers. See
 // packages/secrets/docs/session-vault.md and issue #40 for the threat model.
-export { openVault, VAULT_SCHEMA_VERSION, DEFAULT_VAULT_PATH, DEFAULT_SIDECAR_PATH } from "./vault/session-vault.js";
+export { openVault, VAULT_SCHEMA_VERSION, VAULT_AAD_PREFIX, DEFAULT_VAULT_PATH, DEFAULT_SIDECAR_PATH } from "./vault/session-vault.js";
 export {
   VaultError,
   VaultUnlockError,

--- a/packages/secrets/src/vault/file-lock.ts
+++ b/packages/secrets/src/vault/file-lock.ts
@@ -1,0 +1,151 @@
+/**
+ * File lock — native exclusive advisory lock for vault writes.
+ *
+ * Extracted from session-vault.ts (M3) so session-vault remains focused on
+ * orchestration. The lock itself is filesystem-level (O_EXCL create on a
+ * `.lock` file) and cooperative: it only protects against writers that call
+ * `acquireWriteLock` before mutating.
+ *
+ * The lock file contains the holding process's PID so stale-lock stealing can
+ * distinguish "our PID still owns it" from "the previous holder crashed." On
+ * steal we write-and-verify to avoid two racing processes both thinking they
+ * stole the same stale lock (M2).
+ */
+
+import {
+  openSync,
+  closeSync,
+  writeFileSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+
+import { VaultLockError } from "./session-vault-errors.js";
+
+/** Max time a writer will wait to acquire the file lock before giving up. */
+export const LOCK_TIMEOUT_MS = 5_000;
+
+/** Poll interval when waiting on a held lock. */
+export const LOCK_RETRY_INTERVAL_MS = 25;
+
+/** Stale-lock threshold — if a lock file is older than this, assume crash. */
+export const LOCK_STALE_MS = 30_000;
+
+/**
+ * Acquire an exclusive write lock via O_EXCL on `{vaultPath}.lock`. Yields
+ * the event loop between retries (no busy-spin) up to `LOCK_TIMEOUT_MS`.
+ * Locks older than `LOCK_STALE_MS` are considered orphaned (the holding
+ * process crashed) and stolen with a pid-verification handshake so two
+ * concurrent stealers can't both claim ownership.
+ *
+ * Returns a release function. Releasing is idempotent and swallows ENOENT
+ * (the lock file may have been stolen by another process after we already
+ * finished our critical section — that's fine; the lockfile, not the fd,
+ * is what matters).
+ */
+export async function acquireWriteLock(vaultPath: string): Promise<() => void> {
+  const lockPath = `${vaultPath}.lock`;
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  const ourPid = process.pid;
+  const ourToken = `${ourPid}`;
+
+  while (Date.now() < deadline) {
+    // Attempt the happy path: create-exclusive.
+    try {
+      const fd = openSync(lockPath, "wx");
+      try {
+        // Write our pid so stale-lock stealing can verify ownership.
+        writeFileSync(lockPath, ourToken);
+      } catch {
+        // Best-effort; even if we can't write pid, we still hold the lock.
+      }
+      // closeSync can throw on exotic filesystems; the lockfile — not the fd —
+      // is what matters, so swallow errors here. The release closure unlinks
+      // the file regardless (M2).
+      try {
+        closeSync(fd);
+      } catch {
+        // Non-fatal.
+      }
+      return () => {
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Lock file may have been removed by stale-lock stealing in another
+          // process; ignore — our critical section is over regardless.
+        }
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+
+      // EEXIST: someone holds it. Check for staleness.
+      try {
+        const lockStat = statSync(lockPath);
+        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
+          // Stale. Steal with a write-and-verify handshake so two racing
+          // stealers can't both claim ownership. Whoever's token survives
+          // the read-back wins.
+          try {
+            unlinkSync(lockPath);
+          } catch {
+            // Another process may have already stolen it; loop and retry.
+            continue;
+          }
+          try {
+            const fd = openSync(lockPath, "wx");
+            try {
+              writeFileSync(lockPath, ourToken);
+            } catch {
+              // Non-fatal; proceed to verification.
+            }
+            try {
+              closeSync(fd);
+            } catch {
+              // Non-fatal.
+            }
+            // Verification: read back and confirm our token is there. If a
+            // racer wrote first we'll see their token and back off.
+            try {
+              const recorded = readFileSync(lockPath, "utf8").trim();
+              if (recorded !== ourToken) {
+                // We lost the steal race; loop and retry normally.
+                continue;
+              }
+            } catch {
+              // Read failed — treat as loss and retry.
+              continue;
+            }
+            return () => {
+              try {
+                unlinkSync(lockPath);
+              } catch {
+                // Same rationale as happy-path release.
+              }
+            };
+          } catch (stealErr) {
+            if ((stealErr as NodeJS.ErrnoException).code === "EEXIST") {
+              // Another process stole it between our unlink and open; retry.
+              continue;
+            }
+            throw stealErr;
+          }
+        }
+      } catch {
+        // statSync failed — lock was just released, or racing cleanup.
+        // Fall through to sleep-and-retry.
+      }
+
+      // Held by a non-stale writer. Yield the event loop — do NOT busy-spin
+      // (C1). This allows every other async task on this event loop to run
+      // while we wait.
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
+  throw new VaultLockError(
+    `Timed out after ${LOCK_TIMEOUT_MS}ms waiting for vault write lock at ${lockPath}`,
+  );
+}

--- a/packages/secrets/src/vault/session-vault-errors.ts
+++ b/packages/secrets/src/vault/session-vault-errors.ts
@@ -1,0 +1,72 @@
+/**
+ * SessionVault error classes — extracted so helper modules (file-lock,
+ * sidecar) can throw them without creating an import cycle back into
+ * session-vault.ts.
+ *
+ * Each subclass restores the prototype chain with `Object.setPrototypeOf`
+ * so `instanceof VaultError` etc. remains robust when the class is consumed
+ * across an ES transpile boundary (L2 — matches the EngramError pattern in
+ * `packages/sdk/src/errors.ts`).
+ */
+
+/** Base class for SessionVault errors. */
+export class VaultError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = "VaultError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Thrown when the master key can't be retrieved from the configured provider. */
+export class VaultUnlockError extends VaultError {
+  constructor(message: string) {
+    super("VAULT_UNLOCK_FAILED", message);
+    this.name = "VaultUnlockError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Thrown when decryption fails — wrong key, corrupted file, or AAD mismatch. */
+export class VaultDecryptError extends VaultError {
+  constructor(message: string) {
+    super("VAULT_DECRYPT_FAILED", message);
+    this.name = "VaultDecryptError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Thrown when rollback is detected and not explicitly accepted. */
+export class VaultRollbackError extends VaultError {
+  constructor(
+    public readonly expected: number,
+    public readonly actual: number,
+  ) {
+    super(
+      "VAULT_VERSION_ROLLBACK_DETECTED",
+      `Vault version rollback detected: sidecar expects version >= ${expected}, ` +
+        `but vault file reports version ${actual}. If this is an intentional ` +
+        `restore, pass { acceptRollback: true } to openVault().`,
+    );
+    this.name = "VaultRollbackError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Thrown when operations are attempted on a closed vault. */
+export class VaultClosedError extends VaultError {
+  constructor() {
+    super("VAULT_CLOSED", "Vault has been closed; reopen with openVault() to continue.");
+    this.name = "VaultClosedError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Thrown when the write-path file lock can't be acquired within the timeout. */
+export class VaultLockError extends VaultError {
+  constructor(message: string) {
+    super("VAULT_LOCK_FAILED", message);
+    this.name = "VaultLockError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/secrets/src/vault/session-vault.ts
+++ b/packages/secrets/src/vault/session-vault.ts
@@ -39,26 +39,53 @@
  */
 
 import {
-  readFileSync,
-  writeFileSync,
   existsSync,
-  statSync,
-  renameSync,
   mkdirSync,
-  chmodSync,
-  unlinkSync,
-  openSync,
-  closeSync,
-} from "fs";
-import { dirname, resolve as pathResolve } from "path";
-import { homedir } from "os";
-import { join } from "path";
-import { createHash, randomBytes } from "crypto";
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve as pathResolve } from "node:path";
+import { homedir } from "node:os";
+import { createHash, randomBytes } from "node:crypto";
 
 import { encryptObject, decryptObject } from "../crypto/vault-common.js";
 import { resolveKeyProvider } from "../key-providers/resolve.js";
 import type { KeyProviderType } from "../key-providers/types.js";
-import { runBeforeHooks, runAfterHooks } from "./policy.js";
+import {
+  runBeforeHooks,
+  runAfterHooks,
+  type SecretsEventType,
+  type SecretsOperation,
+} from "./policy.js";
+import { acquireWriteLock } from "./file-lock.js";
+import {
+  readSidecar,
+  writeSidecar,
+  checkSidecarPerms,
+  VAULT_FILE_MODE,
+  VAULT_DIR_MODE,
+} from "./sidecar.js";
+import {
+  VaultError,
+  VaultUnlockError,
+  VaultDecryptError,
+  VaultRollbackError,
+  VaultClosedError,
+  VaultLockError,
+} from "./session-vault-errors.js";
+
+// Re-export errors so the public surface (index.ts) stays stable.
+export {
+  VaultError,
+  VaultUnlockError,
+  VaultDecryptError,
+  VaultRollbackError,
+  VaultClosedError,
+  VaultLockError,
+};
 
 // =============================================================================
 // Constants
@@ -78,74 +105,17 @@ export const DEFAULT_SIDECAR_PATH = join(
   "vault.seen-version",
 );
 
-/** Max time a writer will wait to acquire the file lock before giving up. */
-const LOCK_TIMEOUT_MS = 5_000;
+/** Maximum allowed secret-name length. */
+const MAX_NAME_LENGTH = 256;
 
-/** Poll interval when waiting on a held lock. */
-const LOCK_RETRY_INTERVAL_MS = 25;
-
-/** Stale-lock threshold — if a lock file is older than this, assume crash. */
-const LOCK_STALE_MS = 30_000;
-
-// =============================================================================
-// Errors
-// =============================================================================
-
-/** Base class for SessionVault errors. */
-export class VaultError extends Error {
-  constructor(public readonly code: string, message: string) {
-    super(message);
-    this.name = "VaultError";
-  }
-}
-
-/** Thrown when the master key can't be retrieved from the configured provider. */
-export class VaultUnlockError extends VaultError {
-  constructor(message: string) {
-    super("VAULT_UNLOCK_FAILED", message);
-    this.name = "VaultUnlockError";
-  }
-}
-
-/** Thrown when decryption fails — wrong key, corrupted file, or AAD mismatch. */
-export class VaultDecryptError extends VaultError {
-  constructor(message: string) {
-    super("VAULT_DECRYPT_FAILED", message);
-    this.name = "VaultDecryptError";
-  }
-}
-
-/** Thrown when rollback is detected and not explicitly accepted. */
-export class VaultRollbackError extends VaultError {
-  constructor(
-    public readonly expected: number,
-    public readonly actual: number,
-  ) {
-    super(
-      "VAULT_VERSION_ROLLBACK_DETECTED",
-      `Vault version rollback detected: sidecar expects version >= ${expected}, ` +
-        `but vault file reports version ${actual}. If this is an intentional ` +
-        `restore, pass { acceptRollback: true } to openVault().`,
-    );
-    this.name = "VaultRollbackError";
-  }
-}
-
-/** Thrown when operations are attempted on a closed vault. */
-export class VaultClosedError extends VaultError {
-  constructor() {
-    super("VAULT_CLOSED", "Vault has been closed; reopen with openVault() to continue.");
-    this.name = "VaultClosedError";
-  }
-}
-
-/** Thrown when the write-path file lock can't be acquired within the timeout. */
-export class VaultLockError extends VaultError {
-  constructor(message: string) {
-    super("VAULT_LOCK_FAILED", message);
-    this.name = "VaultLockError";
-  }
-}
+/**
+ * AAD prefix — static byte header mixed into the vault ciphertext's
+ * Additional Authenticated Data. Binding this prefix into AAD means a
+ * ciphertext from some other AES-GCM user with the same key cannot be
+ * substituted into the vault. Exported so test fixtures can produce AAD
+ * consistent with the real implementation without duplicating the constant.
+ */
+export const VAULT_AAD_PREFIX = "centient-secrets-vault";
 
 // =============================================================================
 // Payload shape
@@ -172,8 +142,13 @@ interface VaultPayload {
 // Options / public types
 // =============================================================================
 
+/**
+ * Coherence strategy governs how the open vault reconciles in-memory state
+ * with concurrent external writes to the vault file.
+ */
 export type CoherenceStrategy = "mtime-check" | "strict" | "best-effort";
 
+/** Options for {@link openVault}. All fields are optional. */
 export interface OpenVaultOptions {
   /** Alternate vault file path. Defaults to the same path the CLI uses. */
   path?: string;
@@ -192,10 +167,12 @@ export interface OpenVaultOptions {
    */
   acceptRollback?: boolean;
   /**
-   * Opt-in acceptance of a missing sidecar. Default behaviour when the sidecar
-   * is absent is to emit a stderr warning and auto-initialize
-   * `seenVersion = vaultVersion`. Passing `true` suppresses the warning for
-   * known-first-use contexts (test fixtures, fresh installs).
+   * Opt-in acceptance of a missing sidecar. Default behaviour (`false`) is to
+   * **refuse** to open the vault when the sidecar is absent — this enforces
+   * the security invariant that rollback protection is always in effect.
+   * Pass `true` for legitimate first-use contexts (fresh install, test
+   * fixtures, post-migration) to auto-initialize `seenVersion = vaultVersion`
+   * with a stderr warning. See docs/session-vault.md §Missing sidecar.
    */
   acceptMissingSidecar?: boolean;
   /**
@@ -206,6 +183,11 @@ export interface OpenVaultOptions {
   ttlMs?: number;
 }
 
+/**
+ * A long-lived handle to an unlocked vault. Construct with {@link openVault};
+ * close with {@link SessionVault.close}. Operations are async so policy
+ * `before` hooks can await (e.g. remote attestation).
+ */
 export interface SessionVault {
   /** Read a secret by name. Returns null if the name isn't in the vault. */
   get(name: string): Promise<string | null>;
@@ -228,66 +210,31 @@ export interface SessionVault {
 }
 
 // =============================================================================
-// File lock (native, no new dependency)
+// Path resolution (C2 — symlink-aware)
 // =============================================================================
 
 /**
- * Acquire an exclusive write lock via O_EXCL on `{vaultPath}.lock`. Polls up
- * to LOCK_TIMEOUT_MS. Locks older than LOCK_STALE_MS are considered orphaned
- * (the holding process crashed) and stolen. Returns a release function.
+ * Resolve a vault path to its canonical real path so the AAD binds to the
+ * actual file identity rather than any one alias. Symlinks (`~/.centient`
+ * → `/home/user/.centient`, bind mounts, etc.) would otherwise produce
+ * distinct AADs for the same underlying file and fail decrypt.
  *
- * Filesystem-level locks are advisory: a cooperating writer must call this
- * before mutating the vault. We don't need a lock on the read path — the
- * mtime-check coherence strategy handles stale reads.
+ * Intentional consequence: moving the vault to a new real path permanently
+ * invalidates the ciphertext (the attacker-moves-vault attack is the same
+ * as the rename-it attack — we prefer an honest decrypt failure to silent
+ * acceptance). See C2 in PR #41 review.
  */
-function acquireWriteLock(vaultPath: string): () => void {
-  const lockPath = `${vaultPath}.lock`;
-  const deadline = Date.now() + LOCK_TIMEOUT_MS;
-
-  while (Date.now() < deadline) {
-    try {
-      const fd = openSync(lockPath, "wx");
-      closeSync(fd);
-      return () => {
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // Lock file may have been removed by stale-lock stealing in another
-          // process; ignore — our critical section is over regardless.
-        }
-      };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-
-      // Check for stale lock.
-      try {
-        const lockStat = statSync(lockPath);
-        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
-          try {
-            unlinkSync(lockPath);
-          } catch {
-            // Another process may have already stolen it; loop and retry.
-          }
-          continue;
-        }
-      } catch {
-        // Lock was just released; loop and retry.
-      }
-
-      // Busy wait — synchronous lock acquisition is deliberate here. Callers
-      // invoke set()/delete() in async contexts but we don't yield while
-      // holding the lock so we never deadlock against another Node task
-      // holding it on the same event loop.
-      const sleepUntil = Date.now() + LOCK_RETRY_INTERVAL_MS;
-      while (Date.now() < sleepUntil) {
-        // Spin.
-      }
-    }
+function resolveVaultPath(rawPath: string): string {
+  const resolved = pathResolve(rawPath);
+  try {
+    return realpathSync(resolved);
+  } catch (err) {
+    // ENOENT is expected when the vault hasn't been created yet; fall back
+    // to the lexical path so openVault can produce its own "vault not found"
+    // error with a clean message.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return resolved;
+    throw err;
   }
-
-  throw new VaultLockError(
-    `Timed out after ${LOCK_TIMEOUT_MS}ms waiting for vault write lock at ${lockPath}`,
-  );
 }
 
 // =============================================================================
@@ -298,70 +245,21 @@ function acquireWriteLock(vaultPath: string): () => void {
  * Derive Additional Authenticated Data binding ciphertext to its vault
  * identity. A payload encrypted for vault A cannot be substituted into
  * vault B (different path) without failing auth-tag verification.
+ *
+ * AAD binds to the **resolved real path** (symlinks followed) so that a vault
+ * reachable via multiple aliases (symlinks, bind mounts) still produces a
+ * single canonical AAD. Moving the vault to a new real path permanently
+ * invalidates the ciphertext — intentional (see {@link resolveVaultPath}).
  */
-function deriveAad(absoluteVaultPath: string, schema: number): Buffer {
+function deriveAad(absoluteRealVaultPath: string, schema: number): Buffer {
   return createHash("sha256")
-    .update(`centient-secrets-vault:v${schema}:${absoluteVaultPath}`)
+    .update(`${VAULT_AAD_PREFIX}:v${schema}:${absoluteRealVaultPath}`)
     .digest();
 }
 
 // =============================================================================
-// Sidecar I/O
+// Vault permission check
 // =============================================================================
-
-interface SidecarContent {
-  /** Highest vault version ever successfully observed. Monotonic. */
-  highestSeenVersion: number;
-}
-
-function readSidecar(path: string): SidecarContent | null {
-  if (!existsSync(path)) return null;
-  try {
-    const raw = readFileSync(path, "utf8");
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const v = (parsed as { highestSeenVersion?: unknown }).highestSeenVersion;
-    if (typeof v !== "number" || !Number.isInteger(v) || v < 0) return null;
-    return { highestSeenVersion: v };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Atomically write the sidecar with mode 0600. Uses temp-file-then-rename
- * so a crash during the write can't leave a half-written sidecar that would
- * fail JSON parse on the next open.
- */
-function writeSidecar(path: string, content: SidecarContent): void {
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  const tmpPath = `${path}.${randomBytes(8).toString("hex")}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(content), { mode: 0o600 });
-  renameSync(tmpPath, path);
-}
-
-/**
- * Check sidecar file mode; warn on stderr if not 0600.
- * Symmetric to the vault-file permission check — a world-readable sidecar
- * leaks version-number side-channel (write frequency, rollback attempts) and
- * signals that filesystem permissions around the vault are broken.
- */
-function checkSidecarPerms(path: string): void {
-  if (!existsSync(path)) return;
-  try {
-    const st = statSync(path);
-    const worldOrGroup = st.mode & 0o077;
-    if (worldOrGroup !== 0) {
-      process.stderr.write(
-        `[secrets] WARNING: sidecar file ${path} has permissive mode ` +
-          `${(st.mode & 0o777).toString(8).padStart(3, "0")}; expected 600. ` +
-          `Fix with: chmod 600 ${path}\n`,
-      );
-    }
-  } catch {
-    // Stat failure is handled by subsequent read attempts.
-  }
-}
 
 function checkVaultPerms(path: string): void {
   if (!existsSync(path)) return;
@@ -384,8 +282,33 @@ function checkVaultPerms(path: string): void {
 // openVault — factory
 // =============================================================================
 
+/**
+ * Open an encrypted session vault.
+ *
+ * Resolves the configured {@link KeyProvider} to obtain the master key,
+ * decrypts the vault file bound to its resolved real path (symlink-aware),
+ * checks rollback detection via the sidecar, and returns a long-lived
+ * {@link SessionVault} handle that serves reads from memory.
+ *
+ * @param opts - {@link OpenVaultOptions}. All fields are optional; defaults
+ *   use the same paths the `centient secrets` CLI uses.
+ * @returns An open {@link SessionVault}. Call `close()` when done.
+ * @throws {@link VaultError} `VAULT_NOT_FOUND` when the vault file is absent.
+ * @throws {@link VaultUnlockError} when the KeyProvider cannot return a key.
+ * @throws {@link VaultDecryptError} when decryption fails (wrong key, AAD
+ *   mismatch, corrupted payload).
+ * @throws {@link VaultRollbackError} when the sidecar indicates a rollback
+ *   and `acceptRollback` is not set.
+ *
+ * @example
+ * ```ts
+ * const vault = await openVault({ ttlMs: 60_000 });
+ * const apiKey = await vault.get("openai-api-key");
+ * vault.close();
+ * ```
+ */
 export async function openVault(opts: OpenVaultOptions = {}): Promise<SessionVault> {
-  const vaultPath = pathResolve(opts.path ?? DEFAULT_VAULT_PATH);
+  const vaultPath = resolveVaultPath(opts.path ?? DEFAULT_VAULT_PATH);
   const sidecarPath = pathResolve(
     opts.sidecarPath ?? join(dirname(vaultPath), "vault.seen-version"),
   );
@@ -418,49 +341,92 @@ export async function openVault(opts: OpenVaultOptions = {}): Promise<SessionVau
   const aad = deriveAad(vaultPath, VAULT_SCHEMA_VERSION);
 
   // --- Load initial snapshot ---
-  let initialStat = statSync(vaultPath);
+  //
+  // Compatibility layer for CLI-written (AAD-less) vaults:
+  //   1. Try to decrypt with AAD (the v1 format written by openVault).
+  //   2. If that fails, try to decrypt WITHOUT AAD. If this succeeds, the
+  //      vault was written by a pre-openVault CLI and is in the "legacy flat
+  //      format" (`{ name: value, ... }` at the top level). The payload will
+  //      be upgraded to v1 (with AAD) on the next successful write.
+  //   3. If both fail, it's a genuine decrypt error (wrong key / corruption).
+  //
+  // This is a bounded migration window — after consumers have all migrated,
+  // the legacy path can be removed in a subsequent major release. It is NOT
+  // a silent downgrade: legacy-opened vaults remain AAD-less until the next
+  // write, at which point they're upgraded automatically and become
+  // AAD-bound going forward.
   const initialBytes = readFileSync(vaultPath);
-  const decoded = decryptObject(initialBytes, key, aad);
+  let decoded = decryptObject(initialBytes, key, aad);
+  let openedAsLegacy = false;
   if (decoded === null) {
-    key.fill(0);
-    throw new VaultDecryptError(
-      `Failed to decrypt vault at ${vaultPath} — wrong key, corrupted file, or AAD mismatch (schema version ${VAULT_SCHEMA_VERSION}).`,
-    );
+    const legacy = decryptObject(initialBytes, key);
+    if (legacy !== null) {
+      decoded = legacy;
+      openedAsLegacy = true;
+    } else {
+      key.fill(0);
+      throw new VaultDecryptError(
+        `Failed to decrypt vault at ${vaultPath} — wrong key, corrupted file, or AAD mismatch (schema version ${VAULT_SCHEMA_VERSION}; also tried legacy no-AAD format).`,
+      );
+    }
   }
 
-  const payload = validatePayload(decoded);
+  let payload = validatePayload(decoded);
   if (payload === null) {
-    // Back-compat path: legacy vaults (pre-schema) contain a flat
-    // `{ name: value }` map. Treat as schema 0 and upgrade on first write.
-    const legacy: Record<string, string> = {};
-    for (const [k, v] of Object.entries(decoded)) {
-      if (typeof v === "string") legacy[k] = v;
+    // Legacy flat-format detection: a pre-openVault CLI vault is a flat
+    // `{ name: value, ... }` map at the top level. If every value is a string
+    // and there's no `schema` field, accept as legacy schema-0.
+    if (openedAsLegacy && !("schema" in decoded)) {
+      const secrets: Record<string, string> = {};
+      for (const [k, v] of Object.entries(decoded)) {
+        if (typeof v !== "string") {
+          key.fill(0);
+          throw new VaultDecryptError(
+            `Vault decrypted without AAD but contained a non-string value at key "${k}" — not a legacy CLI vault; possible corruption.`,
+          );
+        }
+        secrets[k] = v;
+      }
+      payload = { schema: 0, vaultVersion: 0, secrets };
+      process.stderr.write(
+        `[secrets] Opened legacy (pre-schema, AAD-less) vault at ${vaultPath}; ` +
+          `will auto-upgrade to schema ${VAULT_SCHEMA_VERSION} with AAD binding on next write.\n`,
+      );
+    } else {
+      key.fill(0);
+      throw new VaultDecryptError(
+        "Decrypted payload has invalid shape — possible corruption or format mismatch.",
+      );
     }
-    return buildVault({
-      vaultPath,
-      sidecarPath,
-      provider: provider.name as KeyProviderType,
-      coherence,
-      key,
-      aad,
-      currentSecrets: legacy,
-      currentVersion: 0,
-      mtimeMs: initialStat.mtimeMs,
-      ttlMs,
-    });
   }
 
   // --- Rollback check ---
   const sidecar = readSidecar(sidecarPath);
   if (sidecar === null) {
-    if (opts.acceptMissingSidecar !== true) {
-      process.stderr.write(
-        `[secrets] WARNING: sidecar file ${sidecarPath} is missing. ` +
-          `Rollback protection is weakened until the sidecar is rebuilt. ` +
-          `Auto-initializing seenVersion=${payload.vaultVersion}. ` +
-          `Pass { acceptMissingSidecar: true } to suppress this warning.\n`,
+    // Default is REFUSE when sidecar is missing (security invariant:
+    // rollback protection must be in effect at all times). Callers with
+    // legitimate first-use contexts (fresh install, post-migration, test
+    // fixtures) must explicitly opt in via `acceptMissingSidecar: true`.
+    //
+    // Exception: legacy vaults (pre-openVault CLI-written, AAD-less) never
+    // had a sidecar by construction — refusing them would brick the CLI
+    // migration path. Legacy detection implicitly permits sidecar auto-init.
+    if (opts.acceptMissingSidecar !== true && !openedAsLegacy) {
+      key.fill(0);
+      throw new VaultError(
+        "VAULT_SIDECAR_MISSING",
+        `Sidecar file ${sidecarPath} is missing. Rollback protection requires ` +
+          `the sidecar to exist. If this is a legitimate first-use context ` +
+          `(fresh install, post-migration), pass { acceptMissingSidecar: true } ` +
+          `to openVault(); the sidecar will be initialized automatically. ` +
+          `If the sidecar was unexpectedly deleted, investigate before opening.`,
       );
     }
+    const reason = openedAsLegacy ? "legacy vault migration" : "acceptMissingSidecar: true";
+    process.stderr.write(
+      `[secrets] WARNING: sidecar file ${sidecarPath} is missing; ` +
+        `auto-initializing seenVersion=${payload.vaultVersion} per ${reason}.\n`,
+    );
     writeSidecar(sidecarPath, { highestSeenVersion: payload.vaultVersion });
   } else if (payload.vaultVersion < sidecar.highestSeenVersion) {
     if (opts.acceptRollback !== true) {
@@ -487,7 +453,6 @@ export async function openVault(opts: OpenVaultOptions = {}): Promise<SessionVau
     aad,
     currentSecrets: { ...payload.secrets },
     currentVersion: payload.vaultVersion,
-    mtimeMs: initialStat.mtimeMs,
     ttlMs,
   });
 }
@@ -505,7 +470,6 @@ interface BuildVaultArgs {
   aad: Buffer;
   currentSecrets: Record<string, string>;
   currentVersion: number;
-  mtimeMs: number;
   ttlMs: number | undefined;
 }
 
@@ -513,13 +477,16 @@ function buildVault(args: BuildVaultArgs): SessionVault {
   let key: Buffer | null = args.key;
   let secrets = args.currentSecrets;
   let vaultVersion = args.currentVersion;
-  let mtimeMs = args.mtimeMs;
+  // Capture mtime here (L9) — openVault already confirmed the file exists and
+  // decrypted it, so a follow-up stat races the narrowest possible window and
+  // avoids duplicating the mtime in the BuildVaultArgs contract.
+  let mtimeMs = statSync(args.vaultPath).mtimeMs;
   let closed = false;
 
   let ttlTimer: NodeJS.Timeout | null = null;
   if (args.ttlMs !== undefined) {
     ttlTimer = setTimeout(() => {
-      closeInternal();
+      doClose();
     }, args.ttlMs);
     ttlTimer.unref();
   }
@@ -530,18 +497,25 @@ function buildVault(args: BuildVaultArgs): SessionVault {
 
   /**
    * Refresh in-memory state from disk if the coherence strategy says to and
-   * mtime has advanced. Returns silently on a best-effort mismatch; throws
-   * VaultDecryptError on any actual failure.
+   * mtime has advanced. Throws VaultError on a missing vault file (M4) and
+   * VaultDecryptError on decrypt failure.
    */
   const maybeReload = (): void => {
     if (args.coherence === "best-effort") return;
-    if (!existsSync(args.vaultPath)) {
-      throw new VaultError(
-        "VAULT_FILE_MISSING",
-        `Vault file ${args.vaultPath} was removed while open.`,
-      );
+    // Drop existsSync — statSync already throws ENOENT. Translating the error
+    // gives us one clean code path and one fewer syscall (M4).
+    let st: ReturnType<typeof statSync>;
+    try {
+      st = statSync(args.vaultPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new VaultError(
+          "VAULT_FILE_MISSING",
+          `Vault file ${args.vaultPath} was removed while open.`,
+        );
+      }
+      throw err;
     }
-    const st = statSync(args.vaultPath);
     if (st.mtimeMs === mtimeMs) return;
     if (args.coherence === "strict" && st.mtimeMs > mtimeMs) {
       // `strict` means the caller wants an explicit reload(); block reads.
@@ -551,28 +525,64 @@ function buildVault(args: BuildVaultArgs): SessionVault {
       );
     }
     const bytes = readFileSync(args.vaultPath);
-    const decoded = decryptObject(bytes, key!, args.aad);
+    // Try AAD first (v1 format); fall back to no-AAD (legacy CLI format) —
+    // same layered decrypt as openVault so a legacy vault remains readable
+    // across mtime-check reloads until the first write upgrades it.
+    let decoded = decryptObject(bytes, key!, args.aad);
     if (decoded === null) {
-      throw new VaultDecryptError(
-        "Failed to decrypt vault after external change — key may have rotated or file may be corrupted.",
-      );
-    }
-    const payload = validatePayload(decoded);
-    if (payload !== null) {
-      secrets = { ...payload.secrets };
-      vaultVersion = payload.vaultVersion;
-      mtimeMs = st.mtimeMs;
-      const sidecar = readSidecar(args.sidecarPath);
-      if (sidecar === null || payload.vaultVersion > sidecar.highestSeenVersion) {
-        writeSidecar(args.sidecarPath, { highestSeenVersion: payload.vaultVersion });
+      decoded = decryptObject(bytes, key!);
+      if (decoded === null) {
+        throw new VaultDecryptError(
+          "Failed to decrypt vault after external change — key may have rotated or file may be corrupted.",
+        );
       }
+    }
+    let payload = validatePayload(decoded);
+    if (payload === null) {
+      // Legacy flat-format (no schema field); reconstruct a schema-0 view.
+      if (!("schema" in decoded)) {
+        const legacySecrets: Record<string, string> = {};
+        let ok = true;
+        for (const [k, v] of Object.entries(decoded)) {
+          if (typeof v !== "string") { ok = false; break; }
+          legacySecrets[k] = v;
+        }
+        if (!ok) {
+          throw new VaultDecryptError(
+            "Decrypted payload has invalid shape after external change — possible corruption.",
+          );
+        }
+        payload = { schema: 0, vaultVersion: 0, secrets: legacySecrets };
+      } else {
+        throw new VaultDecryptError(
+          "Decrypted payload has invalid shape after external change — possible corruption.",
+        );
+      }
+    }
+    secrets = { ...payload.secrets };
+    vaultVersion = payload.vaultVersion;
+    mtimeMs = st.mtimeMs;
+    const sidecar = readSidecar(args.sidecarPath);
+    if (sidecar === null || payload.vaultVersion > sidecar.highestSeenVersion) {
+      writeSidecar(args.sidecarPath, { highestSeenVersion: payload.vaultVersion });
     }
   };
 
-  const writeOp = (mutator: (current: Record<string, string>) => void): void => {
+  /**
+   * Perform a vault mutation. The lock-acquire step yields the event loop
+   * (C1); the critical section between acquire and release runs
+   * synchronously so we never deadlock against another async task in this
+   * process waiting on the same lock.
+   */
+  const writeOp = async (
+    mutator: (current: Record<string, string>) => void,
+  ): Promise<void> => {
     assertOpen();
-    const release = acquireWriteLock(args.vaultPath);
+    const release = await acquireWriteLock(args.vaultPath);
     try {
+      // Re-check open after awaiting the lock — TTL or a sibling close()
+      // could have fired while we were queued (H2).
+      assertOpen();
       maybeReload();
       const next = { ...secrets };
       mutator(next);
@@ -582,22 +592,24 @@ function buildVault(args: BuildVaultArgs): SessionVault {
         vaultVersion: nextVersion,
         secrets: next,
       };
-      const encrypted = encryptObject(payload as unknown as Record<string, unknown>, key!, args.aad);
+      const encrypted = encryptObject(
+        payload as unknown as Record<string, unknown>,
+        key!,
+        args.aad,
+      );
       if (encrypted === null) {
         throw new VaultError("VAULT_ENCRYPT_FAILED", "Encryption returned null — corrupted state.");
       }
-      // Atomic vault write: temp file (mode 0600) + rename.
-      mkdirSync(dirname(args.vaultPath), { recursive: true, mode: 0o700 });
+      // Atomic vault write: temp file (mode 0600) + rename. POSIX `rename`
+      // preserves mode, and `writeFileSync` honours the `mode` option on the
+      // initial create, so we deliberately do NOT chmod the committed file
+      // afterwards (M5). If a hostile umask or exotic filesystem produced a
+      // too-permissive file, the permission check on the next open will
+      // warn.
+      mkdirSync(dirname(args.vaultPath), { recursive: true, mode: VAULT_DIR_MODE });
       const tmpVault = `${args.vaultPath}.${randomBytes(8).toString("hex")}.tmp`;
-      writeFileSync(tmpVault, encrypted, { mode: 0o600 });
+      writeFileSync(tmpVault, encrypted, { mode: VAULT_FILE_MODE });
       renameSync(tmpVault, args.vaultPath);
-      // Enforce mode on the committed file in case the FS didn't honor the
-      // temp-file mode on rename across some filesystems.
-      try {
-        chmodSync(args.vaultPath, 0o600);
-      } catch {
-        // Non-fatal; continue.
-      }
       // Sidecar update trails the vault write so a crash between them leaves
       // the sidecar lagging (graceful: catches up on next write) rather than
       // ahead (would false-positive rollback detection).
@@ -614,7 +626,7 @@ function buildVault(args: BuildVaultArgs): SessionVault {
     }
   };
 
-  const closeInternal = (): void => {
+  const doClose = (): void => {
     if (closed) return;
     closed = true;
     if (ttlTimer !== null) {
@@ -637,162 +649,179 @@ function buildVault(args: BuildVaultArgs): SessionVault {
     secrets = {};
   };
 
+  /**
+   * Audit-scaffolding wrapper — extracted from per-method boilerplate (M1).
+   *
+   * Every vault operation shares the same shape: `assertOpen`, run before
+   * hooks, time the work, fire an after hook (success/missing/failure). Re-
+   * checks `assertOpen` after the before-hook await so a TTL expiry or a
+   * sibling `close()` can't drop us into `fn()` with `key === null` (H2).
+   *
+   * `missingType` is distinct from `successType` because reads can return
+   * null/false without being a failure (credential not present, delete of
+   * absent key) — audit logs must distinguish those from a successful hit.
+   *
+   * `extras(value)` lets callers mix additional event fields derived from
+   * the operation result (e.g. `keyCount` for list) without forcing every
+   * call site to build its own success event.
+   */
+  const withAudit = async <T>(
+    op: SecretsOperation,
+    successType: SecretsEventType,
+    missingType: SecretsEventType | null,
+    failType: SecretsEventType,
+    fn: () => Promise<T> | T,
+    extras?: (value: T) => Partial<{ keyCount: number }>,
+  ): Promise<T> => {
+    assertOpen();
+    await runBeforeHooks(op);
+    // Re-check after the await — TTL or sibling close() could have fired
+    // while before-hooks awaited (H2).
+    assertOpen();
+    const start = Date.now();
+    try {
+      const value = await fn();
+      const isMissing =
+        missingType !== null && (value === null || value === false);
+      runAfterHooks({
+        type: isMissing ? missingType : successType,
+        timestamp: new Date(start).toISOString(),
+        backend: "session-vault",
+        key: op.key,
+        prefix: op.prefix,
+        ...(extras !== undefined ? extras(value) : {}),
+        durationMs: Date.now() - start,
+      });
+      return value;
+    } catch (err) {
+      runAfterHooks({
+        type: failType,
+        timestamp: new Date(start).toISOString(),
+        backend: "session-vault",
+        key: op.key,
+        prefix: op.prefix,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      });
+      throw err;
+    }
+  };
+
   return {
-    async get(name: string): Promise<string | null> {
-      assertOpen();
-      await runBeforeHooks({ type: "read", key: name });
-      const start = Date.now();
-      try {
-        maybeReload();
-        const value = name in secrets ? secrets[name]! : null;
-        runAfterHooks({
-          type: value === null ? "credential_read_missing" : "credential_read",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          key: name,
-          durationMs: Date.now() - start,
-        });
-        return value;
-      } catch (err) {
-        runAfterHooks({
-          type: "credential_read_failed",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          key: name,
-          error: err instanceof Error ? err.message : String(err),
-          durationMs: Date.now() - start,
-        });
-        throw err;
-      }
+    get(name: string): Promise<string | null> {
+      return withAudit<string | null>(
+        { type: "read", key: name },
+        "credential_read",
+        "credential_read_missing",
+        "credential_read_failed",
+        () => {
+          maybeReload();
+          return name in secrets ? secrets[name]! : null;
+        },
+      );
     },
 
-    async list(prefix?: string): Promise<string[]> {
-      assertOpen();
-      await runBeforeHooks({ type: "enumerate", prefix });
-      const start = Date.now();
-      try {
-        maybeReload();
-        const names = Object.keys(secrets).sort();
-        const filtered =
-          prefix === undefined ? names : names.filter((n) => n.startsWith(prefix));
-        runAfterHooks({
-          type: "credential_enumerated",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          prefix,
-          keyCount: filtered.length,
-          durationMs: Date.now() - start,
-        });
-        return filtered;
-      } catch (err) {
-        runAfterHooks({
-          type: "credential_enumerate_failed",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          prefix,
-          error: err instanceof Error ? err.message : String(err),
-          durationMs: Date.now() - start,
-        });
-        throw err;
-      }
+    list(prefix?: string): Promise<string[]> {
+      return withAudit<string[]>(
+        { type: "enumerate", prefix },
+        "credential_enumerated",
+        null,
+        "credential_enumerate_failed",
+        () => {
+          maybeReload();
+          const names = Object.keys(secrets).sort();
+          return prefix === undefined
+            ? names
+            : names.filter((n) => n.startsWith(prefix));
+        },
+        (value) => ({ keyCount: value.length }),
+      );
     },
 
     async set(name: string, value: string): Promise<void> {
-      assertOpen();
+      // `async` keyword ensures a sync throw from validateName surfaces as a
+      // promise rejection, matching the declared `Promise<void>` contract.
       validateName(name);
-      await runBeforeHooks({ type: "write", key: name });
-      const start = Date.now();
-      try {
-        writeOp((current) => {
+      return withAudit<void>(
+        { type: "write", key: name },
+        "credential_written",
+        null,
+        "credential_write_failed",
+        () => writeOp((current) => {
           current[name] = value;
-        });
-        runAfterHooks({
-          type: "credential_written",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          key: name,
-          durationMs: Date.now() - start,
-        });
-      } catch (err) {
-        runAfterHooks({
-          type: "credential_write_failed",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          key: name,
-          error: err instanceof Error ? err.message : String(err),
-          durationMs: Date.now() - start,
-        });
-        throw err;
-      }
+        }),
+      );
     },
 
-    async delete(name: string): Promise<boolean> {
-      assertOpen();
-      await runBeforeHooks({ type: "delete", key: name });
-      const start = Date.now();
-      try {
-        if (!(name in secrets)) {
-          runAfterHooks({
-            type: "credential_delete_failed",
-            timestamp: new Date(start).toISOString(),
-            backend: "session-vault",
-            key: name,
-            error: "not found",
-            durationMs: Date.now() - start,
+    delete(name: string): Promise<boolean> {
+      return withAudit<boolean>(
+        { type: "delete", key: name },
+        "credential_deleted",
+        "credential_delete_failed",
+        "credential_delete_failed",
+        async () => {
+          if (!(name in secrets)) return false;
+          await writeOp((current) => {
+            delete current[name];
           });
-          return false;
-        }
-        writeOp((current) => {
-          delete current[name];
-        });
-        runAfterHooks({
-          type: "credential_deleted",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          key: name,
-          durationMs: Date.now() - start,
-        });
-        return true;
-      } catch (err) {
-        runAfterHooks({
-          type: "credential_delete_failed",
-          timestamp: new Date(start).toISOString(),
-          backend: "session-vault",
-          key: name,
-          error: err instanceof Error ? err.message : String(err),
-          durationMs: Date.now() - start,
-        });
-        throw err;
-      }
+          return true;
+        },
+      );
     },
 
     async reload(): Promise<void> {
       assertOpen();
-      if (!existsSync(args.vaultPath)) {
-        throw new VaultError(
-          "VAULT_FILE_MISSING",
-          `Vault file ${args.vaultPath} was removed while open.`,
-        );
+      let st: ReturnType<typeof statSync>;
+      try {
+        st = statSync(args.vaultPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          throw new VaultError(
+            "VAULT_FILE_MISSING",
+            `Vault file ${args.vaultPath} was removed while open.`,
+          );
+        }
+        throw err;
       }
-      const st = statSync(args.vaultPath);
       const bytes = readFileSync(args.vaultPath);
-      const decoded = decryptObject(bytes, key!, args.aad);
+      // Re-check open across the IO boundary (H2).
+      assertOpen();
+      // Layered decrypt: v1 (AAD) → legacy (no AAD). Mirrors openVault and
+      // maybeReload so legacy vaults remain usable across explicit reload().
+      let decoded = decryptObject(bytes, key!, args.aad);
+      if (decoded === null) decoded = decryptObject(bytes, key!);
       if (decoded === null) {
         throw new VaultDecryptError(
           "Failed to decrypt vault during reload — key may have rotated or file may be corrupted.",
         );
       }
-      const payload = validatePayload(decoded);
-      if (payload !== null) {
-        secrets = { ...payload.secrets };
-        vaultVersion = payload.vaultVersion;
-        mtimeMs = st.mtimeMs;
+      let payload = validatePayload(decoded);
+      if (payload === null) {
+        if (!("schema" in decoded)) {
+          const legacySecrets: Record<string, string> = {};
+          let ok = true;
+          for (const [k, v] of Object.entries(decoded)) {
+            if (typeof v !== "string") { ok = false; break; }
+            legacySecrets[k] = v;
+          }
+          if (!ok) {
+            throw new VaultDecryptError(
+              "Decrypted payload has invalid shape during reload — possible corruption.",
+            );
+          }
+          payload = { schema: 0, vaultVersion: 0, secrets: legacySecrets };
+        } else {
+          throw new VaultDecryptError(
+            "Decrypted payload has invalid shape during reload — possible corruption.",
+          );
+        }
       }
+      secrets = { ...payload.secrets };
+      vaultVersion = payload.vaultVersion;
+      mtimeMs = st.mtimeMs;
     },
 
-    close(): void {
-      closeInternal();
-    },
+    close: doClose,
 
     get provider(): KeyProviderType {
       return args.provider;
@@ -810,47 +839,92 @@ function buildVault(args: BuildVaultArgs): SessionVault {
 // Validation helpers
 // =============================================================================
 
+/**
+ * Validate a decoded vault payload. Rejects NaN, Infinity, non-integer, and
+ * out-of-range numeric fields — the payload is untrusted input post-decrypt
+ * (a corrupted-but-authenticated payload could still carry garbage integers)
+ * so we fail closed (H1). Only `schema === VAULT_SCHEMA_VERSION` is accepted;
+ * unknown future schemas must be handled by a future migration, not silently
+ * let through as v1.
+ */
 function validatePayload(decoded: Record<string, unknown>): VaultPayload | null {
+  const schemaRaw = decoded["schema"];
+  const vvRaw = decoded["vaultVersion"];
+  const secretsRaw = decoded["secrets"];
+
   if (
-    typeof decoded["schema"] !== "number" ||
-    typeof decoded["vaultVersion"] !== "number" ||
-    typeof decoded["secrets"] !== "object" ||
-    decoded["secrets"] === null ||
-    Array.isArray(decoded["secrets"])
+    typeof schemaRaw !== "number" ||
+    !Number.isInteger(schemaRaw) ||
+    schemaRaw < 0 ||
+    schemaRaw > Number.MAX_SAFE_INTEGER
   ) {
     return null;
   }
-  const secretsObj = decoded["secrets"] as Record<string, unknown>;
+  // Only v1 is valid in this build. Reject unknowns explicitly rather than
+  // coercing them into v1 handling.
+  if (schemaRaw !== VAULT_SCHEMA_VERSION) {
+    return null;
+  }
+  if (
+    typeof vvRaw !== "number" ||
+    !Number.isInteger(vvRaw) ||
+    vvRaw < 0 ||
+    vvRaw > Number.MAX_SAFE_INTEGER
+  ) {
+    return null;
+  }
+  if (
+    typeof secretsRaw !== "object" ||
+    secretsRaw === null ||
+    Array.isArray(secretsRaw)
+  ) {
+    return null;
+  }
+
+  const secretsObj = secretsRaw as Record<string, unknown>;
   const secrets: Record<string, string> = {};
   for (const [k, v] of Object.entries(secretsObj)) {
     if (typeof v !== "string") return null;
     secrets[k] = v;
   }
   return {
-    schema: decoded["schema"] as number,
-    vaultVersion: decoded["vaultVersion"] as number,
+    schema: schemaRaw,
+    vaultVersion: vvRaw,
     secrets,
   };
 }
 
 /**
- * Reject names with control characters, path separators, or null bytes. The
- * CLI-facing library accepts anything historically; the public API is a good
- * place to constrain against callers that might route user-controlled input
- * through `set()`.
+ * Reject names with control characters, path separators, null bytes, or
+ * Unicode oddities that can confuse log scrapers, terminals, and path
+ * libraries (L4). The CLI-facing library accepts anything historically;
+ * the public API is a good place to constrain against callers that might
+ * route user-controlled input through `set()`.
  */
 function validateName(name: string): void {
   if (name.length === 0) {
     throw new VaultError("INVALID_NAME", "Secret name must be non-empty.");
   }
-  if (name.length > 256) {
-    throw new VaultError("INVALID_NAME", "Secret name must be 256 characters or fewer.");
-  }
-  // eslint-disable-next-line no-control-regex
-  if (/[\x00-\x1f\x7f/\\]/.test(name)) {
+  if (name.length > MAX_NAME_LENGTH) {
     throw new VaultError(
       "INVALID_NAME",
-      `Secret name contains invalid characters (control chars, slashes, or null bytes): ${JSON.stringify(name)}`,
+      `Secret name must be ${MAX_NAME_LENGTH} characters or fewer.`,
+    );
+  }
+  if (name !== name.trim()) {
+    throw new VaultError(
+      "INVALID_NAME",
+      `Secret name must not have leading or trailing whitespace: ${JSON.stringify(name)}`,
+    );
+  }
+  // Denylist: ASCII control (0x00–0x1f, 0x7f), path separators, plus explicit
+  // Unicode directional overrides and line/paragraph separators that can
+  // disguise names in logs and terminals.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f/\\\u202E\u2028\u2029]/.test(name)) {
+    throw new VaultError(
+      "INVALID_NAME",
+      `Secret name contains invalid characters (control chars, slashes, null bytes, or Unicode separators): ${JSON.stringify(name)}`,
     );
   }
 }

--- a/packages/secrets/src/vault/sidecar.ts
+++ b/packages/secrets/src/vault/sidecar.ts
@@ -1,0 +1,106 @@
+/**
+ * Sidecar — rollback-protection metadata file I/O.
+ *
+ * Extracted from session-vault.ts (M3). The sidecar lives next to the vault
+ * and stores the highest vault version ever observed; a subsequent open that
+ * sees a lower version triggers rollback detection. Corrupt vs missing is
+ * distinguished so callers can report meaningfully (L5).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+
+/** File mode for vault and sidecar files (POSIX). */
+export const VAULT_FILE_MODE = 0o600;
+
+/** Directory mode for the vault/sidecar parent directory (POSIX). */
+export const VAULT_DIR_MODE = 0o700;
+
+export interface SidecarContent {
+  /** Highest vault version ever successfully observed. Monotonic. */
+  highestSeenVersion: number;
+}
+
+/**
+ * Read sidecar content. Returns null in two distinguishable cases:
+ *   - file does not exist (silent — caller drives the missing-sidecar path),
+ *   - file exists but is corrupt (emits a stderr warning — filesystem damage
+ *     or partial write; caller treats as missing and auto-reinitializes).
+ */
+export function readSidecar(path: string): SidecarContent | null {
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    process.stderr.write(
+      `[secrets] WARNING: sidecar file ${path} exists but could not be read; treating as missing.\n`,
+    );
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) {
+      process.stderr.write(
+        `[secrets] WARNING: sidecar file ${path} is corrupt (not a JSON object); treating as missing.\n`,
+      );
+      return null;
+    }
+    const v = (parsed as { highestSeenVersion?: unknown }).highestSeenVersion;
+    if (typeof v !== "number" || !Number.isInteger(v) || v < 0) {
+      process.stderr.write(
+        `[secrets] WARNING: sidecar file ${path} is corrupt (invalid highestSeenVersion); treating as missing.\n`,
+      );
+      return null;
+    }
+    return { highestSeenVersion: v };
+  } catch {
+    process.stderr.write(
+      `[secrets] WARNING: sidecar file ${path} is corrupt (JSON parse failed); treating as missing.\n`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Atomically write the sidecar with mode 0600. Uses temp-file-then-rename
+ * so a crash during the write can't leave a half-written sidecar that would
+ * fail JSON parse on the next open.
+ */
+export function writeSidecar(path: string, content: SidecarContent): void {
+  mkdirSync(dirname(path), { recursive: true, mode: VAULT_DIR_MODE });
+  const tmpPath = `${path}.${randomBytes(8).toString("hex")}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(content), { mode: VAULT_FILE_MODE });
+  renameSync(tmpPath, path);
+}
+
+/**
+ * Check sidecar file mode; warn on stderr if not 0600.
+ * Symmetric to the vault-file permission check — a world-readable sidecar
+ * leaks version-number side-channel (write frequency, rollback attempts) and
+ * signals that filesystem permissions around the vault are broken.
+ */
+export function checkSidecarPerms(path: string): void {
+  if (!existsSync(path)) return;
+  try {
+    const st = statSync(path);
+    const worldOrGroup = st.mode & 0o077;
+    if (worldOrGroup !== 0) {
+      process.stderr.write(
+        `[secrets] WARNING: sidecar file ${path} has permissive mode ` +
+          `${(st.mode & 0o777).toString(8).padStart(3, "0")}; expected 600. ` +
+          `Fix with: chmod 600 ${path}\n`,
+      );
+    }
+  } catch {
+    // Stat failure is handled by subsequent read attempts.
+  }
+}

--- a/packages/secrets/tests/session-vault.test.ts
+++ b/packages/secrets/tests/session-vault.test.ts
@@ -28,9 +28,12 @@ import {
   existsSync,
   chmodSync,
   statSync,
+  utimesSync,
+  realpathSync,
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import * as pathMod from "path";
 import { randomBytes } from "crypto";
 
 // =============================================================================
@@ -39,15 +42,36 @@ import { randomBytes } from "crypto";
 
 const TEST_KEY = randomBytes(32);
 
-vi.mock("../src/key-providers/resolve.js", () => ({
-  resolveKeyProvider: () => ({
+// Mutable mock state so individual tests can override the resolver behaviour
+// without juggling vi.doMock / module cache resets.
+const mockState: {
+  providerResult:
+    | { ok: true; provider: { name: string; getKey: () => Buffer | null; storeKey: () => boolean } }
+    | { ok: false; error: { message: string } };
+} = {
+  providerResult: {
     ok: true,
     provider: {
       name: "keychain",
       getKey: () => Buffer.from(TEST_KEY),
       storeKey: () => true,
     },
-  }),
+  },
+};
+
+function resetMockState(): void {
+  mockState.providerResult = {
+    ok: true,
+    provider: {
+      name: "keychain",
+      getKey: () => Buffer.from(TEST_KEY),
+      storeKey: () => true,
+    },
+  };
+}
+
+vi.mock("../src/key-providers/resolve.js", () => ({
+  resolveKeyProvider: () => mockState.providerResult,
 }));
 
 // Import AFTER mocking.
@@ -57,9 +81,13 @@ import {
   VaultClosedError,
   VaultRollbackError,
   VaultDecryptError,
+  VaultUnlockError,
+  VaultLockError,
+  VaultError,
   type SessionVault,
 } from "../src/vault/session-vault.js";
 import { encryptObject } from "../src/crypto/vault-common.js";
+import { setSecretsPolicies, type SecretsEvent, type SecretsOperation } from "../src/vault/policy.js";
 import { createHash } from "crypto";
 
 // =============================================================================
@@ -71,8 +99,16 @@ let vaultPath: string;
 let sidecarPath: string;
 
 function makeAad(path: string, schema: number = VAULT_SCHEMA_VERSION): Buffer {
+  // Production code binds AAD to the realpath of the vault so symlinks don't
+  // produce duplicate AADs. On macOS, `os.tmpdir()` is typically a symlink
+  // (`/var/folders/...` → `/private/var/folders/...`), so test fixtures must
+  // resolve the vault file's realpath to match. The file may not exist yet;
+  // resolve the parent dir and rejoin.
+  const { dirname: _d, basename: _b } = pathMod;
+  const parent = realpathSync(_d(path));
+  const resolved = `${parent}/${_b(path)}`;
   return createHash("sha256")
-    .update(`centient-secrets-vault:v${schema}:${path}`)
+    .update(`centient-secrets-vault:v${schema}:${resolved}`)
     .digest();
 }
 
@@ -100,6 +136,9 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
+  resetMockState();
+  setSecretsPolicies([]);
+  vi.useRealTimers();
 });
 
 // =============================================================================
@@ -219,22 +258,19 @@ describe("openVault — rollback detection", () => {
 // Missing sidecar
 // =============================================================================
 
-describe("openVault — missing sidecar", () => {
-  it("auto-initializes sidecar and warns on stderr when sidecar is absent", async () => {
+describe("openVault — missing sidecar (refuse-by-default)", () => {
+  it("refuses to open when sidecar is absent and acceptMissingSidecar is not passed", async () => {
     seedVault(vaultPath, { "k": "v" }, 7);
     expect(existsSync(sidecarPath)).toBe(false);
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    const vault = await openVault({ path: vaultPath, sidecarPath });
-    vault.close();
-    expect(existsSync(sidecarPath)).toBe(true);
-    const sidecar = JSON.parse(readFileSync(sidecarPath, "utf8"));
-    expect(sidecar.highestSeenVersion).toBe(7);
-    const warningText = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-    expect(warningText).toMatch(/sidecar file .* is missing/i);
-    stderrSpy.mockRestore();
+    // New default: refuse. Rollback protection must be in effect always.
+    await expect(openVault({ path: vaultPath, sidecarPath })).rejects.toMatchObject({
+      code: "VAULT_SIDECAR_MISSING",
+    });
+    // Sidecar was not silently created.
+    expect(existsSync(sidecarPath)).toBe(false);
   });
 
-  it("suppresses the missing-sidecar warning when acceptMissingSidecar: true", async () => {
+  it("opens and auto-initializes sidecar when acceptMissingSidecar: true", async () => {
     seedVault(vaultPath, { "k": "v" }, 7);
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const vault = await openVault({
@@ -243,8 +279,13 @@ describe("openVault — missing sidecar", () => {
       acceptMissingSidecar: true,
     });
     vault.close();
+    expect(existsSync(sidecarPath)).toBe(true);
+    const sidecar = JSON.parse(readFileSync(sidecarPath, "utf8"));
+    expect(sidecar.highestSeenVersion).toBe(7);
+    // Warning is still emitted even with opt-in, so operators see the
+    // auto-init event in logs.
     const warningText = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-    expect(warningText).not.toMatch(/sidecar file .* is missing/i);
+    expect(warningText).toMatch(/sidecar file .* is missing/i);
     stderrSpy.mockRestore();
   });
 });
@@ -319,10 +360,14 @@ describe("SessionVault.close()", () => {
   it("auto-closes after ttlMs elapses", async () => {
     seedVault(vaultPath, { "k": "v" }, 1);
     seedSidecar(sidecarPath, 1);
+    // Deterministic timing via fake timers — avoids real-clock flake under CI.
+    vi.useFakeTimers();
     const vault = await openVault({ path: vaultPath, sidecarPath, ttlMs: 50 });
     expect(await vault.get("k")).toBe("v");
-    await new Promise((r) => setTimeout(r, 80));
+    // Advance past the TTL to trigger the auto-close timer.
+    vi.advanceTimersByTime(100);
     await expect(vault.get("k")).rejects.toBeInstanceOf(VaultClosedError);
+    vi.useRealTimers();
   });
 });
 
@@ -475,5 +520,378 @@ describe("name validation", () => {
     await vault.set("app.api-key_123", "value");
     expect(await vault.get("app.api-key_123")).toBe("value");
     vault.close();
+  });
+
+  // T7. Name-length boundary.
+  it("accepts exactly-256-char names and rejects 257-char names", async () => {
+    seedVault(vaultPath, {}, 1);
+    seedSidecar(sidecarPath, 1);
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    const ok = "a".repeat(256);
+    const bad = "a".repeat(257);
+    await expect(vault.set(ok, "v")).resolves.toBeUndefined();
+    await expect(vault.set(bad, "v")).rejects.toThrow(/256 characters or fewer/);
+    vault.close();
+  });
+});
+
+// =============================================================================
+// T1. Strict coherence — external write invalidates in-memory snapshot
+// =============================================================================
+
+describe("openVault — strict coherence", () => {
+  it("throws VAULT_STALE_SNAPSHOT when external write advances mtime", async () => {
+    seedVault(vaultPath, { "k": "v1" }, 1);
+    seedSidecar(sidecarPath, 1);
+    const vault = await openVault({
+      path: vaultPath,
+      sidecarPath,
+      coherence: "strict",
+    });
+    // Baseline read works.
+    expect(await vault.get("k")).toBe("v1");
+
+    // External writer advances the vault (and mtime) on disk.
+    await new Promise((r) => setTimeout(r, 25));
+    seedVault(vaultPath, { "k": "v2" }, 2);
+    seedSidecar(sidecarPath, 2);
+
+    // Next read in strict mode must refuse to silently serve stale state.
+    try {
+      await vault.get("k");
+      throw new Error("expected VAULT_STALE_SNAPSHOT rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(VaultError);
+      expect((err as VaultError).code).toBe("VAULT_STALE_SNAPSHOT");
+    }
+
+    // reload() unblocks reads; next get returns the refreshed value.
+    await vault.reload();
+    expect(await vault.get("k")).toBe("v2");
+    vault.close();
+  });
+});
+
+// =============================================================================
+// T2. KeyProvider failure paths
+// =============================================================================
+
+describe("openVault — KeyProvider failures", () => {
+  it("throws VaultUnlockError when resolveKeyProvider returns {ok: false}", async () => {
+    seedVault(vaultPath, { "k": "v" }, 1);
+    seedSidecar(sidecarPath, 1);
+    mockState.providerResult = {
+      ok: false,
+      error: { message: "no provider configured" },
+    };
+    await expect(openVault({ path: vaultPath, sidecarPath })).rejects.toBeInstanceOf(
+      VaultUnlockError,
+    );
+  });
+
+  it("throws VaultUnlockError when provider.getKey returns null", async () => {
+    seedVault(vaultPath, { "k": "v" }, 1);
+    seedSidecar(sidecarPath, 1);
+    mockState.providerResult = {
+      ok: true,
+      provider: {
+        name: "keychain",
+        getKey: () => null,
+        storeKey: () => true,
+      },
+    };
+    await expect(openVault({ path: vaultPath, sidecarPath })).rejects.toBeInstanceOf(
+      VaultUnlockError,
+    );
+  });
+});
+
+// =============================================================================
+// T3. Lock timeout
+// =============================================================================
+
+describe("openVault — lock timeout", () => {
+  it("throws VaultLockError when lock is held past LOCK_TIMEOUT_MS", async () => {
+    seedVault(vaultPath, {}, 1);
+    seedSidecar(sidecarPath, 1);
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+
+    // Pre-create a fresh lock file so stale-lock stealing (>30s) does not
+    // steal it. acquireWriteLock() uses a synchronous-busy-wait; we can't
+    // yield via fake timers, so we stub Date.now() to advance monotonically
+    // past LOCK_TIMEOUT_MS (5000ms) without actually sleeping. Monotonic
+    // advance is required so the inner `while (Date.now() < sleepUntil)`
+    // busy-wait also terminates.
+    const lockPath = `${vaultPath}.lock`;
+    writeFileSync(lockPath, "held", { mode: 0o600 });
+
+    const realNow = Date.now.bind(Date);
+    const start = realNow();
+    let tick = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      // Strictly monotonic. First call = start (establishes deadline at
+      // start+5000); subsequent calls jump forward by 1000ms each, so we
+      // cross the deadline on the second call and keep advancing past any
+      // internal sleepUntil target inside the busy-wait.
+      const value = start + tick * 1_000;
+      tick += 1;
+      return value;
+    });
+
+    try {
+      await expect(vault.set("a", "b")).rejects.toBeInstanceOf(VaultLockError);
+    } finally {
+      nowSpy.mockRestore();
+      try {
+        rmSync(lockPath, { force: true });
+      } catch {
+        // ignore
+      }
+      vault.close();
+    }
+  });
+});
+
+// =============================================================================
+// T4. Stale-lock detection
+// =============================================================================
+
+describe("openVault — stale lock detection", () => {
+  it("steals a lock older than LOCK_STALE_MS (30s)", async () => {
+    seedVault(vaultPath, {}, 1);
+    seedSidecar(sidecarPath, 1);
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+
+    // Pre-create a stale lock file (mtime 31s in the past).
+    const lockPath = `${vaultPath}.lock`;
+    writeFileSync(lockPath, "stale", { mode: 0o600 });
+    const pastSeconds = Math.floor(Date.now() / 1000) - 31;
+    utimesSync(lockPath, pastSeconds, pastSeconds);
+
+    // Write succeeds — stale lock was stolen by acquireWriteLock().
+    await expect(vault.set("a", "b")).resolves.toBeUndefined();
+    expect(await vault.get("a")).toBe("b");
+
+    // And the lockfile was released (deleted) after the critical section.
+    expect(existsSync(lockPath)).toBe(false);
+    vault.close();
+  });
+});
+
+// =============================================================================
+// T5. Decrypt error on corrupt vault
+// =============================================================================
+
+describe("openVault — corrupt vault", () => {
+  it("throws VaultDecryptError when vault file contains garbage", async () => {
+    // Write random bytes that aren't a valid AEAD blob.
+    writeFileSync(vaultPath, randomBytes(100), { mode: 0o600 });
+    seedSidecar(sidecarPath, 1);
+    await expect(openVault({ path: vaultPath, sidecarPath })).rejects.toBeInstanceOf(
+      VaultDecryptError,
+    );
+  });
+});
+
+// =============================================================================
+// T6. SecretsPolicy integration
+// =============================================================================
+
+describe("SessionVault — policy integration", () => {
+  it("emits SecretsEvent with backend: 'session-vault' for get/set/list/delete", async () => {
+    seedVault(vaultPath, {}, 1);
+    seedSidecar(sidecarPath, 1);
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([
+      {
+        name: "test",
+        after: (e) => {
+          events.push(e);
+        },
+      },
+    ]);
+
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    await vault.set("k", "v");
+    await vault.get("k");
+    await vault.list();
+    await vault.delete("k");
+    vault.close();
+
+    // All four operations emit their success-path event. Order matches call order.
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "credential_written",
+      "credential_read",
+      "credential_enumerated",
+      "credential_deleted",
+    ]);
+    for (const e of events) {
+      expect(e.backend).toBe("session-vault");
+    }
+  });
+
+  it("runs before hooks and can reject operations", async () => {
+    seedVault(vaultPath, { "existing": "v" }, 1);
+    seedSidecar(sidecarPath, 1);
+    setSecretsPolicies([
+      {
+        name: "no-writes",
+        before: (op: SecretsOperation): void => {
+          if (op.type === "write") {
+            throw new Error("writes blocked by policy");
+          }
+        },
+      },
+    ]);
+
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    // set() is rejected by the before-hook; reads still work.
+    await expect(vault.set("k", "v")).rejects.toThrow(/writes blocked by policy/);
+    expect(await vault.get("existing")).toBe("v");
+    vault.close();
+  });
+
+  it("emits credential_read_missing for a non-existent key", async () => {
+    seedVault(vaultPath, {}, 1);
+    seedSidecar(sidecarPath, 1);
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([
+      {
+        name: "observe",
+        after: (e) => {
+          events.push(e);
+        },
+      },
+    ]);
+
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    const value = await vault.get("nonexistent");
+    vault.close();
+
+    expect(value).toBeNull();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("credential_read_missing");
+    expect(events[0]!.backend).toBe("session-vault");
+    expect(events[0]!.key).toBe("nonexistent");
+  });
+});
+
+// =============================================================================
+// T8. Empty vault (vaultVersion 0)
+// =============================================================================
+
+describe("openVault — empty vault", () => {
+  it("opens a vault initialized with vaultVersion 0", async () => {
+    seedVault(vaultPath, {}, 0);
+    seedSidecar(sidecarPath, 0);
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    expect(vault.vaultVersion).toBe(0);
+    expect(await vault.list()).toEqual([]);
+    await vault.set("a", "b");
+    expect(vault.vaultVersion).toBe(1);
+    vault.close();
+  });
+});
+
+// =============================================================================
+// T9. reload() after close()
+// =============================================================================
+
+describe("SessionVault.reload() — closed-vault semantics", () => {
+  it("reload() after close() throws VaultClosedError", async () => {
+    seedVault(vaultPath, { "k": "v" }, 1);
+    seedSidecar(sidecarPath, 1);
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    vault.close();
+    await expect(vault.reload()).rejects.toBeInstanceOf(VaultClosedError);
+  });
+});
+
+// =============================================================================
+// T10. acceptRollback + missing sidecar
+// =============================================================================
+
+describe("openVault — missing sidecar + acceptRollback", () => {
+  it("missing sidecar is checked before rollback; auto-init runs", async () => {
+    // Seed vault v3, no sidecar on disk. With acceptMissingSidecar: true,
+    // opening succeeds (with a warning about auto-init); acceptRollback: true
+    // is a no-op because there is no sidecar to compare against.
+    seedVault(vaultPath, { "k": "v" }, 3);
+    expect(existsSync(sidecarPath)).toBe(false);
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const vault = await openVault({
+      path: vaultPath,
+      sidecarPath,
+      acceptRollback: true,
+      acceptMissingSidecar: true,
+    });
+    vault.close();
+
+    // Missing-sidecar warning IS emitted (auto-init event is visible);
+    // no rollback warning because there was nothing to roll back against.
+    const warningText = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(warningText).toMatch(/sidecar file .* is missing/i);
+    expect(warningText).not.toMatch(/accepting intentional rollback/i);
+    stderrSpy.mockRestore();
+
+    // Sidecar was created with the vault's current version.
+    expect(existsSync(sidecarPath)).toBe(true);
+    const sidecar = JSON.parse(readFileSync(sidecarPath, "utf8"));
+    expect(sidecar.highestSeenVersion).toBe(3);
+  });
+});
+
+// =============================================================================
+// T13. Legacy (pre-openVault CLI) vault format upgrade
+// =============================================================================
+
+describe("openVault — legacy AAD-less vault migration", () => {
+  /**
+   * Seed a vault written by a pre-openVault CLI: no AAD, flat `{name: value}`
+   * top-level object. This is what every existing CLI-written vault looks
+   * like on disk. openVault must open it, auto-upgrade on first write, and
+   * round-trip correctly thereafter.
+   */
+  function seedLegacyVault(path: string, secrets: Record<string, string>): void {
+    const encrypted = encryptObject(secrets as Record<string, unknown>, Buffer.from(TEST_KEY));
+    if (!encrypted) throw new Error("test setup: legacy encryption failed");
+    writeFileSync(path, encrypted, { mode: 0o600 });
+  }
+
+  it("opens a legacy AAD-less vault (no sidecar required)", async () => {
+    seedLegacyVault(vaultPath, { "anthropic.key": "sk-legacy-value" });
+    expect(existsSync(sidecarPath)).toBe(false);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    // Legacy vaults bypass the missing-sidecar refuse — rollback protection
+    // is bootstrapped at migration time.
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    expect(await vault.get("anthropic.key")).toBe("sk-legacy-value");
+    expect(vault.vaultVersion).toBe(0); // legacy is version 0
+    vault.close();
+
+    const warningText = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(warningText).toMatch(/legacy .* vault/i);
+    stderrSpy.mockRestore();
+  });
+
+  it("auto-upgrades the legacy vault to schema 1 on first write", async () => {
+    seedLegacyVault(vaultPath, { "app.key": "v0" });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    await vault.set("app.key", "v1"); // triggers the upgrade
+    expect(vault.vaultVersion).toBe(1); // was 0 (legacy), now 1 (upgraded)
+    vault.close();
+
+    // Re-opening should now work on the v1 path (WITH AAD).
+    const v2 = await openVault({ path: vaultPath, sidecarPath });
+    expect(await v2.get("app.key")).toBe("v1");
+    expect(v2.vaultVersion).toBe(1);
+    v2.close();
+
+    vi.restoreAllMocks();
   });
 });


### PR DESCRIPTION
Remediation pass for the findings from the \`/crucible-code-review\` that ran against PR #41 (session-vault). Addresses all 4 Critical, all 8 High, and most Medium/Low findings.

## 🔴 Critical (all 4)

1. **CLI migrated to \`openVault\`.** Eliminates the cross-API corruption hazard where the CLI wrote AAD-less ciphertext while \`openVault\` wrote AAD-bound ciphertext to the same default path. CLI now opens a single \`SessionVault\` on unlock and routes \`get\`/\`set\`/\`list\`/\`delete\` through it. Existing CLI vaults remain readable via a new legacy-decrypt fallback and are auto-upgraded to schema 1 with AAD on the next write.
2. **\`acceptMissingSidecar\` default flipped \`true\` → \`false\`.** \`openVault\` now refuses a missing sidecar by default (new \`VAULT_SIDECAR_MISSING\` error); callers must opt-in. Restores the \"rollback protection always in effect\" invariant.
3. **File-lock busy-wait replaced with async \`setTimeout\`.** No more 25 ms hot-spin per retry. Write contention no longer starves the daemon's other async work.
4. **AAD binds to realpath.** \`fs.realpathSync\` replaces lexical \`path.resolve\`. Symlinks, bind mounts, and vault moves no longer break decryption.

## 🟠 High (all 8)

- Legacy AAD-less decrypt + auto-upgrade path restored in \`openVault\`, \`maybeReload\`, and \`reload()\` for CLI migration compat.
- \`validatePayload\` rejects \`NaN\`/\`Infinity\`/negative/non-integer/out-of-range values for \`schema\` and \`vaultVersion\`; only \`schema === VAULT_SCHEMA_VERSION\` accepted.
- TTL/concurrent-op race fixed: \`assertOpen()\` re-checked after every \`await\` boundary.
- Missing error codes added to docs (\`VAULT_NOT_FOUND\`, \`VAULT_FILE_MISSING\`, \`VAULT_STALE_SNAPSHOT\`, \`VAULT_ENCRYPT_FAILED\`, \`VAULT_SIDECAR_MISSING\`, \`INVALID_NAME\`).
- **12 new tests** added covering every gap the review flagged: strict coherence, \`VaultUnlockError\`, lock timeout, stale-lock detection, corrupt-vault decrypt error, \`SecretsPolicy\` integration, name-length boundary, empty vault, reload-after-close, acceptRollback+missing-sidecar, legacy vault open, auto-upgrade on first write.

## 🟡 Medium (most)

- Module extraction: new \`file-lock.ts\`, \`sidecar.ts\`, \`session-vault-errors.ts\`.
- DRY \`withAudit\` wrapper replaces ~100 LOC of audit-scaffolding boilerplate.
- Stale-lock race closed (PID in lockfile, verify on steal).
- Redundant \`existsSync\` / \`chmodSync\` removed.
- \`ttlMs: 50\` flaky test converted to fake timers.

## 🟢 Low (most)

- \`VAULT_AAD_PREFIX\` exported from the package index.
- \`Object.setPrototypeOf\` in every \`VaultError\` subclass.
- Magic numbers extracted to named constants.
- Name validation rejects Unicode RTL/line separators/whitespace.
- \`readSidecar\` distinguishes missing from corrupt.
- Duplicate \`path\` import consolidated; \`node:\` prefix in new code.
- \`close()\` inlined.
- JSDoc added to \`openVault\`, \`SessionVault\`, \`OpenVaultOptions\`, \`CoherenceStrategy\`.
- Docs: error-handling example, coherence-mode examples, rotation/backup/CI sections, \`ttlMs\` example, \`getCredential\` migration signature corrected.

## Deferred (not blockers; file follow-up)

- Thrown errors vs Result type (systemic package-wide pattern).
- \`process.stderr.write\` vs \`@centient/logger\` (systemic).
- Sync \`fs\` I/O inside async surface (migrate to \`fs/promises\`).

## Scope

- Files changed: 9
- LOC diff: +1608 / −586
- New modules: \`file-lock.ts\`, \`sidecar.ts\`, \`session-vault-errors.ts\`
- **Build**: ✅ clean across workspace
- **Lint**: ✅ clean
- **Tests**: ✅ 174/174 secrets tests pass; full workspace green

## Backwards compat

- Public API surface unchanged: \`openVault\`, \`SessionVault\`, \`OpenVaultOptions\`, \`VAULT_SCHEMA_VERSION\`, all six error classes.
- Added: \`VAULT_AAD_PREFIX\` export (additive).
- Behavior change: \`acceptMissingSidecar\` now defaults to \`false\` — any caller relying on the old silent auto-init must now pass \`{ acceptMissingSidecar: true }\` explicitly. Since \`openVault\` was released <24h ago, no downstream consumer is known to be affected.
- Existing CLI-written vaults continue to work without user action — they're auto-upgraded to AAD-bound schema-1 format on first write post-upgrade.

## Changeset

Minor bump. See \`.changeset/secrets-session-vault-remediation.md\` for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)