### PR TITLE
feat(sdk): add crystals.related(id)

### DIFF
--- a/.changeset/crystals-related.md
+++ b/.changeset/crystals-related.md
@@ -1,0 +1,7 @@
+---
+"@centient/sdk": patch
+---
+
+Add `crystals.related(id)` method that wraps `GET /v1/crystals/:id/related` and returns the paginated edge envelope as `{ edges, total, hasMore }`.
+
+The current server implementation returns graph neighbours (incoming + outgoing edges), not embedding-similarity matches — callers should label UI accordingly. Mirrors the typing pattern of `crystals.list()`.

--- a/packages/sdk/src/resources/crystals.ts
+++ b/packages/sdk/src/resources/crystals.ts
@@ -436,6 +436,29 @@ export class CrystalsResource extends BaseResource {
   }
 
   /**
+   * Get edges connected to a crystal node (graph neighbours).
+   *
+   * Returns all relationships where the node is either the source or target,
+   * flattened into a single list. The current implementation returns graph
+   * edges (incoming + outgoing), not embedding-similar nodes.
+   */
+  async related(id: string): Promise<{
+    edges: KnowledgeCrystalEdge[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    const response = await this.request<ApiSuccessResponse<KnowledgeCrystalEdge[]>>(
+      "GET",
+      `/v1/crystals/${encodeURIComponent(id)}/related`
+    );
+    return {
+      edges: response.data,
+      total: response.meta?.pagination?.total ?? response.data.length,
+      hasMore: response.meta?.pagination?.hasMore ?? false,
+    };
+  }
+
+  /**
    * List knowledge crystal nodes with optional filters.
    *
    * Use `nodeType` to filter by one or more node types (e.g. `"pattern"`,

--- a/packages/sdk/tests/unified-knowledge-crystal.test.ts
+++ b/packages/sdk/tests/unified-knowledge-crystal.test.ts
@@ -293,6 +293,52 @@ describe("CrystalsResource — nodeType filter (ADR-055)", () => {
     expect(node.nodeType).toBe("collection");
     expect(node.title).toBe("Auth Patterns");
   });
+
+  it("client.crystals.related fetches edges from /related and unwraps the envelope", async () => {
+    const outgoing = createMockEdge({
+      id: "edge-out",
+      sourceId: "node-target",
+      targetId: "neighbour-1",
+      relationship: "related_to",
+    });
+    const incoming = createMockEdge({
+      id: "edge-in",
+      sourceId: "neighbour-2",
+      targetId: "node-target",
+      relationship: "depends_on",
+    });
+    mockFetch = mockFetchResponse({
+      data: [outgoing, incoming],
+      meta: { pagination: { total: 2, limit: 2, offset: 0, hasMore: false } },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.crystals.related("node-target");
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("http://localhost:3100/v1/crystals/node-target/related");
+
+    expect(result.edges).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.hasMore).toBe(false);
+    expect(result.edges[0].id).toBe("edge-out");
+    expect(result.edges[1].id).toBe("edge-in");
+  });
+
+  it("client.crystals.related URL-encodes the crystal id", async () => {
+    mockFetch = mockFetchResponse({
+      data: [],
+      meta: { pagination: { total: 0, limit: 0, offset: 0, hasMore: false } },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await client.crystals.related("some/id with spaces");
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(
+      "http://localhost:3100/v1/crystals/some%2Fid%20with%20spaces/related"
+    );
+  });
 });
 
 // ============================================================================

--- a/packages/sdk/tests/unified-knowledge-crystal.test.ts
+++ b/packages/sdk/tests/unified-knowledge-crystal.test.ts
@@ -339,6 +339,31 @@ describe("CrystalsResource — nodeType filter (ADR-055)", () => {
       "http://localhost:3100/v1/crystals/some%2Fid%20with%20spaces/related"
     );
   });
+
+  it("client.crystals.related falls back to data.length when meta.pagination is absent", async () => {
+    const edge = createMockEdge({ id: "edge-no-meta" });
+    mockFetch = mockFetchResponse({ data: [edge] });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.crystals.related("node-1");
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("client.crystals.related propagates hasMore: true from the envelope", async () => {
+    mockFetch = mockFetchResponse({
+      data: [createMockEdge({ id: "edge-page-1" })],
+      meta: { pagination: { total: 10, limit: 1, offset: 0, hasMore: true } },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.crystals.related("node-1");
+
+    expect(result.hasMore).toBe(true);
+    expect(result.total).toBe(10);
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `client.crystals.related(id)` to the SDK, wrapping `GET /v1/crystals/:id/related`. Returns the paginated edge envelope unwrapped to `{ edges, total, hasMore }` — mirrors the typing pattern of `crystals.list()`.
- Adds a changeset for a `@centient/sdk` patch bump (1.7.0 → 1.7.1).
- Adds two unit tests: happy-path envelope unwrap and id URL-encoding.

## Caveat to flag (not fixing here)

The route is documented as "Get semantically related nodes" but the current server implementation calls `getNodeRelationships()` and returns graph edges (incoming + outgoing), not embedding-similar nodes. The SDK method is named `related()` (matches the URL) and the JSDoc spells out the actual behaviour.

UI consumers (engram-web search-polish PR is the first one) should label the affordance "Related items" / "Connections" rather than "Similar" until the server-side semantics are settled.

## Test plan

- [x] `pnpm test` — 393/393 pass (2 new)
- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)