### PR TITLE
docs(agent): pull phase b canonical templates

### DIFF
--- a/.agent/constraints/communication.md
+++ b/.agent/constraints/communication.md
@@ -1,0 +1,36 @@
+# Communication Constraints
+
+Style and tone directives that apply to every agent operating in
+centient-labs repos. These are non-negotiable across all sessions,
+regardless of which Claude model or which tool surface.
+
+The directive set is intended to grow over time. Add new directives
+under existing categories where they fit; add a new H2 when none does.
+
+## Banned phrases
+
+These phrases signal pseudo-virtuous hedging without adding information.
+They typically appear as preambles ("Honest answer:") or self-praise
+("To be honest with you,"). Drop them.
+
+- "honest answer" / "honest take" / "honest opinion"
+- "to be honest" / "to be honest with you"
+- "in all candor" / "candidly"
+- "frankly" (when used as a throat-clearing preamble, not as a natural adverb)
+- "to be perfectly clear" (when functioning as warm-up rather than for an actual clarification)
+
+**Why:** these phrases are visual noise the reader has to parse past to
+reach actual content. They also implicitly suggest *other* responses are
+dishonest, which corrodes trust.
+
+**What to do instead:** state the answer. If hedging is genuinely needed,
+name the specific uncertainty ("I haven't tested this", "this is a guess
+based on the file structure, not the runtime behavior") rather than
+claiming honesty. Specific uncertainty is informative; generic hedging is
+not.
+
+## Repo-specific
+
+<!-- Append repo-specific communication conventions here: domain
+     terminology rules, customer-facing tone guidelines, audience-specific
+     constraints, etc. -->

--- a/.agent/index.json
+++ b/.agent/index.json
@@ -5,62 +5,187 @@
     "DESIGN-PHILOSOPHY.md": {
       "purpose": "Tiered design principles (14 principles, 3 tiers) and tension resolution",
       "tokens": 800,
-      "triggers": ["principle", "philosophy", "design", "architecture", "trade-off", "why"]
+      "triggers": [
+        "principle",
+        "philosophy",
+        "design",
+        "architecture",
+        "trade-off",
+        "why"
+      ]
     },
     "STANDARDS.md": {
       "purpose": "TypeScript standards, package publishing, testing conventions",
       "tokens": 250,
-      "triggers": ["rule", "standard", "quality", "best practice", "typescript"]
+      "triggers": [
+        "rule",
+        "standard",
+        "quality",
+        "best practice",
+        "typescript"
+      ]
     },
     "constraints/security.md": {
       "purpose": "Security requirements and audit trail guidelines",
       "tokens": 250,
-      "triggers": ["security", "secret", "credential", "auth", "permission", "audit"]
+      "triggers": [
+        "security",
+        "secret",
+        "credential",
+        "auth",
+        "permission",
+        "audit"
+      ]
     },
     "constraints/observability.md": {
       "purpose": "Logging, cost tracking, audit trail, health signals",
       "tokens": 200,
-      "triggers": ["logging", "observability", "cost", "monitoring", "audit", "health"]
+      "triggers": [
+        "logging",
+        "observability",
+        "cost",
+        "monitoring",
+        "audit",
+        "health"
+      ]
     },
     "procedures/commits.md": {
       "purpose": "Git commit workflow, changesets versioning, and conventions",
       "tokens": 200,
-      "triggers": ["commit", "git", "branch", "merge", "pull request", "changeset", "version"]
+      "triggers": [
+        "commit",
+        "git",
+        "branch",
+        "merge",
+        "pull request",
+        "changeset",
+        "version"
+      ]
     },
     "patterns/error-handling.md": {
       "purpose": "Error handling with no silent degradation, idempotency, honest uncertainty",
       "tokens": 300,
-      "triggers": ["error", "exception", "failure", "catch", "try", "result"]
+      "triggers": [
+        "error",
+        "exception",
+        "failure",
+        "catch",
+        "try",
+        "result"
+      ]
     },
     "patterns/api-design.md": {
       "purpose": "API design: least surprise, idempotency, progressive disclosure, composability",
       "tokens": 250,
-      "triggers": ["api", "endpoint", "response", "idempotent", "batch", "composable"]
+      "triggers": [
+        "api",
+        "endpoint",
+        "response",
+        "idempotent",
+        "batch",
+        "composable"
+      ]
+    },
+    "patterns/known-pitfalls.md": {
+      "purpose": "Org-wide ecosystem traps — pnpm Packages: -N, octokit auth-cache stale-token, stacked-PR merge trap, auto-mode classifier",
+      "tokens": 600,
+      "triggers": [
+        "pitfall",
+        "gotcha",
+        "footgun",
+        "pnpm",
+        "auth-cache",
+        "stale token",
+        "stacked pr",
+        "merge trap",
+        "auto-mode",
+        "classifier"
+      ]
+    },
+    "procedures/handoff-creation.md": {
+      "purpose": "When/why/how to write a session handoff (sibling of handoff-template.md)",
+      "tokens": 400,
+      "triggers": [
+        "handoff",
+        "session-end",
+        "wrap-up",
+        "next session"
+      ]
+    },
+    "procedures/handoff-template.md": {
+      "purpose": "Fillable template for session handoffs (copy into docs/handoffs/)",
+      "tokens": 300,
+      "triggers": [
+        "handoff",
+        "template"
+      ]
+    },
+    "procedures/session-kickoff.md": {
+      "purpose": "What a fresh session does first — read CLAUDE.md, check handoffs, init MCP session, search memory, check repo state",
+      "tokens": 400,
+      "triggers": [
+        "kickoff",
+        "session-start",
+        "fresh session",
+        "new session"
+      ]
     }
   },
   "packages": {
     "sdk": {
       "path": "packages/sdk",
-      "triggers": ["sdk", "client", "engram", "resource", "session", "crystal"]
+      "triggers": [
+        "sdk",
+        "client",
+        "engram",
+        "resource",
+        "session",
+        "crystal"
+      ]
     },
     "logger": {
       "path": "packages/logger",
-      "triggers": ["logger", "logging", "transport", "audit", "sanitize"]
+      "triggers": [
+        "logger",
+        "logging",
+        "transport",
+        "audit",
+        "sanitize"
+      ]
     },
     "wal": {
       "path": "packages/wal",
-      "triggers": ["wal", "write-ahead", "crash", "recovery", "replay"]
+      "triggers": [
+        "wal",
+        "write-ahead",
+        "crash",
+        "recovery",
+        "replay"
+      ]
     },
     "sdk-python": {
       "path": "packages/sdk-python",
-      "triggers": ["python", "pydantic", "async", "sync"]
+      "triggers": [
+        "python",
+        "pydantic",
+        "async",
+        "sync"
+      ]
     }
   },
   "filePatterns": {
-    "*.test.*": ["procedures/commits.md"],
-    "*.spec.*": ["procedures/commits.md"],
-    ".env*": ["constraints/security.md"],
-    ".changeset/*": ["procedures/commits.md"]
+    "*.test.*": [
+      "procedures/commits.md"
+    ],
+    "*.spec.*": [
+      "procedures/commits.md"
+    ],
+    ".env*": [
+      "constraints/security.md"
+    ],
+    ".changeset/*": [
+      "procedures/commits.md"
+    ]
   },
   "scaffoldedAt": "2026-03-27T00:00:00.000Z",
   "crucibleVersion": "0.38.1"

