### PR TITLE
chore: add .mcp.json registering centient MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "centient": {
+      "type": "stdio",
+      "command": "centient",
+      "args": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` at repo root registering the `centient` MCP server (stdio transport).
- Part of the centient-labs standards rollout (Tier A repo).

## Test plan
- [x] File matches `/Users/owenjohnson/centient-labs/support/standards/templates/.mcp.json`
- [ ] CI passes