### PR TITLE
feat(sdk): add skipEmbedding to UpdateKnowledgeCrystalParams (closes #35)

### DIFF
--- a/.changeset/sdk-skip-embedding.md
+++ b/.changeset/sdk-skip-embedding.md
@@ -1,0 +1,19 @@
+---
+"@centient/sdk": minor
+---
+
+Add optional `skipEmbedding: boolean` to `UpdateKnowledgeCrystalParams`. Closes #35.
+
+When set to `true`, the server commits the update without regenerating the crystal's embedding. Use for high-frequency status updates (heartbeats, lock holders, counters, last-seen timestamps) where the embedding is meaningless for semantic search and the regenerate-on-every-write LLM cost is pure waste.
+
+**Composes with `expectedVersion`:** a single update may set both. CAS still enforced; embedding still skipped on success.
+
+**Server requirements:** requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id` (engram-server#65). **Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional so the SDK can ship without coordinating a flag-day server upgrade. `MIN_SERVER_VERSION` will be bumped in a follow-up release once engram-server#65 lands and the version is known.
+
+**Default:** `false` (regenerate embedding on every update — pre-`skipEmbedding` behavior). Fully backward compatible.
+
+**Docs:** new `packages/sdk/docs/skip-embedding.md` with usage guidance, when-to-use checklist, composition example with `expectedVersion`, and clear "what this does NOT do" section. Linked from the SDK README.
+
+**Tests:** 4 new — forwards `skipEmbedding: true`, forwards explicit `false`, omits when not supplied (backward compat), composes with `expectedVersion` in the same PATCH body. All field naming is camelCase per ADR-018.
+
+This addresses **ADR-017 OQ#2** (per the maintainer planning docs). Pairs with engram-server#65 (server-side); ship them together.

--- a/.changeset/sdk-skip-embedding.md
+++ b/.changeset/sdk-skip-embedding.md
@@ -14,6 +14,10 @@ When set to `true`, the server commits the update without regenerating the cryst
 
 **Docs:** new `packages/sdk/docs/skip-embedding.md` with usage guidance, when-to-use checklist, composition example with `expectedVersion`, and clear "what this does NOT do" section. Linked from the SDK README.
 
-**Tests:** 4 new — forwards `skipEmbedding: true`, forwards explicit `false`, omits when not supplied (backward compat), composes with `expectedVersion` in the same PATCH body. All field naming is camelCase per ADR-018.
+**Tests:** 5 new — forwards `skipEmbedding: true`, forwards explicit `false`, omits when not supplied (backward compat), composes with `expectedVersion` happy path, composes with `expectedVersion` 409 conflict (still surfaces `CrystalVersionConflictError`). All field naming is camelCase per ADR-018.
 
-This addresses **ADR-017 OQ#2** (per the maintainer planning docs). Pairs with engram-server#65 (server-side); ship them together.
+**Tracking:** `TODO(skipEmbedding)` comment added at `packages/sdk/src/client.ts` adjacent to `MIN_SERVER_VERSION` so the pending version bump surfaces during normal code review once engram-server#65 ships.
+
+**ADR cross-reference:** pairs with **ADR-017 OQ#2** in the maintainer repo. The SDK can't update a cross-repo ADR directly; the maintainer team owns marking OQ#2 resolved once both sides ship. This PR forwards the decision (passthrough optional field, intentional silent no-op on older servers) without claiming resolution authority over the ADR itself.
+
+Pairs with engram-server#65; ship them together. A follow-up SDK patch bumps `MIN_SERVER_VERSION` to the engram-server release that lands #65.

--- a/.changeset/sdk-skip-embedding.md
+++ b/.changeset/sdk-skip-embedding.md
@@ -8,16 +8,16 @@ When set to `true`, the server commits the update without regenerating the cryst
 
 **Composes with `expectedVersion`:** a single update may set both. CAS still enforced; embedding still skipped on success.
 
-**Server requirements:** requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id` (engram-server#65). **Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional so the SDK can ship without coordinating a flag-day server upgrade. `MIN_SERVER_VERSION` will be bumped in a follow-up release once engram-server#65 lands and the version is known.
+**Server requirements:** requires engram-server **>= 0.31.0** (engram-server#65 shipped in 0.31.0). `MIN_SERVER_VERSION` is bumped from `0.30.0` to `0.31.0` in this release — a single floor now gates both `expectedVersion` CAS (engram-server#60 in 0.30.0) and `skipEmbedding` (engram-server#65 in 0.31.0). `client.checkCompatibility()` is now a meaningful runtime gate for `skipEmbedding` usage.
 
-**Default:** `false` (regenerate embedding on every update — pre-`skipEmbedding` behavior). Fully backward compatible.
+**Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected on any server; callers pointing the SDK at a pre-0.31.0 server will fail `checkCompatibility()` against the new floor.
 
-**Docs:** new `packages/sdk/docs/skip-embedding.md` with usage guidance, when-to-use checklist, composition example with `expectedVersion`, and clear "what this does NOT do" section. Linked from the SDK README.
+**Default:** omit the field for pre-`skipEmbedding` behavior (server regenerates the embedding). JSDoc guidance: to opt out of the optimization, **omit** rather than passing explicit `false`. The SDK forwards whatever the caller supplies without injecting a default on the wire.
 
-**Tests:** 5 new — forwards `skipEmbedding: true`, forwards explicit `false`, omits when not supplied (backward compat), composes with `expectedVersion` happy path, composes with `expectedVersion` 409 conflict (still surfaces `CrystalVersionConflictError`). All field naming is camelCase per ADR-018.
+**Docs:** new `packages/sdk/docs/skip-embedding.md` with usage guidance, when-to-use checklist, composition example with `expectedVersion`, runtime-gating example via `checkCompatibility()`, and clear "what this does NOT do" section. Linked from the SDK README.
 
-**Tracking:** `TODO(skipEmbedding)` comment added at `packages/sdk/src/client.ts` adjacent to `MIN_SERVER_VERSION` so the pending version bump surfaces during normal code review once engram-server#65 ships.
+**Tests:** 5 new crystals.update tests + 5 `checkCompatibility` fixture bumps (0.30 → 0.31 floor). Crystals tests: forwards `skipEmbedding: true`, forwards explicit `false`, omits when field absent (backward compat), composes with `expectedVersion` happy path, composes with `expectedVersion` 409 conflict (still surfaces `CrystalVersionConflictError` via `.rejects.toBeInstanceOf` + `.rejects.toMatchObject`). All field naming is camelCase per ADR-018.
 
-**ADR cross-reference:** pairs with **ADR-017 OQ#2** in the maintainer repo. The SDK can't update a cross-repo ADR directly; the maintainer team owns marking OQ#2 resolved once both sides ship. This PR forwards the decision (passthrough optional field, intentional silent no-op on older servers) without claiming resolution authority over the ADR itself.
+**ADR cross-reference:** pairs with **ADR-017 OQ#2** in the maintainer repo. The SDK can't update a cross-repo ADR directly; the maintainer team owns marking OQ#2 resolved once both sides ship. This PR forwards the decision (passthrough optional field, coordinated `MIN_SERVER_VERSION` floor) without claiming resolution authority over the ADR itself.
 
-Pairs with engram-server#65; ship them together. A follow-up SDK patch bumps `MIN_SERVER_VERSION` to the engram-server release that lands #65.
+Ships together with engram-server 0.31.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ See `.agent/DESIGN-PHILOSOPHY.md` for the 14 principles (3 tiers) that guide all
 | `@centient/events` | 0.2.1 | Typed event streaming with backpressure. AsyncIterable + callback fan-out, JSONL persistence/replay, configurable backpressure. Factory: `createEventStream()`, `fromJsonl()` |
 | `@centient/logger` | 0.17.0 | Structured logging with transport abstraction. 6 levels, Console/File/Null transports, audit events, data redaction. `version` field unreserved (callers own it). Factory: `createLogger()`, `createAuditWriter()` |
 | `@centient/secrets` | 0.6.0 | Cross-platform secrets vault with AES-256-GCM encryption + AAD binding, session-backed envelope vault (`openVault`), monotonic-version + sidecar rollback protection. Keychain/libsecret/Windows Credential Manager/GPG file/env backends. Factory: `openVault()`, `storeCredential()`, `getCredential()`, `deleteCredential()`, `listCredentials()` |
-| `@centient/sdk` | 1.5.0 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types, `expectedVersion` CAS on `crystals.update`. Factory: `createEngramClient()`. Requires engram-server >= 0.30.0 |
+| `@centient/sdk` | 1.6.0 | TypeScript SDK for Engram Memory Server REST API. 20 resource classes, 130+ types, `expectedVersion` CAS + `skipEmbedding` optimization on `crystals.update`. Factory: `createEngramClient()`. Requires engram-server >= 0.31.0 |
 | `@centient/wal` | 0.3.1 | Write-ahead log for crash recovery. `appendEntry`, `confirmEntry`, `replayUnconfirmed`, `compactWal` |
 | `sdk-python` | - | Python SDK client with Pydantic v2 (async + sync) |
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -62,6 +62,7 @@ const results = await client.search(session.id, {
 ## Documentation
 
 - [Optimistic concurrency (CAS)](./docs/optimistic-concurrency.md) — using `expectedVersion` on `crystals.update` to prevent lost writes under concurrent mutation.
+- [Skip-embedding optimization](./docs/skip-embedding.md) — using `skipEmbedding` on `crystals.update` to reclaim LLM compute on high-frequency status updates (heartbeats, counters, lock holders).
 - [Full monorepo docs](https://github.com/centient-labs/centient-sdk) — architecture, ADRs, and cross-package guides.
 
 ## License

--- a/packages/sdk/docs/skip-embedding.md
+++ b/packages/sdk/docs/skip-embedding.md
@@ -1,0 +1,77 @@
+# Skip-embedding optimization (`skipEmbedding`)
+
+`crystals.update` accepts an optional `skipEmbedding: boolean` parameter that tells the server to commit the update **without** regenerating the crystal's embedding. The persisted embedding stays at its previous value; subsequent semantic search returns the (now-stale) prior content.
+
+This is a **compute-cost optimization** for high-frequency updates where the new content is not meaningful to semantic search — heartbeats, lock holders, last-seen timestamps, counters, status flags. Misuse on content-bearing fields silently degrades search quality without surfacing an error.
+
+## Quick start
+
+```typescript
+import { createEngramClient } from "@centient/sdk";
+
+const client = createEngramClient();
+
+// Heartbeat update — runs every few seconds. The embedding is meaningless
+// for this content, so skip the regen and reclaim the LLM compute.
+await client.crystals.update(instanceCrystalId, {
+  contentInline: JSON.stringify({ lastHeartbeat: new Date().toISOString() }),
+  skipEmbedding: true,
+});
+```
+
+When `skipEmbedding` is omitted (or `false`), today's behaviour is preserved: every update regenerates the embedding.
+
+## When to use
+
+✅ **Good fits:**
+- Heartbeat / liveness timestamps written by long-running daemons
+- Lock-holder fields with rapid contention
+- Counters (request count, error count, retry count)
+- Status flags (`active` / `paused` / `draining`)
+- Bookkeeping metadata that no one searches semantically
+
+❌ **Don't use for:**
+- Anything a user might type a query about
+- Content fields (titles, descriptions, body text)
+- Tags or categories that participate in faceted search
+- Any field where retrieval quality matters
+
+## Composes with `expectedVersion`
+
+Both flags are independent:
+
+```typescript
+// Atomic CAS update + embedding skip — typical for maintainer's
+// heartbeat write that must not race with a peer's lock takeover.
+await client.crystals.update(instanceCrystalId, {
+  contentInline: JSON.stringify({ lastHeartbeat: now, holder: instanceId }),
+  expectedVersion: localVersion,
+  skipEmbedding: true,
+});
+```
+
+CAS is still enforced server-side. The embedding is still skipped on success.
+
+## Server requirements
+
+Requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id` (sibling issue [centient-labs/engram-server#65](https://github.com/centient-labs/engram-server/issues/65)).
+
+**Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional: it lets the SDK ship the optimization without coordinating a flag-day server upgrade. To verify your server supports it, gate startup on `client.checkCompatibility()` and require the engram-server version that landed engram-server#65 (TBD until it ships).
+
+## What `skipEmbedding` does NOT do
+
+- It does not delete the existing embedding. Searches continue to return the crystal at its old embedding.
+- It does not skip the version bump. `vaultVersion`/`version` still increments per the server's normal semantics.
+- It does not skip audit-trail emission. Every update flows through the server's standard observability.
+- It does not skip integrity checks (CAS, validation, ACL).
+
+## Background
+
+This is **ADR-017 OQ#2** in the maintainer planning docs. Maintainer's instance-heartbeat pattern writes `lastHeartbeat` every few seconds; without `skipEmbedding`, every write would trigger a 50–100ms LLM call to regenerate the embedding for content nobody searches semantically. With `skipEmbedding: true`, that compute is reclaimed entirely.
+
+## References
+
+- [centient-labs/engram-server#65](https://github.com/centient-labs/engram-server/issues/65) — server-side sibling
+- [centient-labs/centient-sdk#35](https://github.com/centient-labs/centient-sdk/issues/35) — this SDK feature
+- [Optimistic concurrency (`expectedVersion`)](./optimistic-concurrency.md) — composable companion API
+- centient-labs/maintainer ADR-017 §Open Questions OQ#2

--- a/packages/sdk/docs/skip-embedding.md
+++ b/packages/sdk/docs/skip-embedding.md
@@ -58,26 +58,22 @@ Requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id` (si
 
 **Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional: it lets the SDK ship the optimization without coordinating a flag-day server upgrade.
 
-### Detecting support at runtime
+### Detecting support at runtime (currently no programmatic check)
 
-`client.checkCompatibility()` returns `{ compatible, serverVersion, minRequired }`:
+There is **no SDK-level way to confirm `skipEmbedding` is honored by the remote server** in the current release. The SDK's `client.checkCompatibility()` only verifies the server meets `MIN_SERVER_VERSION` (currently `0.30.0`, the CAS floor) — it says nothing about whether the server is at or past the `skipEmbedding`-capable release.
+
+Operators who need to verify `skipEmbedding` support today must inspect the server version manually against the engram-server#65 release tag:
 
 ```typescript
-const compat = await client.checkCompatibility();
-if (!compat.compatible) {
-  throw new Error(
-    `engram-server ${compat.serverVersion} is below required ${compat.minRequired}; ` +
-    `skipEmbedding may be a no-op. Upgrade to unlock the optimization.`,
-  );
-}
-// Note: `compatible: true` only means the server meets MIN_SERVER_VERSION
-// (currently 0.30.0 — the CAS floor). Once engram-server#65 ships, a
-// future SDK release will bump MIN_SERVER_VERSION to the skipEmbedding-
-// capable version. Until then, `skipEmbedding: true` is accepted and
-// forwarded but may be ignored by the server.
+const health = await fetch(`${baseUrl}/health`).then((r) => r.json());
+// Compare health.version against the engram-server release that lands
+// engram-server#65 (TBD). Until then, treat `skipEmbedding: true` as a
+// best-effort optimization that may be a no-op on older servers.
 ```
 
-The `MIN_SERVER_VERSION` constant in `@centient/sdk` will bump to the skipEmbedding-capable engram-server release once it ships. Track [engram-server#65](https://github.com/centient-labs/engram-server/issues/65) and [centient-sdk#35](https://github.com/centient-labs/centient-sdk/issues/35) for the coordinated release.
+Once engram-server#65 ships, a follow-up SDK release will bump `MIN_SERVER_VERSION` to the `skipEmbedding`-capable version. At that point `client.checkCompatibility()` becomes meaningful as a `skipEmbedding` gate. Track [engram-server#65](https://github.com/centient-labs/engram-server/issues/65) and [centient-sdk#35](https://github.com/centient-labs/centient-sdk/issues/35) for the coordinated release.
+
+Meanwhile: correctness is unaffected on any server. The optimization is just silently absent on servers pre-dating engram-server#65.
 
 ## What `skipEmbedding` does NOT do
 

--- a/packages/sdk/docs/skip-embedding.md
+++ b/packages/sdk/docs/skip-embedding.md
@@ -54,26 +54,33 @@ CAS is still enforced server-side. The embedding is still skipped on success.
 
 ## Server requirements
 
-Requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id` (sibling issue [centient-labs/engram-server#65](https://github.com/centient-labs/engram-server/issues/65)).
+Requires engram-server **>= 0.31.0** (landed via [centient-labs/engram-server#65](https://github.com/centient-labs/engram-server/issues/65)). This SDK release bumps `MIN_SERVER_VERSION` to `0.31.0` so the same floor covers both `expectedVersion` CAS (0.30.0, engram-server#60) and `skipEmbedding` (0.31.0, engram-server#65).
 
-**Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional: it lets the SDK ship the optimization without coordinating a flag-day server upgrade.
+**Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. A caller pointing this SDK at a pre-0.31.0 server will fail `client.checkCompatibility()` against the pinned floor, not the `skipEmbedding`-specific capability.
 
-### Detecting support at runtime (currently no programmatic check)
+### Verifying support at runtime
 
-There is **no SDK-level way to confirm `skipEmbedding` is honored by the remote server** in the current release. The SDK's `client.checkCompatibility()` only verifies the server meets `MIN_SERVER_VERSION` (currently `0.30.0`, the CAS floor) — it says nothing about whether the server is at or past the `skipEmbedding`-capable release.
-
-Operators who need to verify `skipEmbedding` support today must inspect the server version manually against the engram-server#65 release tag:
+`client.checkCompatibility()` is the supported way to gate `skipEmbedding` usage. Because `MIN_SERVER_VERSION` now includes the `skipEmbedding`-capable release, a compatible server is a `skipEmbedding`-capable server:
 
 ```typescript
-const health = await fetch(`${baseUrl}/health`).then((r) => r.json());
-// Compare health.version against the engram-server release that lands
-// engram-server#65 (TBD). Until then, treat `skipEmbedding: true` as a
-// best-effort optimization that may be a no-op on older servers.
+const { compatible, serverVersion, minRequired } =
+  await client.checkCompatibility();
+if (!compatible) {
+  throw new Error(
+    `Server ${serverVersion} < ${minRequired}; skipEmbedding unavailable`,
+  );
+}
+// safe to use skipEmbedding below
 ```
 
-Once engram-server#65 ships, a follow-up SDK release will bump `MIN_SERVER_VERSION` to the `skipEmbedding`-capable version. At that point `client.checkCompatibility()` becomes meaningful as a `skipEmbedding` gate. Track [engram-server#65](https://github.com/centient-labs/engram-server/issues/65) and [centient-sdk#35](https://github.com/centient-labs/centient-sdk/issues/35) for the coordinated release.
+If you need a lower-level check against an ad-hoc server, guard the response:
 
-Meanwhile: correctness is unaffected on any server. The optimization is just silently absent on servers pre-dating engram-server#65.
+```typescript
+const res = await fetch(`${baseUrl}/health`);
+if (!res.ok) throw new Error(`health check failed: ${res.status}`);
+const health = await res.json();
+// health.version is now safely parsed JSON from a 2xx response
+```
 
 ## What `skipEmbedding` does NOT do
 

--- a/packages/sdk/docs/skip-embedding.md
+++ b/packages/sdk/docs/skip-embedding.md
@@ -56,7 +56,28 @@ CAS is still enforced server-side. The embedding is still skipped on success.
 
 Requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id` (sibling issue [centient-labs/engram-server#65](https://github.com/centient-labs/engram-server/issues/65)).
 
-**Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional: it lets the SDK ship the optimization without coordinating a flag-day server upgrade. To verify your server supports it, gate startup on `client.checkCompatibility()` and require the engram-server version that landed engram-server#65 (TBD until it ships).
+**Older servers silently ignore the field** — the optimization becomes a no-op (embedding regenerates as before). Correctness is unaffected; only the compute saving is lost. This is intentional: it lets the SDK ship the optimization without coordinating a flag-day server upgrade.
+
+### Detecting support at runtime
+
+`client.checkCompatibility()` returns `{ compatible, serverVersion, minRequired }`:
+
+```typescript
+const compat = await client.checkCompatibility();
+if (!compat.compatible) {
+  throw new Error(
+    `engram-server ${compat.serverVersion} is below required ${compat.minRequired}; ` +
+    `skipEmbedding may be a no-op. Upgrade to unlock the optimization.`,
+  );
+}
+// Note: `compatible: true` only means the server meets MIN_SERVER_VERSION
+// (currently 0.30.0 — the CAS floor). Once engram-server#65 ships, a
+// future SDK release will bump MIN_SERVER_VERSION to the skipEmbedding-
+// capable version. Until then, `skipEmbedding: true` is accepted and
+// forwarded but may be ignored by the server.
+```
+
+The `MIN_SERVER_VERSION` constant in `@centient/sdk` will bump to the skipEmbedding-capable engram-server release once it ships. Track [engram-server#65](https://github.com/centient-labs/engram-server/issues/65) and [centient-sdk#35](https://github.com/centient-labs/centient-sdk/issues/35) for the coordinated release.
 
 ## What `skipEmbedding` does NOT do
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -180,6 +180,12 @@ const DEFAULT_RETRY_DELAY = 1000;
  * Bumped to 0.30.0 for crystals.update `expectedVersion` CAS support
  * (engram-server #60). Older servers silently ignore the field, so the
  * SDK will still load, but CAS semantics are not guaranteed.
+ *
+ * TODO(skipEmbedding): bump to the engram-server version that lands
+ * `skipEmbedding` support on PATCH /crystals/:id once engram-server#65
+ * ships. Until then, `UpdateKnowledgeCrystalParams.skipEmbedding` is a
+ * silent no-op against the current MIN_SERVER_VERSION floor — correct
+ * but a lost optimization. See centient-sdk#35 and engram-server#65.
  */
 export const MIN_SERVER_VERSION = "0.30.0";
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -177,17 +177,17 @@ const DEFAULT_RETRY_DELAY = 1000;
  * Minimum engram-server version required by this SDK.
  * Use `client.checkCompatibility()` to verify at runtime.
  *
- * Bumped to 0.30.0 for crystals.update `expectedVersion` CAS support
- * (engram-server #60). Older servers silently ignore the field, so the
- * SDK will still load, but CAS semantics are not guaranteed.
+ * - 0.30.0 landed `expectedVersion` CAS support on `PATCH /crystals/:id`
+ *   (engram-server#60).
+ * - 0.31.0 landed `skipEmbedding` support on `PATCH /crystals/:id`
+ *   (engram-server#65).
  *
- * TODO(skipEmbedding): bump to the engram-server version that lands
- * `skipEmbedding` support on PATCH /crystals/:id once engram-server#65
- * ships. Until then, `UpdateKnowledgeCrystalParams.skipEmbedding` is a
- * silent no-op against the current MIN_SERVER_VERSION floor — correct
- * but a lost optimization. See centient-sdk#35 and engram-server#65.
+ * Older servers silently ignore both fields: correctness is preserved, but
+ * CAS is not enforced and the embedding-skip optimization is a no-op.
+ * `checkCompatibility()` against this floor is a meaningful gate for both
+ * features.
  */
-export const MIN_SERVER_VERSION = "0.30.0";
+export const MIN_SERVER_VERSION = "0.31.0";
 
 /**
  * Engram Memory Server Client

--- a/packages/sdk/src/types/knowledge-crystal.ts
+++ b/packages/sdk/src/types/knowledge-crystal.ts
@@ -279,6 +279,30 @@ export interface UpdateKnowledgeCrystalParams {
    * @see docs/optimistic-concurrency.md
    */
   expectedVersion?: number;
+  /**
+   * When `true`, the server commits this update without regenerating the
+   * crystal's embedding. The persisted embedding stays at its previous value,
+   * so subsequent semantic search returns the (now-stale) prior content.
+   *
+   * Use only for fields where the embedding is **meaningless** for semantic
+   * search — high-frequency status updates (heartbeats, lock holders, last-
+   * seen timestamps), counters, or numeric flags. Misuse on content-bearing
+   * fields silently degrades search quality without surfacing an error.
+   *
+   * Composes with `expectedVersion`: a single update may set both. CAS
+   * remains enforced; embedding is still skipped on success.
+   *
+   * Requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id`.
+   * Older servers silently ignore the field and regenerate the embedding as
+   * before — i.e. the optimization is a no-op against older servers, but
+   * does not break correctness.
+   *
+   * Default: `false` (regenerate embedding on every update — pre-`skipEmbedding`
+   * behavior).
+   *
+   * @see docs/skip-embedding.md
+   */
+  skipEmbedding?: boolean;
 }
 
 // ============================================================================

--- a/packages/sdk/src/types/knowledge-crystal.ts
+++ b/packages/sdk/src/types/knowledge-crystal.ts
@@ -297,8 +297,11 @@ export interface UpdateKnowledgeCrystalParams {
    * before — i.e. the optimization is a no-op against older servers, but
    * does not break correctness.
    *
-   * Default: `false` (regenerate embedding on every update — pre-`skipEmbedding`
-   * behavior).
+   * **Wire-format note:** when omitted, the server regenerates the embedding
+   * (pre-`skipEmbedding` behavior). Explicit `false` is forwarded to the
+   * server on the wire; whether it is semantically distinct from absent is
+   * server-defined. The SDK does not assume or enforce a default — it passes
+   * whatever the caller supplies.
    *
    * @see docs/skip-embedding.md
    */

--- a/packages/sdk/src/types/knowledge-crystal.ts
+++ b/packages/sdk/src/types/knowledge-crystal.ts
@@ -292,16 +292,17 @@ export interface UpdateKnowledgeCrystalParams {
    * Composes with `expectedVersion`: a single update may set both. CAS
    * remains enforced; embedding is still skipped on success.
    *
-   * Requires engram-server with `skipEmbedding` support on `PATCH /crystals/:id`.
-   * Older servers silently ignore the field and regenerate the embedding as
-   * before — i.e. the optimization is a no-op against older servers, but
-   * does not break correctness.
+   * Requires engram-server >= 0.31.0 (engram-server#65). Older servers
+   * silently ignore the field and regenerate the embedding as before — the
+   * optimization is a no-op against older servers, but correctness is
+   * unaffected. Call `client.checkCompatibility()` to verify at runtime.
    *
-   * **Wire-format note:** when omitted, the server regenerates the embedding
-   * (pre-`skipEmbedding` behavior). Explicit `false` is forwarded to the
-   * server on the wire; whether it is semantically distinct from absent is
-   * server-defined. The SDK does not assume or enforce a default — it passes
-   * whatever the caller supplies.
+   * **Default behavior:** to keep the normal regenerate-embedding behavior,
+   * **omit this field**. The SDK forwards whatever the caller supplies —
+   * explicit `false` is sent on the wire (semantically equivalent to absent
+   * on the current server but treated as an explicit caller signal), while
+   * omitting the field is the documented idiom and the recommended way to
+   * opt out of the optimization.
    *
    * @see docs/skip-embedding.md
    */

--- a/packages/sdk/tests/client-compat.test.ts
+++ b/packages/sdk/tests/client-compat.test.ts
@@ -32,22 +32,22 @@ describe("EngramClient.checkCompatibility", () => {
   });
 
   it("should return compatible: true for server >= MIN_SERVER_VERSION", async () => {
-    mockFetch = mockFetchResponse({ version: "0.30.0" });
+    mockFetch = mockFetchResponse({ version: "0.31.0" });
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await client.checkCompatibility();
     expect(result.compatible).toBe(true);
-    expect(result.serverVersion).toBe("0.30.0");
+    expect(result.serverVersion).toBe("0.31.0");
     expect(result.minRequired).toBe(MIN_SERVER_VERSION);
   });
 
   it("should return compatible: false for older server", async () => {
-    mockFetch = mockFetchResponse({ version: "0.29.0" });
+    mockFetch = mockFetchResponse({ version: "0.30.0" });
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await client.checkCompatibility();
     expect(result.compatible).toBe(false);
-    expect(result.serverVersion).toBe("0.29.0");
+    expect(result.serverVersion).toBe("0.30.0");
   });
 
   it("should return compatible: false when version is missing", async () => {
@@ -60,16 +60,16 @@ describe("EngramClient.checkCompatibility", () => {
   });
 
   it("should compare patch versions correctly", async () => {
-    mockFetch = mockFetchResponse({ version: "0.29.99" });
+    mockFetch = mockFetchResponse({ version: "0.30.99" });
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await client.checkCompatibility();
-    // 0.29.99 < 0.30.0 (MIN_SERVER_VERSION)
+    // 0.30.99 < 0.31.0 (MIN_SERVER_VERSION)
     expect(result.compatible).toBe(false);
   });
 
   it("should return compatible: true for higher minor version", async () => {
-    mockFetch = mockFetchResponse({ version: "0.31.0" });
+    mockFetch = mockFetchResponse({ version: "0.32.0" });
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await client.checkCompatibility();

--- a/packages/sdk/tests/resources/crystals.test.ts
+++ b/packages/sdk/tests/resources/crystals.test.ts
@@ -560,6 +560,79 @@ describe("CrystalsResource", () => {
 
       expect(result.version).toBe(8);
     });
+
+    // skipEmbedding (#35) — high-frequency update optimization (ADR-017 OQ#2),
+    // depends on engram-server#65. SDK side just forwards the field; older
+    // servers silently ignore it.
+    it("should forward skipEmbedding: true in the PATCH body", async () => {
+      const mockCrystal = createMockCrystal({ title: "heartbeat" });
+      mockFetch = mockFetchResponse({ data: mockCrystal });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.crystals.update("crystal-123", {
+        contentInline: JSON.stringify({ lastHeartbeat: "2026-04-19T18:00:00Z" }),
+        skipEmbedding: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/crystals/crystal-123",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            contentInline: JSON.stringify({ lastHeartbeat: "2026-04-19T18:00:00Z" }),
+            skipEmbedding: true,
+          }),
+        }),
+      );
+    });
+
+    it("should forward skipEmbedding: false explicitly when set", async () => {
+      // Explicit `false` is meaningful: it overrides any policy-default the
+      // server may apply for the route. Not the same as omitting.
+      const mockCrystal = createMockCrystal({ title: "Updated" });
+      mockFetch = mockFetchResponse({ data: mockCrystal });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.crystals.update("crystal-123", {
+        title: "Updated",
+        skipEmbedding: false,
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+      expect(callBody).toHaveProperty("skipEmbedding", false);
+    });
+
+    it("should omit skipEmbedding when not supplied (backward compat)", async () => {
+      const mockCrystal = createMockCrystal({ title: "Updated" });
+      mockFetch = mockFetchResponse({ data: mockCrystal });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.crystals.update("crystal-123", { title: "Updated" });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+      expect(callBody).not.toHaveProperty("skipEmbedding");
+    });
+
+    it("should compose skipEmbedding with expectedVersion in the same PATCH", async () => {
+      // Both flags are independent and should appear together in the body.
+      // CAS still enforced server-side; embedding still skipped on success.
+      const mockCrystal = createMockCrystal({ title: "heartbeat", version: 8 });
+      mockFetch = mockFetchResponse({ data: mockCrystal });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await client.crystals.update("crystal-123", {
+        contentInline: '{"hb":"now"}',
+        expectedVersion: 7,
+        skipEmbedding: true,
+      });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+      expect(callBody).toMatchObject({
+        contentInline: '{"hb":"now"}',
+        expectedVersion: 7,
+        skipEmbedding: true,
+      });
+    });
   });
 
   // ========================================================================

--- a/packages/sdk/tests/resources/crystals.test.ts
+++ b/packages/sdk/tests/resources/crystals.test.ts
@@ -575,15 +575,16 @@ describe("CrystalsResource", () => {
         skipEmbedding: true,
       });
 
-      // Order-independent assertion via parse + toMatchObject — matches the
-      // style used by the sibling tests in this block and by the expectedVersion
-      // tests at lines 495-503. Raw JSON.stringify comparison is brittle under
-      // any future field-ordering or undefined-filtering change.
-      const callUrl = mockFetch.mock.calls[0]![0];
-      const callInit = mockFetch.mock.calls[0]![1];
-      expect(callUrl).toBe("http://localhost:3100/v1/crystals/crystal-123");
-      expect(callInit.method).toBe("PATCH");
-      expect(JSON.parse(callInit.body)).toMatchObject({
+      // URL + method via `expect.objectContaining` — matches the established
+      // expectedVersion test at line 486. Body via `toEqual` on the parsed
+      // object — exact match (catches accidental extra fields), order-
+      // independent (not brittle under future field-ordering changes).
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/crystals/crystal-123",
+        expect.objectContaining({ method: "PATCH" }),
+      );
+      const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+      expect(callBody).toEqual({
         contentInline: heartbeat,
         skipEmbedding: true,
       });
@@ -607,12 +608,20 @@ describe("CrystalsResource", () => {
       expect(callBody).toHaveProperty("skipEmbedding", false);
     });
 
-    it("should omit skipEmbedding when not supplied (backward compat)", async () => {
+    it("should omit skipEmbedding when explicitly set to undefined (documents absent-vs-undefined equivalence)", async () => {
+      // Callers who destructure an options object (e.g., `{...base, skipEmbedding: base.skipEmbedding}`)
+      // may pass `undefined`. `JSON.stringify` drops undefined values, so the
+      // wire body is identical to omitting the field. Pin this explicitly so
+      // a future undefined-preserving serializer change doesn't silently
+      // send `{"skipEmbedding": null}` or similar.
       const mockCrystal = createMockCrystal({ title: "Updated" });
       mockFetch = mockFetchResponse({ data: mockCrystal });
       vi.stubGlobal("fetch", mockFetch);
 
-      await client.crystals.update("crystal-123", { title: "Updated" });
+      await client.crystals.update("crystal-123", {
+        title: "Updated",
+        skipEmbedding: undefined,
+      });
 
       const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
       expect(callBody).not.toHaveProperty("skipEmbedding");

--- a/packages/sdk/tests/resources/crystals.test.ts
+++ b/packages/sdk/tests/resources/crystals.test.ts
@@ -608,20 +608,15 @@ describe("CrystalsResource", () => {
       expect(callBody).toHaveProperty("skipEmbedding", false);
     });
 
-    it("should omit skipEmbedding when explicitly set to undefined (documents absent-vs-undefined equivalence)", async () => {
-      // Callers who destructure an options object (e.g., `{...base, skipEmbedding: base.skipEmbedding}`)
-      // may pass `undefined`. `JSON.stringify` drops undefined values, so the
-      // wire body is identical to omitting the field. Pin this explicitly so
-      // a future undefined-preserving serializer change doesn't silently
-      // send `{"skipEmbedding": null}` or similar.
+    it("should omit skipEmbedding when not supplied (backward compat: regenerate embedding)", async () => {
+      // Mirrors the expectedVersion field-absent test above. A real caller
+      // who just wants normal update behavior omits the field entirely; this
+      // pins that the SDK does not inject a default on the wire.
       const mockCrystal = createMockCrystal({ title: "Updated" });
       mockFetch = mockFetchResponse({ data: mockCrystal });
       vi.stubGlobal("fetch", mockFetch);
 
-      await client.crystals.update("crystal-123", {
-        title: "Updated",
-        skipEmbedding: undefined,
-      });
+      await client.crystals.update("crystal-123", { title: "Updated" });
 
       const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
       expect(callBody).not.toHaveProperty("skipEmbedding");
@@ -653,7 +648,7 @@ describe("CrystalsResource", () => {
       // matters: a 409 OPERATION_VERSION_CONFLICT should still produce a
       // typed CrystalVersionConflictError regardless of whether
       // skipEmbedding was set on the request. Mirrors the expectedVersion-
-      // only conflict test but with skipEmbedding: true.
+      // only conflict test at line 506 but with skipEmbedding: true.
       mockFetch = mockFetchResponse(
         {
           code: "OPERATION_VERSION_CONFLICT",
@@ -664,17 +659,13 @@ describe("CrystalsResource", () => {
       );
       vi.stubGlobal("fetch", mockFetch);
 
-      try {
-        await client.crystals.update("crystal-123", {
-          contentInline: '{"hb":"now"}',
-          expectedVersion: 7,
-          skipEmbedding: true,
-        });
-        expect.fail("update should have thrown");
-      } catch (err) {
-        expect(err).toBeInstanceOf(CrystalVersionConflictError);
-        expect((err as CrystalVersionConflictError).currentVersion).toBe(9);
-      }
+      const update = client.crystals.update("crystal-123", {
+        contentInline: '{"hb":"now"}',
+        expectedVersion: 7,
+        skipEmbedding: true,
+      });
+      await expect(update).rejects.toBeInstanceOf(CrystalVersionConflictError);
+      await expect(update).rejects.toMatchObject({ currentVersion: 9 });
     });
   });
 

--- a/packages/sdk/tests/resources/crystals.test.ts
+++ b/packages/sdk/tests/resources/crystals.test.ts
@@ -569,26 +569,31 @@ describe("CrystalsResource", () => {
       mockFetch = mockFetchResponse({ data: mockCrystal });
       vi.stubGlobal("fetch", mockFetch);
 
+      const heartbeat = JSON.stringify({ lastHeartbeat: "2026-04-19T18:00:00Z" });
       await client.crystals.update("crystal-123", {
-        contentInline: JSON.stringify({ lastHeartbeat: "2026-04-19T18:00:00Z" }),
+        contentInline: heartbeat,
         skipEmbedding: true,
       });
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:3100/v1/crystals/crystal-123",
-        expect.objectContaining({
-          method: "PATCH",
-          body: JSON.stringify({
-            contentInline: JSON.stringify({ lastHeartbeat: "2026-04-19T18:00:00Z" }),
-            skipEmbedding: true,
-          }),
-        }),
-      );
+      // Order-independent assertion via parse + toMatchObject — matches the
+      // style used by the sibling tests in this block and by the expectedVersion
+      // tests at lines 495-503. Raw JSON.stringify comparison is brittle under
+      // any future field-ordering or undefined-filtering change.
+      const callUrl = mockFetch.mock.calls[0]![0];
+      const callInit = mockFetch.mock.calls[0]![1];
+      expect(callUrl).toBe("http://localhost:3100/v1/crystals/crystal-123");
+      expect(callInit.method).toBe("PATCH");
+      expect(JSON.parse(callInit.body)).toMatchObject({
+        contentInline: heartbeat,
+        skipEmbedding: true,
+      });
     });
 
     it("should forward skipEmbedding: false explicitly when set", async () => {
-      // Explicit `false` is meaningful: it overrides any policy-default the
-      // server may apply for the route. Not the same as omitting.
+      // Verifies the SDK does not suppress the field when the caller
+      // explicitly passes `false`. This is a serialization-fidelity test —
+      // whether explicit `false` is server-semantically distinct from
+      // omitting is a server concern, not the SDK's to assert.
       const mockCrystal = createMockCrystal({ title: "Updated" });
       mockFetch = mockFetchResponse({ data: mockCrystal });
       vi.stubGlobal("fetch", mockFetch);
@@ -632,6 +637,35 @@ describe("CrystalsResource", () => {
         expectedVersion: 7,
         skipEmbedding: true,
       });
+    });
+
+    it("should surface CAS conflict as CrystalVersionConflictError when skipEmbedding is set", async () => {
+      // The composition happy path is tested above. The failure mode also
+      // matters: a 409 OPERATION_VERSION_CONFLICT should still produce a
+      // typed CrystalVersionConflictError regardless of whether
+      // skipEmbedding was set on the request. Mirrors the expectedVersion-
+      // only conflict test but with skipEmbedding: true.
+      mockFetch = mockFetchResponse(
+        {
+          code: "OPERATION_VERSION_CONFLICT",
+          message: "expected version 7, got 9",
+          currentVersion: 9,
+        },
+        409,
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      try {
+        await client.crystals.update("crystal-123", {
+          contentInline: '{"hb":"now"}',
+          expectedVersion: 7,
+          skipEmbedding: true,
+        });
+        expect.fail("update should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(CrystalVersionConflictError);
+        expect((err as CrystalVersionConflictError).currentVersion).toBe(9);
+      }
     });
   });
 


### PR DESCRIPTION
Closes #35.

## Summary

Add optional \`skipEmbedding: boolean\` to \`UpdateKnowledgeCrystalParams\` so callers can elide the LLM embedding-regeneration cost on high-frequency status writes (heartbeats, lock holders, counters, last-seen timestamps) where the embedding is meaningless for semantic search.

The maintainer's R2 instance-heartbeat pattern is the driving consumer — every few seconds per instance × N instances × ~50–100ms LLM call = pure waste today. With \`skipEmbedding: true\`, that compute is reclaimed entirely.

## Sibling

This is the **SDK side**. The server-side counterpart is **centient-labs/engram-server#65**. The engram-server agent is implementing it in parallel; they ship together. Older servers silently ignore the field, so this PR can ship safely now and become useful as soon as the server-side lands.

## API addition

\`\`\`ts
export interface UpdateKnowledgeCrystalParams {
  // ...existing fields including expectedVersion...

  /**
   * When true, the server commits this update without regenerating the
   * crystal's embedding. Use only for fields where the embedding is
   * meaningless for semantic search (heartbeats, counters, status flags).
   * Composes with expectedVersion. Older servers ignore the field.
   */
  skipEmbedding?: boolean;
}
\`\`\`

Wire format: camelCase per ADR-018. Flows through the existing \`crystals.update\` path with no remapping.

## Composition with \`expectedVersion\`

Both flags are independent. Maintainer's typical heartbeat write needs both:

\`\`\`ts
await client.crystals.update(instanceCrystalId, {
  contentInline: JSON.stringify({ lastHeartbeat: now, holder: instanceId }),
  expectedVersion: localVersion,
  skipEmbedding: true,
});
\`\`\`

CAS still enforced; embedding still skipped on success.

## Backwards compatibility

Default \`false\` — pre-\`skipEmbedding\` behavior preserved. No changes to any existing caller.

\`MIN_SERVER_VERSION\` is **not bumped** in this PR — older servers ignore the field, so correctness is preserved against any server version. Bump will happen in a follow-up release once engram-server#65 lands and the version is known.

## Tests

4 new in \`packages/sdk/tests/resources/crystals.test.ts\`:

- Forwards \`skipEmbedding: true\` in the PATCH body (camelCase)
- Forwards explicit \`false\` (distinct from omitted)
- Omits when not supplied (backward-compat regression test)
- Composes with \`expectedVersion\` in the same PATCH body

390/390 SDK tests pass; full workspace build + lint + test green.

## Docs

New \`packages/sdk/docs/skip-embedding.md\` with:
- Quick-start example
- When-to-use checklist (heartbeats / counters / status flags ✅; content / titles / tags ❌)
- Composition example with \`expectedVersion\`
- "What this does NOT do" section (no embedding deletion, version still bumps, audit still emits, integrity checks still run)
- Server-requirements with the older-server-no-op guarantee
- Background section linking ADR-017 OQ#2

Linked from \`packages/sdk/README.md\`.

## Changeset

Minor bump (additive, backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)