--- a/.agent/index.json
+++ b/.agent/index.json
@@ -129,6 +129,20 @@
         "fresh session",
         "new session"
       ]
+    },
+    "constraints/communication.md": {
+      "purpose": "Agent-side communication style — banned phrases (no honest answer/take/etc preambles), tone directives",
+      "tokens": 300,
+      "triggers": [
+        "communication",
+        "style",
+        "tone",
+        "phrase",
+        "honest",
+        "candid",
+        "frankly",
+        "directive"
+      ]
     }
   },
   "packages": {

--- a/.agent/patterns/known-pitfalls.md
+++ b/.agent/patterns/known-pitfalls.md
@@ -1,0 +1,131 @@
+# Known Pitfalls
+
+Org-wide ecosystem traps that have bitten multiple repos and are worth
+keeping warm. Repos extend with `## Repo-specific` for their own gotchas.
+
+Each entry follows: **Symptom → Root cause → Diagnostic → Remedy.**
+
+## pnpm `Packages: -N` (net-negative install)
+
+**Symptom:** `pnpm install` reports `Packages: -N` for some N.
+
+**Root cause:** Existing `node_modules` is stale and `--frozen-lockfile`
+is pruning packages without restoring missing ones.
+
+**Diagnostic:** Compare `pnpm-lock.yaml` against `node_modules/.modules.yaml`.
+If the lockfile is ahead, prune-without-restore is the cause.
+
+**Remedy** depends on environment.
+
+**For local development:**
+
+```bash
+rm -rf node_modules
+pnpm install
+```
+
+**For CI** (where `--frozen-lockfile` is enforced): the underlying cause
+is lockfile drift versus the manifest, and `rm -rf node_modules` will not
+fix it — `--frozen-lockfile` will still fail. Instead, run `pnpm install`
+locally to update `pnpm-lock.yaml`, verify the diff (no unintended version
+bumps), and commit the updated lockfile. Re-running CI then succeeds.
+
+Applies to any pnpm-managed repo in the workspace.
+
+## octokit auth-cache stale-token
+
+**Symptom:** A GitHub adapter starts returning `AUTH_FAILED` on every call
+after roughly one hour of healthy operation. The App Installation is healthy
+and the PEM private key is intact.
+
+**Root cause:** `@octokit/auth-app` caches installation tokens internally.
+After the 1-hour TTL, there is a window where the cached token is expired
+but the cache hasn't refreshed; GitHub returns 401.
+
+**Diagnostic:** If the failure window aligns with the 1-hour TTL boundary
+and the PEM/App Installation are verified healthy, this is the cause.
+
+**Remedy:** Restart the process so the TokenProvider rebuilds its cache.
+Substitute the actual daemon/process name for `YOUR_SERVICE` below
+(document the concrete name under `## Repo-specific` when copying this
+template):
+
+- For daemons: `YOUR_SERVICE stop && YOUR_SERVICE start` (replace `YOUR_SERVICE` with the actual command name; angle-bracket syntax avoided here because `<word>` is valid POSIX shell input redirection)
+- For stateless workers: redeploy
+
+The next request after restart succeeds.
+
+**Structural fix candidate:** Wrap `@octokit/auth-app` in a thin layer that
+forces a token refresh on 401 before bubbling the error.
+
+Applies to any centient-labs repo using `@octokit/auth-app` for installation
+tokens.
+
+## Stacked-PR merge trap
+
+**Symptom:** `gh pr view PR_NUMBER` reports `state: MERGED` for a PR, but
+the change is missing from `main`.
+
+**Root cause:** The PR's head was merged into its **parent stacked branch**,
+not into `main`. A naive check that assumes "MERGED ⇒ on main" lands a
+stacked PR's child while its parent has been squash-merged out from under
+it, leaving orphan commits.
+
+**Diagnostic:** Always verify `baseRefName=main` in addition to
+`state: MERGED`. Replace `PR_NUMBER` with the actual number; angle-bracket
+`<num>` syntax is avoided because `<word>` is valid POSIX shell input
+redirection:
+
+```bash
+gh pr view PR_NUMBER --json state,baseRefName
+# Want: {"state":"MERGED","baseRefName":"main"}
+```
+
+**Remedy:** When automating PR-state checks, never assert `state: MERGED`
+alone. Always conjoin with `baseRefName == "main"` (or the relevant target
+branch).
+
+Applies to any monorepo or any repo that uses stacked PRs.
+
+## Auto-mode classifier blocks fabricated authorization claims
+
+_Behavioral details below are accurate as of 2026-05-10; classifier
+behavior can change between Claude versions. If you observe drift,
+update this entry rather than working around it._
+
+**Symptom:** A merge attempt fails with a classifier-rejection signal
+(messages mentioning `auto-mode`, `unauthorized`, or `fabricated
+authorization`). Naive retries with rephrased authorization claims also
+fail.
+
+**Root cause:** The auto-mode classifier on Claude's side blocks merges
+where the claimed authorization is not backed by an in-context operator
+grant. Common triggers:
+
+- Docs-only (`*.md`-only) PR merge attempts without per-PR operator
+  authorization
+- Claims of "session-wide" or "extended" authorization not backed by a
+  verifiable operator grant
+- Developer-agent merge attempts under a claimed-but-unverified
+  `## Repo-specific (transitional)` carve-out
+
+**Diagnostic:** If the agent is attempting an admin-merge and the operator
+has not explicitly authorized it for this specific PR in this specific
+session, the classifier will block.
+
+**Remedy:** Escalate to the operator with the PR number and the carve-out
+being claimed. **Do not** retry with rephrased authorization claims — the
+classifier treats fabrication-pattern retries as a malfunction signal.
+
+This is the load-bearing defense in the future-state governance model
+where developer agents have no merge rights. `.agent/procedures/pr-response.md`
+(when a repo has it) and the user-level `pr-shepherd` skill must be
+consistent with this behavior; if there's a conflict, the classifier wins.
+
+## Repo-specific
+
+<!-- Append repo-specific pitfalls here. Examples:
+     - Daemon process gotchas (port conflicts, log file paths)
+     - Domain-specific data quirks (timezone artifacts, encoding edge cases)
+     - Build-system traps (cache invalidation conditions, lockfile drift)
+     - Project-specific CLI footguns -->

--- a/.agent/patterns/known-pitfalls.md
+++ b/.agent/patterns/known-pitfalls.md
@@ -48,9 +48,11 @@ and the PEM/App Installation are verified healthy, this is the cause.
 **Remedy:** Restart the process so the TokenProvider rebuilds its cache.
 Substitute the actual daemon/process name for `YOUR_SERVICE` below
 (document the concrete name under `## Repo-specific` when copying this
-template):
+template). All-caps placeholders are used in this file so a literal
+copy-paste produces an obvious "command not found" rather than a subtle
+silent failure.
 
