### PR TITLE
fix(events,wal): bump @centient/logger dep to ^0.17.0

### DIFF
--- a/.changeset/events-logger-017.md
+++ b/.changeset/events-logger-017.md
@@ -1,0 +1,16 @@
+---
+"@centient/events": patch
+---
+
+Bump `@centient/logger` dep to `^0.17.0`.
+
+Follow-up to `@centient/logger@0.17.0` (which dropped the reserved `version`
+context slot and stopped silently stripping user-supplied `version` fields).
+No events API changes; runtime logger calls inside `jsonl.ts`, `replay.ts`,
+and `stream.ts` continue to work unchanged.
+
+Unblocks downstream `centient-labs/daemon#7` and any other consumer that
+imports both `@centient/events` and `@centient/logger` and wants to move
+to the 0.17.0 logger without a split-version install.
+
+Ref: centient-labs/centient-sdk#45.

--- a/.changeset/wal-logger-017.md
+++ b/.changeset/wal-logger-017.md
@@ -1,0 +1,17 @@
+---
+"@centient/wal": patch
+---
+
+Bump `@centient/logger` dep to `^0.17.0`.
+
+Follow-up to `@centient/logger@0.17.0` (which dropped the reserved `version`
+context slot and stopped silently stripping user-supplied `version` fields).
+No WAL API changes; runtime logger calls inside `wal.ts` and `replay.ts`
+continue to work unchanged.
+
+Aligns the workspace at the 0.17.x logger boundary alongside
+`@centient/events`. Without this bump, downstream consumers that depend on
+both `@centient/wal` and `@centient/logger@^0.17.0` would end up with a
+split-version install (wal pulls in 0.16.1 alongside the caller's 0.17.x).
+
+Ref: centient-labs/centient-sdk#45.


### PR DESCRIPTION
## Summary

- Closes #45 — bumps `@centient/events` and `@centient/wal` so their published metadata resolves `@centient/logger@^0.17.0`, eliminating the split-version install that currently blocks `centient-labs/daemon#7`.
- Two patch changesets, no source changes. Logger 0.17.0 dropped a reserved `version` slot (see #36) — events/wal don't use that slot, so the bump is drop-in.
- Sweep result: only events and wal directly depend on the logger; sdk and secrets do not.

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm --filter @centient/events build && test` — 60/60 pass
- [x] `pnpm --filter @centient/wal build && test` — 63/63 pass
- [x] workspace-wide `pnpm build && test` — 5 builds, 10 test suites green
- [x] No tests asserted on the now-removed `version=0.0.0` log slot
- [ ] Maintainer bot review
- [ ] Publish (changeset version + publish) after merge

## Coordination

After publish, comment on #45 closing it. Daemon's PR #7 can then bump events + logger together; daemon's pack-check gate will self-verify the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)