### PR TITLE
fix(sdk): shape-guard the remaining sync read paths (advances #62)

### DIFF
--- a/.changeset/sdk-sync-shape-guards.md
+++ b/.changeset/sdk-sync-shape-guards.md
@@ -1,0 +1,9 @@
+---
+"@centient/sdk": patch
+---
+
+Complete runtime response-shape validation across the sync resource:
+`getStatus`, `pullFrom`, and `resolveConflict` now reject a null/malformed
+`data` envelope with a structured `EngramError` (instead of a downstream
+`TypeError`), consistent with the guards already on `push`/`pushTo`/
+`listConflicts`/peers. No change for well-formed responses. (Advances #62.)

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -446,7 +446,17 @@ export class SyncResource extends BaseResource {
       "GET",
       "/v1/sync/status"
     );
-    return response.data;
+    const data = requireData(response.data, "GET /v1/sync/status");
+    if (
+      typeof data.schemaVersion !== "string" ||
+      typeof data.changelogSize !== "number"
+    ) {
+      throw new EngramError(
+        "Unexpected GET /v1/sync/status response shape",
+        "INTERNAL_ERROR",
+      );
+    }
+    return data;
   }
 
   /**
@@ -486,7 +496,17 @@ export class SyncResource extends BaseResource {
       "POST",
       path
     );
-    return response.data;
+    const data = requireData(response.data, "POST /v1/sync/pull-from");
+    if (
+      typeof data.entriesStreamed !== "number" ||
+      typeof data.duration !== "number"
+    ) {
+      throw new EngramError(
+        "Unexpected POST /v1/sync/pull-from response shape",
+        "INTERNAL_ERROR",
+      );
+    }
+    return data;
   }
 
   /**
@@ -532,6 +552,13 @@ export class SyncResource extends BaseResource {
       `/v1/sync/conflicts/${encodeURIComponent(id)}/resolve`,
       params
     );
-    return response.data;
+    const data = requireData(response.data, "POST /v1/sync/conflicts/{id}/resolve");
+    if (typeof data.id !== "string") {
+      throw new EngramError(
+        "Unexpected POST /v1/sync/conflicts/{id}/resolve response shape",
+        "INTERNAL_ERROR",
+      );
+    }
+    return data;
   }
 }

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -500,13 +500,16 @@ export class SyncResource extends BaseResource {
       path
     );
     const data = requireData(response.data, "POST /v1/sync/pull-from");
+    // Required numeric fields must be present; maxSeq is optional/nullable —
+    // only reject it when present with a non-string value (an absent or null
+    // maxSeq is a valid "no entries" response and must not be rejected).
     if (
       typeof data.entriesStreamed !== "number" ||
       typeof data.duration !== "number" ||
-      !(data.maxSeq === null || typeof data.maxSeq === "string")
+      (data.maxSeq != null && typeof data.maxSeq !== "string")
     ) {
       throw new EngramError(
-        "Unexpected POST /v1/sync/pull-from response shape (expected { entriesStreamed: number, maxSeq: string | null, duration: number })",
+        "Unexpected POST /v1/sync/pull-from response shape (expected { entriesStreamed: number, maxSeq?: string | null, duration: number })",
         "INTERNAL_ERROR",
       );
     }
@@ -557,12 +560,13 @@ export class SyncResource extends BaseResource {
       params
     );
     const data = requireData(response.data, "POST /v1/sync/conflicts/{id}/resolve");
-    // Structural validation only (forward-compatible): non-nullable string
-    // fields via typeof, and nullable timestamps as `string | null`. `winner`
-    // and `resolution` are checked as strings rather than against fixed literal
-    // sets so a future server-side enum value isn't rejected. localValue /
-    // remoteValue are `unknown`, so presence-only.
-    const isStringOrNull = (v: unknown) => v === null || typeof v === "string";
+    // Validate the required identifying string fields via typeof (winner /
+    // resolution as plain strings so a future server-side enum value isn't
+    // rejected). The nullable timestamps are validated only when present with a
+    // non-string, non-null value — an absent key is a legitimate wire variant
+    // of `null` and must not be rejected. localValue / remoteValue are
+    // `unknown`, so they're not validated here.
+    const badNullableString = (v: unknown) => v != null && typeof v !== "string";
     if (
       typeof data.id !== "string" ||
       typeof data.entityType !== "string" ||
@@ -571,11 +575,9 @@ export class SyncResource extends BaseResource {
       typeof data.winner !== "string" ||
       typeof data.resolution !== "string" ||
       typeof data.createdAt !== "string" ||
-      !("localValue" in data) ||
-      !("remoteValue" in data) ||
-      !isStringOrNull(data.localUpdatedAt) ||
-      !isStringOrNull(data.remoteUpdatedAt) ||
-      !isStringOrNull(data.resolvedAt)
+      badNullableString(data.localUpdatedAt) ||
+      badNullableString(data.remoteUpdatedAt) ||
+      badNullableString(data.resolvedAt)
     ) {
       throw new EngramError(
         "Unexpected POST /v1/sync/conflicts/{id}/resolve response shape (expected a full SyncConflict)",

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -448,11 +448,14 @@ export class SyncResource extends BaseResource {
     );
     const data = requireData(response.data, "GET /v1/sync/status");
     if (
+      typeof data.instanceId !== "string" ||
       typeof data.schemaVersion !== "string" ||
+      typeof data.peersCount !== "number" ||
+      typeof data.activeLinksCount !== "number" ||
       typeof data.changelogSize !== "number"
     ) {
       throw new EngramError(
-        "Unexpected GET /v1/sync/status response shape",
+        "Unexpected GET /v1/sync/status response shape (expected { instanceId: string, schemaVersion: string, peersCount: number, activeLinksCount: number, changelogSize: number })",
         "INTERNAL_ERROR",
       );
     }
@@ -499,10 +502,11 @@ export class SyncResource extends BaseResource {
     const data = requireData(response.data, "POST /v1/sync/pull-from");
     if (
       typeof data.entriesStreamed !== "number" ||
-      typeof data.duration !== "number"
+      typeof data.duration !== "number" ||
+      !("maxSeq" in data)
     ) {
       throw new EngramError(
-        "Unexpected POST /v1/sync/pull-from response shape",
+        "Unexpected POST /v1/sync/pull-from response shape (expected { entriesStreamed: number, maxSeq: string | null, duration: number })",
         "INTERNAL_ERROR",
       );
     }
@@ -553,9 +557,23 @@ export class SyncResource extends BaseResource {
       params
     );
     const data = requireData(response.data, "POST /v1/sync/conflicts/{id}/resolve");
-    if (typeof data.id !== "string") {
+    // Validate the non-nullable fields callers rely on. The nullable fields
+    // (localUpdatedAt, remoteUpdatedAt, resolvedAt) and `unknown`-typed values
+    // (localValue, remoteValue) are checked for presence only.
+    if (
+      typeof data.id !== "string" ||
+      typeof data.entityType !== "string" ||
+      typeof data.entityId !== "string" ||
+      typeof data.fieldName !== "string" ||
+      typeof data.winner !== "string" ||
+      typeof data.resolution !== "string" ||
+      typeof data.createdAt !== "string" ||
+      !("localValue" in data) ||
+      !("remoteValue" in data) ||
+      !("resolvedAt" in data)
+    ) {
       throw new EngramError(
-        "Unexpected POST /v1/sync/conflicts/{id}/resolve response shape",
+        "Unexpected POST /v1/sync/conflicts/{id}/resolve response shape (expected a full SyncConflict)",
         "INTERNAL_ERROR",
       );
     }

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -503,7 +503,7 @@ export class SyncResource extends BaseResource {
     if (
       typeof data.entriesStreamed !== "number" ||
       typeof data.duration !== "number" ||
-      !("maxSeq" in data)
+      !(data.maxSeq === null || typeof data.maxSeq === "string")
     ) {
       throw new EngramError(
         "Unexpected POST /v1/sync/pull-from response shape (expected { entriesStreamed: number, maxSeq: string | null, duration: number })",
@@ -557,19 +557,23 @@ export class SyncResource extends BaseResource {
       params
     );
     const data = requireData(response.data, "POST /v1/sync/conflicts/{id}/resolve");
-    // Validate the non-nullable fields callers rely on. The nullable fields
-    // (localUpdatedAt, remoteUpdatedAt, resolvedAt) and `unknown`-typed values
-    // (localValue, remoteValue) are checked for presence only.
+    // Validate the non-nullable string fields callers rely on, the discriminated
+    // unions against their allowed members, and the presence of every nullable /
+    // `unknown`-typed field (localValue, remoteValue, localUpdatedAt,
+    // remoteUpdatedAt, resolvedAt) so a missing field can't masquerade as
+    // `null`.
     if (
       typeof data.id !== "string" ||
       typeof data.entityType !== "string" ||
       typeof data.entityId !== "string" ||
       typeof data.fieldName !== "string" ||
-      typeof data.winner !== "string" ||
-      typeof data.resolution !== "string" ||
+      (data.winner !== "local" && data.winner !== "remote") ||
+      (data.resolution !== "auto_lww" && data.resolution !== "manual") ||
       typeof data.createdAt !== "string" ||
       !("localValue" in data) ||
       !("remoteValue" in data) ||
+      !("localUpdatedAt" in data) ||
+      !("remoteUpdatedAt" in data) ||
       !("resolvedAt" in data)
     ) {
       throw new EngramError(

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -557,24 +557,25 @@ export class SyncResource extends BaseResource {
       params
     );
     const data = requireData(response.data, "POST /v1/sync/conflicts/{id}/resolve");
-    // Validate the non-nullable string fields callers rely on, the discriminated
-    // unions against their allowed members, and the presence of every nullable /
-    // `unknown`-typed field (localValue, remoteValue, localUpdatedAt,
-    // remoteUpdatedAt, resolvedAt) so a missing field can't masquerade as
-    // `null`.
+    // Structural validation only (forward-compatible): non-nullable string
+    // fields via typeof, and nullable timestamps as `string | null`. `winner`
+    // and `resolution` are checked as strings rather than against fixed literal
+    // sets so a future server-side enum value isn't rejected. localValue /
+    // remoteValue are `unknown`, so presence-only.
+    const isStringOrNull = (v: unknown) => v === null || typeof v === "string";
     if (
       typeof data.id !== "string" ||
       typeof data.entityType !== "string" ||
       typeof data.entityId !== "string" ||
       typeof data.fieldName !== "string" ||
-      (data.winner !== "local" && data.winner !== "remote") ||
-      (data.resolution !== "auto_lww" && data.resolution !== "manual") ||
+      typeof data.winner !== "string" ||
+      typeof data.resolution !== "string" ||
       typeof data.createdAt !== "string" ||
       !("localValue" in data) ||
       !("remoteValue" in data) ||
-      !("localUpdatedAt" in data) ||
-      !("remoteUpdatedAt" in data) ||
-      !("resolvedAt" in data)
+      !isStringOrNull(data.localUpdatedAt) ||
+      !isStringOrNull(data.remoteUpdatedAt) ||
+      !isStringOrNull(data.resolvedAt)
     ) {
       throw new EngramError(
         "Unexpected POST /v1/sync/conflicts/{id}/resolve response shape (expected a full SyncConflict)",

--- a/packages/sdk/src/resources/sync.ts
+++ b/packages/sdk/src/resources/sync.ts
@@ -513,7 +513,9 @@ export class SyncResource extends BaseResource {
         "INTERNAL_ERROR",
       );
     }
-    return data;
+    // Normalize an absent maxSeq to `null` so the return matches the declared
+    // `string | null` type (never `undefined`).
+    return { ...data, maxSeq: data.maxSeq ?? null };
   }
 
   /**
@@ -584,6 +586,13 @@ export class SyncResource extends BaseResource {
         "INTERNAL_ERROR",
       );
     }
-    return data;
+    // Normalize absent nullable timestamps to `null` so the return matches the
+    // declared `string | null` types (never `undefined`).
+    return {
+      ...data,
+      localUpdatedAt: data.localUpdatedAt ?? null,
+      remoteUpdatedAt: data.remoteUpdatedAt ?? null,
+      resolvedAt: data.resolvedAt ?? null,
+    };
   }
 }

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -581,6 +581,8 @@ describe("SyncResource", () => {
 
       const result = await client.sync.pullFrom("my-peer");
       expect(result.entriesStreamed).toBe(0);
+      // An absent maxSeq is normalized to null (matches the string | null type).
+      expect(result.maxSeq).toBeNull();
     });
 
     it("throws EngramError on null data", async () => {
@@ -747,6 +749,19 @@ describe("SyncResource", () => {
 
       const result = await client.sync.resolveConflict("conflict-1");
       expect(result.id).toBe("conflict-1");
+      // Absent timestamps are normalized to null (match the string | null type).
+      expect(result.localUpdatedAt).toBeNull();
+      expect(result.remoteUpdatedAt).toBeNull();
+      expect(result.resolvedAt).toBeNull();
+    });
+
+    it("throws EngramError on null data", async () => {
+      mockFetch = mockFetchResponse({ data: null });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.sync.resolveConflict("conflict-1")
+      ).rejects.toBeInstanceOf(EngramError);
     });
   });
 });

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -571,6 +571,37 @@ describe("SyncResource", () => {
         EngramError
       );
     });
+
+    it("throws EngramError on null data", async () => {
+      mockFetch = mockFetchResponse({ data: null });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.pullFrom("my-peer")).rejects.toBeInstanceOf(
+        EngramError
+      );
+    });
+
+    it("throws EngramError when entriesStreamed has the wrong type", async () => {
+      mockFetch = mockFetchResponse({
+        data: { entriesStreamed: "five", maxSeq: "120", duration: 90 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.pullFrom("my-peer")).rejects.toBeInstanceOf(
+        EngramError
+      );
+    });
+
+    it("throws EngramError when maxSeq is a non-string/non-null value", async () => {
+      mockFetch = mockFetchResponse({
+        data: { entriesStreamed: 5, maxSeq: 42, duration: 90 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.pullFrom("my-peer")).rejects.toBeInstanceOf(
+        EngramError
+      );
+    });
   });
 
   describe("sync.listConflicts", () => {
@@ -629,6 +660,8 @@ describe("SyncResource", () => {
         fieldName: "title",
         localValue: "Local Title",
         remoteValue: "Remote Title",
+        localUpdatedAt: null,
+        remoteUpdatedAt: null,
         winner: "local",
         resolution: "manual",
         resolvedAt: "2026-01-25T12:00:00Z",
@@ -653,6 +686,39 @@ describe("SyncResource", () => {
       mockFetch = mockFetchResponse({ data: {} });
       vi.stubGlobal("fetch", mockFetch);
 
+      await expect(
+        client.sync.resolveConflict("conflict-1")
+      ).rejects.toBeInstanceOf(EngramError);
+    });
+
+    it("throws EngramError on an out-of-union winner / resolution", async () => {
+      const base = {
+        id: "conflict-1",
+        entityType: "crystal",
+        entityId: "c-1",
+        fieldName: "title",
+        localValue: "L",
+        remoteValue: "R",
+        localUpdatedAt: null,
+        remoteUpdatedAt: null,
+        resolvedAt: null,
+        createdAt: "2026-01-25T10:00:00Z",
+      };
+
+      // winner not in {local, remote}
+      mockFetch = mockFetchResponse({
+        data: { ...base, winner: "tie", resolution: "manual" },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+      await expect(
+        client.sync.resolveConflict("conflict-1")
+      ).rejects.toBeInstanceOf(EngramError);
+
+      // resolution not in {auto_lww, manual}
+      mockFetch = mockFetchResponse({
+        data: { ...base, winner: "local", resolution: "coin_flip" },
+      });
+      vi.stubGlobal("fetch", mockFetch);
       await expect(
         client.sync.resolveConflict("conflict-1")
       ).rejects.toBeInstanceOf(EngramError);

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -691,34 +691,26 @@ describe("SyncResource", () => {
       ).rejects.toBeInstanceOf(EngramError);
     });
 
-    it("throws EngramError on an out-of-union winner / resolution", async () => {
-      const base = {
-        id: "conflict-1",
-        entityType: "crystal",
-        entityId: "c-1",
-        fieldName: "title",
-        localValue: "L",
-        remoteValue: "R",
-        localUpdatedAt: null,
-        remoteUpdatedAt: null,
-        resolvedAt: null,
-        createdAt: "2026-01-25T10:00:00Z",
-      };
-
-      // winner not in {local, remote}
+    it("throws EngramError when a nullable timestamp has the wrong type", async () => {
+      // localUpdatedAt must be string | null — a number must be rejected.
       mockFetch = mockFetchResponse({
-        data: { ...base, winner: "tie", resolution: "manual" },
+        data: {
+          id: "conflict-1",
+          entityType: "crystal",
+          entityId: "c-1",
+          fieldName: "title",
+          localValue: "L",
+          remoteValue: "R",
+          localUpdatedAt: 42,
+          remoteUpdatedAt: null,
+          resolvedAt: null,
+          winner: "local",
+          resolution: "manual",
+          createdAt: "2026-01-25T10:00:00Z",
+        },
       });
       vi.stubGlobal("fetch", mockFetch);
-      await expect(
-        client.sync.resolveConflict("conflict-1")
-      ).rejects.toBeInstanceOf(EngramError);
 
-      // resolution not in {auto_lww, manual}
-      mockFetch = mockFetchResponse({
-        data: { ...base, winner: "local", resolution: "coin_flip" },
-      });
-      vi.stubGlobal("fetch", mockFetch);
       await expect(
         client.sync.resolveConflict("conflict-1")
       ).rejects.toBeInstanceOf(EngramError);

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -474,6 +474,13 @@ describe("SyncResource", () => {
       expect(status.schemaVersion).toBe("1.0.0");
       expect(status.changelogSize).toBe(42);
     });
+
+    it("throws EngramError on a malformed response (null data)", async () => {
+      mockFetch = mockFetchResponse({ data: null });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.getStatus()).rejects.toBeInstanceOf(EngramError);
+    });
   });
 
   describe("sync.pushTo", () => {
@@ -524,6 +531,15 @@ describe("SyncResource", () => {
 
       expect(result.entriesStreamed).toBe(5);
       expect(result.maxSeq).toBe("120");
+    });
+
+    it("throws EngramError when entriesStreamed/duration are missing", async () => {
+      mockFetch = mockFetchResponse({ data: { maxSeq: "120" } });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.pullFrom("my-peer")).rejects.toBeInstanceOf(
+        EngramError
+      );
     });
   });
 
@@ -601,6 +617,15 @@ describe("SyncResource", () => {
 
       expect(result.id).toBe("conflict-1");
       expect(result.resolvedAt).toBe("2026-01-25T12:00:00Z");
+    });
+
+    it("throws EngramError when the resolved conflict has no id", async () => {
+      mockFetch = mockFetchResponse({ data: {} });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(
+        client.sync.resolveConflict("conflict-1")
+      ).rejects.toBeInstanceOf(EngramError);
     });
   });
 });

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -572,6 +572,17 @@ describe("SyncResource", () => {
       );
     });
 
+    it("accepts a response that omits maxSeq (no-entries case)", async () => {
+      // maxSeq is optional/nullable — an absent key must NOT be rejected.
+      mockFetch = mockFetchResponse({
+        data: { entriesStreamed: 0, duration: 4 },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.pullFrom("my-peer");
+      expect(result.entriesStreamed).toBe(0);
+    });
+
     it("throws EngramError on null data", async () => {
       mockFetch = mockFetchResponse({ data: null });
       vi.stubGlobal("fetch", mockFetch);
@@ -714,6 +725,28 @@ describe("SyncResource", () => {
       await expect(
         client.sync.resolveConflict("conflict-1")
       ).rejects.toBeInstanceOf(EngramError);
+    });
+
+    it("accepts a conflict that omits the nullable timestamp keys", async () => {
+      // Absent localUpdatedAt/remoteUpdatedAt/resolvedAt is a legitimate wire
+      // variant of null and must NOT be rejected.
+      mockFetch = mockFetchResponse({
+        data: {
+          id: "conflict-1",
+          entityType: "crystal",
+          entityId: "c-1",
+          fieldName: "title",
+          localValue: "L",
+          remoteValue: "R",
+          winner: "local",
+          resolution: "manual",
+          createdAt: "2026-01-25T10:00:00Z",
+        },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.sync.resolveConflict("conflict-1");
+      expect(result.id).toBe("conflict-1");
     });
   });
 });

--- a/packages/sdk/tests/resources/sync.test.ts
+++ b/packages/sdk/tests/resources/sync.test.ts
@@ -481,6 +481,36 @@ describe("SyncResource", () => {
 
       await expect(client.sync.getStatus()).rejects.toBeInstanceOf(EngramError);
     });
+
+    it("throws EngramError when a required field has the wrong type", async () => {
+      // schemaVersion as a number must hit the typeof guard, not just the null path.
+      mockFetch = mockFetchResponse({
+        data: {
+          instanceId: "inst-1",
+          schemaVersion: 1,
+          peersCount: 2,
+          activeLinksCount: 1,
+          changelogSize: 42,
+        },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.getStatus()).rejects.toBeInstanceOf(EngramError);
+    });
+
+    it("throws EngramError when instanceId is missing", async () => {
+      mockFetch = mockFetchResponse({
+        data: {
+          schemaVersion: "1.0.0",
+          peersCount: 2,
+          activeLinksCount: 1,
+          changelogSize: 42,
+        },
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await expect(client.sync.getStatus()).rejects.toBeInstanceOf(EngramError);
+    });
   });
 
   describe("sync.pushTo", () => {


### PR DESCRIPTION
## Summary

Advances #62 (exhaustive runtime response-shape validation). #58 added shape guards to the sync methods it touched (`push`/`pushTo`/`listConflicts`/peers/`pull`); this completes the **sync resource** by guarding the three that were still unguarded:

- `getStatus()` — `requireData` + `schemaVersion` is a string / `changelogSize` is a number.
- `pullFrom()` — `requireData` + `entriesStreamed` / `duration` are numbers.
- `resolveConflict()` — `requireData` + the resolved conflict has a string `id`.

A null or malformed `data` envelope now throws a structured `EngramError` at the boundary instead of a `TypeError` at the call site, reusing the existing `requireData` helper for consistency.

## Scope
This is the **sync-resource increment** of #62. Other resources' read paths can adopt the same pattern incrementally; #62 stays open to track that. Kept deliberately small to stay reviewable.

## Verification
- `npm run build` ✅ · `npm test` ✅ **419 passed** (+3 negative-path tests) · `npm run lint` ✅ · patch changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)