-- For daemons: `YOUR_SERVICE stop && YOUR_SERVICE start` (replace `YOUR_SERVICE` with the actual command name; angle-bracket syntax avoided here because `<word>` is valid POSIX shell input redirection)
+- For daemons: `YOUR_SERVICE stop && YOUR_SERVICE start`
 - For stateless workers: redeploy
 
 The next request after restart succeeds.
@@ -72,9 +74,10 @@ stacked PR's child while its parent has been squash-merged out from under
 it, leaving orphan commits.
 
 **Diagnostic:** Always verify `baseRefName=main` in addition to
-`state: MERGED`. Replace `PR_NUMBER` with the actual number; angle-bracket
-`<num>` syntax is avoided because `<word>` is valid POSIX shell input
-redirection:
+`state: MERGED`. Replace `PR_NUMBER` with the actual integer; the
+all-caps placeholder convention (also `YOUR_SERVICE` above) makes a
+forgetting-to-substitute mistake produce an obvious failure on first
+run:
 
 ```bash
 gh pr view PR_NUMBER --json state,baseRefName

--- a/.agent/procedures/handoff-creation.md
+++ b/.agent/procedures/handoff-creation.md
@@ -1,0 +1,97 @@
+# Handoff Creation Procedure
+
+When and how to write a session handoff. A handoff is a single file that lets
+a fresh session pick up cold without re-deriving state from git, memory, or
+chat history.
+
+Pairs with `procedures/handoff-template.md` (the actual template) and
+`procedures/session-kickoff.md` (the reader's procedure).
+
+## When to write a handoff
+
+Write one when ANY of these holds:
+
+- Work spans multiple sessions or multiple days
+- State is complex: open PRs across repos, in-flight migrations, partial
+  implementations, blocked-on-upstream items
+- Bug-bash or incident wrap-up where context will be needed later
+- Workstream charter (longer-term initiative with multiple stages)
+- Session-end checkpoint regardless of completion — the next session should
+  know what's in flight
+
+Skip when:
+
+- The work fully completed in-session and shipped
+- Trivial fixes / single-PR work where the PR description carries full context
+- Read-only exploration with no follow-up
+
+## Where it goes
+
+`docs/handoffs/HANDOFF-YYYY-MM-DD-topic.md` (e.g.,
+`docs/handoffs/HANDOFF-2026-05-09-shepherd-system.md`).
+
+For workspace-meta repos without a `docs/` directory, a top-level `HANDOFF.md`
+is acceptable as a current-snapshot file — but rotate to `docs/handoffs/`
+when the directory is created.
+
+## What it must contain
+
+Minimum sections (see `handoff-template.md` for the fillable structure):
+
+1. **Priority for next session** — 1-3 specific actions, in order
+2. **What was accomplished** — concrete, with PR links / file paths / metrics
+3. **Open follow-ups** — known unfinished items with current state
+4. **Operational notes** — commands, paths, credential references (vault
+   entry names, keychain entries, or env var names — never actual secret
+   values) the next session will need
+5. **Hard guardrails** — anything the next session must not do, and why
+
+## How to write one
+
+1. Copy the template (creating `docs/handoffs/` if needed). Set the
+   `topic` shell variable to a kebab-case slug of the workstream; the
+   snippet interpolates it into the destination filename. The default
+   value is intentionally invalid so the snippet refuses to proceed
+   if you forget to edit it. (`REPLACE_ME` matches the `YOUR_SERVICE`
+   placeholder convention used in `patterns/known-pitfalls.md`.)
+   ```bash
+   topic=REPLACE_ME    # <-- EDIT THIS to your kebab-case slug
+   : "${topic:?set topic= to a kebab-case slug}"
+   if [ "$topic" = REPLACE_ME ]; then
+     echo "edit topic= first" >&2
+     exit 1
+   fi
+   mkdir -p docs/handoffs && \
+     cp .agent/procedures/handoff-template.md \
+        "docs/handoffs/HANDOFF-$(date +%Y-%m-%d)-${topic}.md"
+   ```
+2. Fill in sections top-to-bottom. The template marks each section
+   **(required)** or **(optional)**:
+   - **Required sections** (the minimum-section set above) must remain
+     in the file. If a required section has nothing real to say, write
+     a one-line `n/a — <reason>` rather than deleting the heading.
+   - **Optional sections** can be deleted cleanly when they don't apply.
+     Empty optional sections rot; either fill them or remove them.
+3. Cite specific PRs / issues / commits with **full URLs**. Handoffs are
+   read in fresh contexts where short refs are ambiguous.
+4. **Convert relative dates to absolute.** "Thursday" → "2026-05-15."
+   Handoffs outlive their relative time references.
+5. Date the file in its frontmatter or H1 subtitle.
+
+## Anti-patterns
+
+- **"We'll figure it out" sections.** If you don't know, say
+  "Open question: X" with the question framed.
+- **Vague pointers.** "Check the auth code" → "Check
+  `src/auth/token-provider.ts:142` — the token cache TTL handling."
+- **Relative time references.** "Yesterday" / "next week" → absolute dates.
+- **Copy-paste from chat.** Synthesize. The handoff is a contract, not a
+  transcript.
+- **Burying decisions.** Open questions and pending decisions go in their
+  own section, not inline in narrative prose.
+
+## Repo-specific
+
+<!-- Append repo-specific handoff conventions here: storage location overrides,
+     naming conventions, required cross-references (e.g., ADR links),
+     cadence (every release, every incident, weekly). -->

--- a/.agent/procedures/handoff-creation.md
+++ b/.agent/procedures/handoff-creation.md
@@ -50,21 +50,21 @@ Minimum sections (see `handoff-template.md` for the fillable structure):
 
 1. Copy the template (creating `docs/handoffs/` if needed). Set the
    `topic` shell variable to a kebab-case slug of the workstream; the
-   snippet interpolates it into the destination filename. The default
-   value is intentionally invalid so the snippet refuses to proceed
-   if you forget to edit it. (`REPLACE_ME` matches the `YOUR_SERVICE`
-   placeholder convention used in `patterns/known-pitfalls.md`.)
+   snippet interpolates it into the destination filename. The sentinel
+   default refuses to proceed if you forget to edit, and `cp -n`
+   prevents silently overwriting a same-day handoff for the same topic.
    ```bash
    topic=REPLACE_ME    # <-- EDIT THIS to your kebab-case slug
