### PR TITLE
fix(sdk): add jitter to retry backoff [gap-none-retry-jitter]

### DIFF
--- a/.changeset/remediate-gap-none-retry-jitter.md
+++ b/.changeset/remediate-gap-none-retry-jitter.md
@@ -1,0 +1,5 @@
+---
+"@centient/sdk": patch
+---
+
+Add jitter to retry backoff: every retry site now sleeps `retryDelay * attempt + Math.random() * retryDelay * 0.5` via a single `backoffDelay` method, so synchronized consumers no longer retry in lockstep against a struggling server. The linear base budget is unchanged; worst case adds at most `0.5 * retryDelay` per attempt.

--- a/.changeset/remediate-gap-none-retry-jitter.md
+++ b/.changeset/remediate-gap-none-retry-jitter.md
@@ -2,4 +2,6 @@
 "@centient/sdk": patch
 ---
 
-Add jitter to retry backoff: every retry site now sleeps `retryDelay * attempt + Math.random() * retryDelay * 0.5` via a single `backoffDelay` method, so synchronized consumers no longer retry in lockstep against a struggling server. The linear base budget is unchanged; worst case adds at most `0.5 * retryDelay` per attempt.
+Add jitter to retry backoff: every retry site now sleeps `retryDelay * attempt + Math.random() * retryDelay * 0.5` via a single `backoffDelay` method, so synchronized consumers no longer retry in lockstep against a struggling server.
+
+**Behavioral change:** retry delays were previously deterministic (`retryDelay * attempt` exactly); they are now randomized within `[retryDelay * attempt, retryDelay * attempt + 0.5 * retryDelay)`. The linear base budget is unchanged and the worst case adds at most `0.5 * retryDelay` per attempt, but tests or monitors that assert exact retry timing must either tolerate the jitter window or stub `Math.random()` to pin delays.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -242,6 +242,11 @@ export class EngramClient {
   private readonly userId?: string;
   private readonly timeout: number;
   private readonly retries: number;
+  /**
+   * Base retry delay in ms. Actual sleep before retry `attempt` is
+   * `attempt * retryDelay` plus a random jitter of up to `0.5 * retryDelay`
+   * (see {@link backoffDelay}) to avoid synchronized retry storms.
+   */
   private readonly retryDelay: number;
 
   /**
@@ -467,7 +472,7 @@ export class EngramClient {
           response.status >= 500 &&
           attempt < this.retries
         ) {
-          await this.sleep(this.retryDelay * attempt);
+          await this.sleep(this.backoffDelay(attempt));
           return this._requestRaw(method, path, body, attempt + 1);
         }
         parseApiError(response.status, errorData);
@@ -486,7 +491,7 @@ export class EngramClient {
       }
 
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        await this.sleep(this.backoffDelay(attempt));
         return this._requestRaw(method, path, body, attempt + 1);
       }
 
@@ -555,7 +560,7 @@ export class EngramClient {
           errorData = { error: { message: errorText } };
         }
         if (response.status >= 500 && attempt < this.retries) {
-          await this.sleep(this.retryDelay * attempt);
+          await this.sleep(this.backoffDelay(attempt));
           return this._requestRawBody<T>(method, path, rawBody, contentType, attempt + 1);
         }
         parseApiError(response.status, errorData);
@@ -592,7 +597,7 @@ export class EngramClient {
       }
 
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        await this.sleep(this.backoffDelay(attempt));
         return this._requestRawBody<T>(method, path, rawBody, contentType, attempt + 1);
       }
 
@@ -643,7 +648,7 @@ export class EngramClient {
 
       if (!response.ok) {
         if (response.status >= 500 && attempt < this.retries) {
-          await this.sleep(this.retryDelay * attempt);
+          await this.sleep(this.backoffDelay(attempt));
           return this._requestFormData<T>(method, path, formData, attempt + 1);
         }
         parseApiError(response.status, data);
@@ -662,7 +667,7 @@ export class EngramClient {
       }
 
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        await this.sleep(this.backoffDelay(attempt));
         return this._requestFormData<T>(method, path, formData, attempt + 1);
       }
 
@@ -737,7 +742,7 @@ export class EngramClient {
           error.statusCode >= 500 &&
           attempt < this.retries
         ) {
-          await this.sleep(this.retryDelay * attempt);
+          await this.sleep(this.backoffDelay(attempt));
           return this.request<T>(method, path, body, attempt + 1);
         }
         throw error;
@@ -745,7 +750,7 @@ export class EngramClient {
 
       // Handle network errors with retry
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        await this.sleep(this.backoffDelay(attempt));
         return this.request<T>(method, path, body, attempt + 1);
       }
 
@@ -754,6 +759,19 @@ export class EngramClient {
         error instanceof Error ? error : undefined,
       );
     }
+  }
+
+  /**
+   * Compute the sleep duration before retry `attempt` (1-based): the linear
+   * base (`attempt * retryDelay`) plus a random jitter in
+   * `[0, 0.5 * retryDelay)` so synchronized consumers do not retry in
+   * lockstep against a struggling server. Worst-case total retry time stays
+   * within the documented linear budget plus `0.5 * retryDelay` per attempt.
+   * Every retry site MUST route its sleep through this method — no inline
+   * `retryDelay` multiplications (enforced by a source-grep test).
+   */
+  private backoffDelay(attempt: number): number {
+    return this.retryDelay * attempt + Math.random() * this.retryDelay * 0.5;
   }
 
   private sleep(ms: number): Promise<void> {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1400,7 +1400,13 @@ export interface EngramClientConfig {
   timeout?: number;
   /** Number of retry attempts for failed requests (default: 3) */
   retries?: number;
-  /** Base delay between retries in ms (default: 1000) */
+  /**
+   * Base delay between retries in ms (default: 1000). Each retry sleeps the
+   * linear base (`attempt * retryDelay`) plus a random jitter of up to
+   * `0.5 * retryDelay`, so synchronized clients do not retry in lockstep
+   * against a struggling server. Worst-case total retry time is the linear
+   * budget plus `0.5 * retryDelay` per attempt.
+   */
   retryDelay?: number;
 }
 

--- a/packages/sdk/tests/client.test.ts
+++ b/packages/sdk/tests/client.test.ts
@@ -4,6 +4,7 @@
  * Tests for all SDK client methods, mocking fetch to verify correct API calls.
  */
 
+import { readFileSync } from "node:fs";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { EngramClient, createEngramClient } from "../src/client.js";
 import { EngramError, NotFoundError, TimeoutError } from "../src/errors.js";
@@ -877,5 +878,135 @@ describe("EngramClient", () => {
       expect(result.status).toBe("ok");
     });
 
+  });
+
+  // ============================================
+  // Retry Backoff Jitter
+  // ============================================
+
+  describe("Retry Backoff Jitter", () => {
+    const RETRY_DELAY = 1000;
+
+    /** Reach into the private method — its contract is what the ticket pins. */
+    function getBackoff(c: EngramClient): (attempt: number) => number {
+      return (
+        c as unknown as { backoffDelay(attempt: number): number }
+      ).backoffDelay.bind(c);
+    }
+
+    it("backoffDelay returns base + Math.random() * 0.5 * retryDelay (stubbed Math.random)", () => {
+      const client = new EngramClient({
+        baseUrl: "http://localhost:3100",
+        retryDelay: RETRY_DELAY,
+      });
+      const backoff = getBackoff(client);
+      const randomSpy = vi.spyOn(Math, "random");
+
+      for (const attempt of [1, 2, 3, 5]) {
+        const base = RETRY_DELAY * attempt;
+
+        // Lower bound: random = 0 → exactly the linear base (budget unchanged)
+        randomSpy.mockReturnValue(0);
+        expect(backoff(attempt)).toBe(base);
+
+        // Midpoint: random = 0.5 → base + 0.25 * retryDelay
+        randomSpy.mockReturnValue(0.5);
+        expect(backoff(attempt)).toBe(base + 0.5 * RETRY_DELAY * 0.5);
+
+        // Upper bound: random → 1 stays strictly under base + 0.5 * retryDelay
+        randomSpy.mockReturnValue(0.999999);
+        const nearMax = backoff(attempt);
+        expect(nearMax).toBeLessThan(base + 0.5 * RETRY_DELAY);
+        expect(nearMax).toBeCloseTo(base + 0.999999 * 0.5 * RETRY_DELAY, 6);
+      }
+
+      randomSpy.mockRestore();
+    });
+
+    it("backoffDelay stays within [base, base + 0.5 * retryDelay) with real Math.random", () => {
+      const client = new EngramClient({
+        baseUrl: "http://localhost:3100",
+        retryDelay: RETRY_DELAY,
+      });
+      const backoff = getBackoff(client);
+
+      for (const attempt of [1, 2, 3]) {
+        const base = RETRY_DELAY * attempt;
+        for (let i = 0; i < 50; i++) {
+          const delay = backoff(attempt);
+          expect(delay).toBeGreaterThanOrEqual(base);
+          expect(delay).toBeLessThan(base + 0.5 * RETRY_DELAY);
+        }
+      }
+    });
+
+    it("retry path sleeps the jittered duration from backoffDelay", async () => {
+      const client = new EngramClient({
+        baseUrl: "http://localhost:3100",
+        retries: 2,
+        retryDelay: 10,
+      });
+
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const sleepSpy = vi
+        .spyOn(
+          client as unknown as { sleep(ms: number): Promise<void> },
+          "sleep"
+        )
+        .mockResolvedValue(undefined);
+
+      let callCount = 0;
+      mockFetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount < 2) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: () =>
+              Promise.resolve({ code: "INTERNAL_ERROR", message: "boom" }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await client.health();
+      expect(result.status).toBe("ok");
+      // attempt 1 → 10 * 1 + 0.5 * 10 * 0.5 = 12.5
+      expect(sleepSpy).toHaveBeenCalledTimes(1);
+      expect(sleepSpy).toHaveBeenCalledWith(12.5);
+
+      randomSpy.mockRestore();
+      sleepSpy.mockRestore();
+    });
+
+    it("all retry sites route through backoffDelay (no inline retryDelay multiplications)", () => {
+      const source = readFileSync(
+        new URL("../src/client.ts", import.meta.url),
+        "utf8"
+      );
+
+      // Every sleep call must take backoffDelay(attempt) — never an inline product.
+      const sleepCalls =
+        source.match(/this\.sleep\((?:[^()]|\([^()]*\))*\)/g) ?? [];
+      expect(sleepCalls.length).toBeGreaterThanOrEqual(8);
+      for (const call of sleepCalls) {
+        expect(call).toBe("this.sleep(this.backoffDelay(attempt))");
+      }
+
+      // `retryDelay *` appears exactly once: backoffDelay's own return line.
+      const multiplicationLines = source
+        .split("\n")
+        .filter((line) => /retryDelay \*/.test(line));
+      expect(multiplicationLines).toHaveLength(1);
+      expect(multiplicationLines[0]).toContain("Math.random()");
+      expect(multiplicationLines[0]).toContain(
+        "this.retryDelay * attempt + Math.random() * this.retryDelay * 0.5"
+      );
+    });
   });
 });