-   : "${topic:?set topic= to a kebab-case slug}"
-   if [ "$topic" = REPLACE_ME ]; then
-     echo "edit topic= first" >&2
+   if [ "$topic" = REPLACE_ME ] || [ -z "$topic" ]; then
+     echo "edit topic= to a kebab-case slug first" >&2
      exit 1
    fi
    mkdir -p docs/handoffs && \
-     cp .agent/procedures/handoff-template.md \
-        "docs/handoffs/HANDOFF-$(date +%Y-%m-%d)-${topic}.md"
+     cp -n .agent/procedures/handoff-template.md \
+           "docs/handoffs/HANDOFF-$(date +%Y-%m-%d)-${topic}.md"
    ```
+   `cp -n` exits non-zero without overwrite if the destination already
+   exists; re-run with a different `topic` if you hit that case.
 2. Fill in sections top-to-bottom. The template marks each section
    **(required)** or **(optional)**:
    - **Required sections** (the minimum-section set above) must remain

--- a/.agent/procedures/handoff-template.md
+++ b/.agent/procedures/handoff-template.md
@@ -1,0 +1,66 @@
+# Handoff: <one-line topic>
+
+**Date:** YYYY-MM-DD
+**Author:** <agent or operator name>
+**Predecessor:** <previous handoff filename, if any — repo-relative path or full GitHub URL>
+
+<!-- Copy this file to docs/handoffs/HANDOFF-YYYY-MM-DD-topic.md and fill in.
+     Sections labelled (required) below are the minimum-section set
+     enforced by procedures/handoff-creation.md — do not delete them. If
+     a required section has nothing to say, write a one-line "n/a —
+     <reason>" instead of removing the heading.
+     Sections labelled (optional) may be deleted cleanly when they do
+     not apply. See procedures/handoff-creation.md for guidance. -->
+
+## Priority for next session **(required)**
+
+1. <action 1 — specific, with PR/issue/file references>
+2. <action 2>
+3. <action 3>
+
+## What was accomplished **(required)**
+
+### <Workstream name>
+
+- <PR or shipped change with full URL>
+- <Metric or concrete outcome — e.g., "17/19 repos compliant", "4 PRs merged">
+
+### <Another workstream, if any>
+
+...
+
+## Open follow-ups **(required)**
+
+| Item | State | Owner | Blocker |
+|------|-------|-------|---------|
+| [description] | open / in-review / blocked | [name or "—"] | [issue link or "—"] |
+
+## Operational notes **(required)**
+
+### Commands
+
+```bash
+# Common commands the next session will need
+```
+
+### Paths and credentials
+
+- `<path>` — what it's for
+- Credential source: <vault entry name / keychain entry / env var>
+
+## Hard guardrails **(required)**
+
+- <Thing the next session must not do, with reason>
+- <Example: "Do not push to `main` of `support/maintainer` while #189 is open
+   — pnpm test passthrough bug will fail CI">
+
+## Open questions **(optional)**
+
+- <Question framed as a question, with the decision-maker named if known>
+
+## References **(optional)**
+
+- ADRs: <links>
+- Issues: <links>
+- PRs: <links>
+- Prior handoffs: <links>

--- a/.agent/procedures/session-kickoff.md
+++ b/.agent/procedures/session-kickoff.md
@@ -1,0 +1,90 @@
+# Session Kickoff Procedure
+
+What a fresh session does first, before any task-specific work. Pairs with
+`procedures/session-management.md` (MCP knowledge tools used throughout the
+session) and `procedures/handoff-creation.md` (the writer's side of the
+handoff/kickoff loop).
+
+## Standard kickoff sequence
+
+In order:
+
+1. **Read `CLAUDE.md`** (auto-loaded). Verify it has the design-philosophy
+   pointer and the Session & Knowledge Management block.
+2. **Check for recent handoffs** at `docs/handoffs/HANDOFF-*.md`. The
+   most recent one tells you what's in flight. Gate on the directory
+   first so missing-dir is a clean no-op without globally silencing
+   stderr (which would hide real I/O errors like permission denials
+   or broken symlinks):
+   ```bash
+   latest=
+   if [ -d docs/handoffs ]; then
+     latest=$(find docs/handoffs -maxdepth 1 -type f -name 'HANDOFF-*.md' | sort | tail -1)
+   fi
+   if [ -n "$latest" ]; then
+     cat "$latest"
+   fi
+   # empty $latest = no handoff yet (safe under set -e)
+   ```
+   The `YYYY-MM-DD` filename prefix makes lexicographic sort
+   chronological. Do NOT use mtime — it is affected by checkout order.
+   `-type f` filters out any directory that happens to match the glob.
+   Test the **value of `$latest`**, not the pipeline's `$?`: `find ...
+   | sort | tail` exits 0 whether or not anything matched, so `$?`
+   cannot distinguish "no handoff" from "I/O error" — only the value
+   of `$latest` can.
+3. **Initialize the MCP session.** Call `mcp__centient__start_session_coordination`
+   with `sessionId="YYYY-MM-DD-<keyword>"` and the absolute `projectPath`.
+   See `procedures/session-management.md` for parameters.
+4. **Search memory for the task topic.** Call `mcp__centient__search_crystals`
+   with the keyword. Skim the top results for prior decisions.
+5. **Check repo state** (fetch first — `git status -sb` only reports
+   ahead/behind against locally-cached remote refs, which can be stale):
+   ```bash
+   git fetch --prune
+   git status -sb
+   git log --oneline -10
+   gh pr list --state open --author "@me"
+   ```
+
+## When to skip steps
+
+- **Trivial tasks** (typo fixes, single-line changes): skip steps 3-5.
+- **MCP unavailable**: skip steps 3-4. Note in your first response so the
+  operator knows the knowledge layer is offline.
+- **No `docs/handoffs/`**: skip step 2 silently.
+- **No prior PRs by the agent**: step 5's `gh pr list` returns empty, which
+  is fine.
+
+## What you should know after kickoff
+
+By the end of the kickoff sequence, you should be able to answer:
+
+1. What is the in-flight workstream, if any?
+2. What PRs are open and at what review state?
+3. What did the previous session leave for this one?
+4. Are there active branches I should switch to, or stay off of?
+
+If you can't answer these, keep digging before starting the user's task.
+The kickoff is cheap; an uninformed first action is expensive.
+
+## Anti-patterns
+
+- **Skipping the handoff read** and then asking the user "what should I
+  work on?" — they'll point you at the handoff. Read it first.
+- **Initializing the MCP session after starting work.** Duplicate-detection
+  and search lose value if state isn't established up front.
+- **Treating kickoff as ceremony.** If a step gives you nothing useful,
+  that's a signal — note it, don't fail. But don't skip steps because
+  "they probably won't help."
+- **Branching from a stale local `main`.** `git status -sb` reads
+  locally-cached remote-tracking refs; without a preceding `git fetch`,
+  ahead/behind counts may be hours or days out of date. Always fetch
+  first (step 5 does this) before deciding whether to rebase or branch.
+
+## Repo-specific
+
+<!-- Append repo-specific kickoff steps here: daemon health checks,
+     cluster connectivity probes, project-specific status commands
+     (e.g., "maintainer status" before working on the maintainer repo),
+     credential verification. -->

--- a/.agent/procedures/session-kickoff.md
+++ b/.agent/procedures/session-kickoff.md
@@ -41,11 +41,14 @@ In order:
 5. **Check repo state** (fetch first — `git status -sb` only reports
    ahead/behind against locally-cached remote refs, which can be stale):
    ```bash
-   git fetch --prune
+   git fetch --prune --quiet
    git status -sb
    git log --oneline -10
    gh pr list --state open --author "@me"
    ```
+   `--quiet` suppresses the per-ref output but still reports actual errors.
+   On large repos the fetch can add noticeable latency; skip steps 3-5
+   entirely for trivial tasks per "When to skip steps" below.
 
 ## When to skip steps
 


### PR DESCRIPTION
## Summary

Phase D of the shepherd-system restructure (centient-labs/workspace#20).

Pulls four RECOMMENDED canonical templates from `support/standards/templates/.agent/` (shipped in centient-labs/standards#11) into this repo's `.agent/` directory:

- `procedures/handoff-creation.md` — when/why/how to write a handoff
- `procedures/handoff-template.md` — fillable handoff template
- `procedures/session-kickoff.md` — what a fresh session does first
- `patterns/known-pitfalls.md` — org-wide ecosystem traps (pnpm `Packages: -N`, octokit auth-cache stale, stacked-PR merge trap, auto-mode classifier)

`.agent/index.json` updated to register all four.

## What this is NOT

- No canonical content modified — pure copy-from-canonical
- No `## Repo-specific (transitional)` extension — this repo does not have a maintainer-style transitional state
- No CLAUDE.md changes — `.agent/` content not duplicated into CLAUDE.md per conventions

## Verify

After merge, run from workspace root:

    bash support/release-toolkit/lib/audit-agent-docs.sh

This repo's row should flip KP / HOC / HOT / KIK columns from "rec" to "yes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