### PR DESCRIPTION
Hardening backlog ticket gap-none-retry-jitter (docs/hardening/BACKLOG.md) — phase 5 of the hardening pipeline.

## Gap

All 6+ retry sites in packages/sdk/src/client.ts (470, 489, 558, 595, 665, 748) sleep exactly retryDelay*attempt with zero jitter — synchronized consumers retry in lockstep against a struggling engram-server.

## What changed

Implemented jittered retry backoff per spec. Commit a1b07c1 on remediate/gap-none-retry-jitter (pushed).

Changes:
- /packages/sdk/src/client.ts: added private backoffDelay(attempt) returning `this.retryDelay * attempt + Math.random() * this.retryDelay * 0.5` (single line, full-jitter-lite, linear base preserved); replaced ALL inline `this.sleep(this.retryDelay * attempt)` calls with `this.sleep(this.backoffDelay(attempt))` — there were 8 retry sites, not 6 (ticket said "6+"): _requestRaw (5xx + network), _requestRawBody (5xx + network), _requestFormData (5xx + network), request (5xx-EngramError + network). Added JSDoc on the private retryDelay field and on backoffDelay documenting the jitter and worst-case bound.
- /packages/sdk/src/types.ts: EngramClientConfig.retryDelay JSDoc updated to document the jitter and that worst-case total retry time is the linear budget + 0.5*retryDelay per attempt.
- /packages/sdk/tests/client.test.ts: new "Retry Backoff Jitter" describe — (1) stubbed Math.random pins exact lower bound (random=0 → exactly base, budget unchanged), midpoint, and near-upper bound strictly < base + 0.5*retryDelay for attempts 1,2,3,5; (2) real-Math.random property test asserts [base, base + 0.5*retryDelay) over 50 samples per attempt; (3) end-to-end retry path test spies the private sleep and asserts the jittered argument (12.5 for retryDelay=10, attempt=1, random=0.5); (4) source-grep enforcement test reads src/client.ts and asserts every this.sleep(...) call is exactly this.sleep(this.backoffDelay(attempt)) (>=8 sites) and `retryDelay *` appears on exactly one line (backoffDelay's return). Existing retry-count tests unchanged; TimeoutError/EngramError/NetworkError non-retry semantics untouched (only sleep arguments changed).
- Changeset added: yes — /.changeset/remediate-gap-none-retry-jitter.md, "@centient/sdk": patch.

Guards verified: `grep -rn 'retryDelay \*' packages/sdk/src/` returns only client.ts:774 (backoffDelay's return line — JSDoc deliberately phrases the formula as `attempt * retryDelay` so comments cannot match the guard grep); existing retry tests pass with the same attempt counts; JSDoc updated in both config type and field.

Conservative readings: (a) ticket listed 6 line numbers but 8 inline multiplications existed — all 8 were routed through backoffDelay (the only reading consistent with the acceptance criterion); (b) spec offered "grep in test or eslint rule" — implemented as a source-read assertion in the test suite. Environment note: the worktree's scripts/release-toolkit git submodule was uninitialized, which broke make; ran `git submodule update --init scripts/release-toolkit` (checked out the recorded commit b55a0f9, no diff introduced) before make check.

## Verification

make check green: true; adversarial refutation verdict: survived.

Refuter summary: Could not refute. Branch remediate/gap-none-retry-jitter (a1b07c1) closes gap-none-retry-jitter: a single private backoffDelay(attempt) implements the exact specified formula, all 8 retry sleep sites route through it (grep confirms `retryDelay *` appears only on backoffDelay's return line), TimeoutError/EngramError non-retry semantics and existing retry-count tests are untouched, and JSDoc on retryDelay in both client.ts and types.ts documents the jitter and budget bound. The new tests stub Math.random to pin bounds and enforce no-inline-multiplication via source grep; both mutations I tried (removing jitter, reverting one site to inline) were caught by the new tests. Full sdk suite passes 436/436. No retry path sleeps a deterministic duration, and worst-case retry time stays within the linear budget + 0.5*retryDelay per attempt.

## Guards

- [x] grep 'retryDelay \*' returns only backoffDelay's own line
- [x] Existing retry-count tests unchanged (same number of attempts)
- [x] TimeoutError/EngramError non-retry semantics untouched
- [x] JSDoc on retryDelay updated to mention jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
