### PR TITLE
feat(sdk): optional client logger for retries, timeouts and exhaustion [gap-none-sdk-client-logging]

### DIFF
--- a/.changeset/remediate-gap-none-sdk-client-logging.md
+++ b/.changeset/remediate-gap-none-sdk-client-logging.md
@@ -1,0 +1,20 @@
+---
+"@centient/sdk": minor
+---
+
+Add optional `logger` to `EngramClientConfig` for client-side request
+diagnostics. The client previously performed zero logging, so retries,
+timeouts, and network errors were invisible to consumers diagnosing hangs vs
+retry storms. With a logger injected, the client emits `debug` for each retry
+(attempt number, delay, error class, HTTP method + path) and `warn` when
+retries are exhausted or a request times out — across all four request paths
+(`request`, `_requestRaw`, `_requestRawBody`, `_requestFormData`).
+
+The logger contract is a minimal structural interface (`ClientLogger`,
+context-first `debug`/`warn`) that a `@centient/logger` instance satisfies
+directly — `@centient/logger` is NOT a runtime dependency (the SDK stays
+zero-dependency). Default is a no-op: without a logger the client emits
+nothing (no console fallback). All logged context is routed through sanitize
+helpers: method + pathname only — never headers (`X-API-Key`,
+`Authorization`), request bodies, query strings, or error messages (which can
+embed full URLs).

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -48,6 +48,36 @@ const results = await client.search(session.id, {
 });
 ```
 
+## Request logging
+
+The client is **silent by default** — no console output, ever. To make
+retries, exhausted retry budgets, and timeouts observable (e.g. when
+diagnosing a hang vs. a retry storm), inject an optional `logger`:
+
+```typescript
+import { createEngramClient } from "@centient/sdk";
+import { createLogger } from "@centient/logger";
+
+const client = createEngramClient({
+  logger: createLogger({ service: "my-agent" }),
+});
+```
+
+`logger` is a minimal *structural* interface (`ClientLogger`): any object with
+context-first `debug(context, message)` and `warn(context, message)` methods
+works — a `@centient/logger` instance satisfies it directly, but
+`@centient/logger` is **not** a runtime dependency of the SDK.
+
+What gets logged:
+
+- `debug` — each retry: attempt number, delay, error class, HTTP method + path
+- `warn` — retries exhausted, and request timeouts (`TimeoutError`)
+
+Everything is sanitized before it reaches the logger: HTTP method and
+**pathname only**. Headers (`X-API-Key`, `Authorization`), request bodies,
+query strings/fragments, and error messages (which can embed full URLs) are
+never logged.
+
 ## Features
 
 - 13+ resource classes covering sessions, notes, crystals, entities, search, and more

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -824,6 +824,14 @@ export class EngramClient {
   // sanitization contract is enforced in exactly one place: method + sanitized
   // pathname + error CLASS only. Never headers, request bodies, error
   // messages, or query strings (which can carry search text or credentials).
+  //
+  // errorClass at the raw-response 5xx retry sites (_requestRaw /
+  // _requestRawBody / _requestFormData) is the literal "HttpError": no error
+  // instance exists at that point — parseApiError only constructs one after
+  // retries are exhausted — so the literal names the category and the logged
+  // `status` carries the real diagnostic. The request() catch path retries an
+  // already-thrown EngramError and therefore logs the actual class via
+  // sanitizeErrorClass.
 
   /** Log a single retry at debug level. */
   private logRetry(

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -10,6 +10,12 @@ import {
   TimeoutError,
   parseApiError,
 } from "./errors.js";
+import {
+  NOOP_CLIENT_LOGGER,
+  sanitizeErrorClass,
+  sanitizeRequestPath,
+  type ClientLogger,
+} from "./logging.js";
 import { SessionsResource, NotesResource, EdgesResource, SessionLinksResource, CrystalsResource, TerrafirmaResource, ExportImportResource, EntitiesResource, ExtractionResource, EventsResource, AgentsResource, AmbientContextResource, FactsResource, MemorySpacesResource, UsersResource, AuditResource, SyncResource, GcResource, MaintenanceResource } from "./resources/index.js";
 import type {
   AddRelationshipRequest,
@@ -243,6 +249,13 @@ export class EngramClient {
   private readonly timeout: number;
   private readonly retries: number;
   private readonly retryDelay: number;
+  /**
+   * Client-side diagnostics logger (retries, exhaustion, timeouts). Defaults
+   * to a no-op: without an injected logger the client is completely silent.
+   * Everything logged is routed through the sanitize helpers in logging.ts —
+   * method + pathname only; never headers, bodies, or query strings.
+   */
+  private readonly logger: ClientLogger;
 
   /**
    * Resource-based access to sessions (engram Knowledge API)
@@ -360,6 +373,7 @@ export class EngramClient {
     this.timeout = config.timeout ?? DEFAULT_TIMEOUT;
     this.retries = config.retries ?? DEFAULT_RETRIES;
     this.retryDelay = config.retryDelay ?? DEFAULT_RETRY_DELAY;
+    this.logger = config.logger ?? NOOP_CLIENT_LOGGER;
 
     // Initialize resource accessors
     this.sessions = new SessionsResource(this);
@@ -463,12 +477,14 @@ export class EngramClient {
         } catch {
           errorData = { error: { message: await response.text() } };
         }
-        if (
-          response.status >= 500 &&
-          attempt < this.retries
-        ) {
-          await this.sleep(this.retryDelay * attempt);
-          return this._requestRaw(method, path, body, attempt + 1);
+        if (response.status >= 500) {
+          if (attempt < this.retries) {
+            const delayMs = this.retryDelay * attempt;
+            this.logRetry(method, path, attempt, delayMs, "HttpError", response.status);
+            await this.sleep(delayMs);
+            return this._requestRaw(method, path, body, attempt + 1);
+          }
+          this.logRetriesExhausted(method, path, attempt, "HttpError", response.status);
         }
         parseApiError(response.status, errorData);
       }
@@ -478,6 +494,7 @@ export class EngramClient {
       clearTimeout(timeoutId);
 
       if (error instanceof Error && error.name === "AbortError") {
+        this.logTimeout(method, path, attempt);
         throw new TimeoutError(this.timeout);
       }
 
@@ -486,10 +503,13 @@ export class EngramClient {
       }
 
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        const delayMs = this.retryDelay * attempt;
+        this.logRetry(method, path, attempt, delayMs, sanitizeErrorClass(error));
+        await this.sleep(delayMs);
         return this._requestRaw(method, path, body, attempt + 1);
       }
 
+      this.logRetriesExhausted(method, path, attempt, sanitizeErrorClass(error));
       throw new NetworkError(
         `Failed to ${method} ${path}: ${error instanceof Error ? error.message : "Unknown error"}`,
         error instanceof Error ? error : undefined,
@@ -554,9 +574,14 @@ export class EngramClient {
         } catch {
           errorData = { error: { message: errorText } };
         }
-        if (response.status >= 500 && attempt < this.retries) {
-          await this.sleep(this.retryDelay * attempt);
-          return this._requestRawBody<T>(method, path, rawBody, contentType, attempt + 1);
+        if (response.status >= 500) {
+          if (attempt < this.retries) {
+            const delayMs = this.retryDelay * attempt;
+            this.logRetry(method, path, attempt, delayMs, "HttpError", response.status);
+            await this.sleep(delayMs);
+            return this._requestRawBody<T>(method, path, rawBody, contentType, attempt + 1);
+          }
+          this.logRetriesExhausted(method, path, attempt, "HttpError", response.status);
         }
         parseApiError(response.status, errorData);
       }
@@ -575,6 +600,7 @@ export class EngramClient {
       clearTimeout(timeoutId);
 
       if (error instanceof Error && error.name === "AbortError") {
+        this.logTimeout(method, path, attempt);
         throw new TimeoutError(this.timeout);
       }
 
@@ -592,10 +618,13 @@ export class EngramClient {
       }
 
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        const delayMs = this.retryDelay * attempt;
+        this.logRetry(method, path, attempt, delayMs, sanitizeErrorClass(error));
+        await this.sleep(delayMs);
         return this._requestRawBody<T>(method, path, rawBody, contentType, attempt + 1);
       }
 
+      this.logRetriesExhausted(method, path, attempt, sanitizeErrorClass(error));
       throw new NetworkError(
         `Failed to ${method} ${path}: ${error instanceof Error ? error.message : "Unknown error"}`,
         error instanceof Error ? error : undefined,
@@ -642,9 +671,14 @@ export class EngramClient {
       const data = await response.json();
 
       if (!response.ok) {
-        if (response.status >= 500 && attempt < this.retries) {
-          await this.sleep(this.retryDelay * attempt);
-          return this._requestFormData<T>(method, path, formData, attempt + 1);
+        if (response.status >= 500) {
+          if (attempt < this.retries) {
+            const delayMs = this.retryDelay * attempt;
+            this.logRetry(method, path, attempt, delayMs, "HttpError", response.status);
+            await this.sleep(delayMs);
+            return this._requestFormData<T>(method, path, formData, attempt + 1);
+          }
+          this.logRetriesExhausted(method, path, attempt, "HttpError", response.status);
         }
         parseApiError(response.status, data);
       }
@@ -654,6 +688,7 @@ export class EngramClient {
       clearTimeout(timeoutId);
 
       if (error instanceof Error && error.name === "AbortError") {
+        this.logTimeout(method, path, attempt);
         throw new TimeoutError(this.timeout);
       }
 
@@ -662,10 +697,13 @@ export class EngramClient {
       }
 
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        const delayMs = this.retryDelay * attempt;
+        this.logRetry(method, path, attempt, delayMs, sanitizeErrorClass(error));
+        await this.sleep(delayMs);
         return this._requestFormData<T>(method, path, formData, attempt + 1);
       }
 
+      this.logRetriesExhausted(method, path, attempt, sanitizeErrorClass(error));
       throw new NetworkError(
         `Failed to ${method} ${path}: ${error instanceof Error ? error.message : "Unknown error"}`,
         error instanceof Error ? error : undefined,
@@ -726,29 +764,47 @@ export class EngramClient {
 
       // Handle abort (timeout)
       if (error instanceof Error && error.name === "AbortError") {
+        this.logTimeout(method, path, attempt);
         throw new TimeoutError(this.timeout);
       }
 
       // Re-throw Engram errors
       if (error instanceof EngramError) {
         // Retry on server errors if attempts remain
-        if (
-          error.statusCode &&
-          error.statusCode >= 500 &&
-          attempt < this.retries
-        ) {
-          await this.sleep(this.retryDelay * attempt);
-          return this.request<T>(method, path, body, attempt + 1);
+        if (error.statusCode && error.statusCode >= 500) {
+          if (attempt < this.retries) {
+            const delayMs = this.retryDelay * attempt;
+            this.logRetry(
+              method,
+              path,
+              attempt,
+              delayMs,
+              sanitizeErrorClass(error),
+              error.statusCode,
+            );
+            await this.sleep(delayMs);
+            return this.request<T>(method, path, body, attempt + 1);
+          }
+          this.logRetriesExhausted(
+            method,
+            path,
+            attempt,
+            sanitizeErrorClass(error),
+            error.statusCode,
+          );
         }
         throw error;
       }
 
       // Handle network errors with retry
       if (attempt < this.retries) {
-        await this.sleep(this.retryDelay * attempt);
+        const delayMs = this.retryDelay * attempt;
+        this.logRetry(method, path, attempt, delayMs, sanitizeErrorClass(error));
+        await this.sleep(delayMs);
         return this.request<T>(method, path, body, attempt + 1);
       }
 
+      this.logRetriesExhausted(method, path, attempt, sanitizeErrorClass(error));
       throw new NetworkError(
         `Failed to ${method} ${path}: ${error instanceof Error ? error.message : "Unknown error"}`,
         error instanceof Error ? error : undefined,
@@ -758,6 +814,73 @@ export class EngramClient {
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // ============================================
+  // Logging Helpers
+  // ============================================
+  //
+  // All request-path diagnostics funnel through these three methods so the
+  // sanitization contract is enforced in exactly one place: method + sanitized
+  // pathname + error CLASS only. Never headers, request bodies, error
+  // messages, or query strings (which can carry search text or credentials).
+
+  /** Log a single retry at debug level. */
+  private logRetry(
+    method: string,
+    path: string,
+    attempt: number,
+    delayMs: number,
+    errorClass: string,
+    status?: number,
+  ): void {
+    this.logger.debug(
+      {
+        method,
+        path: sanitizeRequestPath(path),
+        attempt,
+        maxRetries: this.retries,
+        delayMs,
+        errorClass,
+        ...(status !== undefined ? { status } : {}),
+      },
+      "engram-sdk: retrying request",
+    );
+  }
+
+  /** Log a retryable failure with no attempts remaining at warn level. */
+  private logRetriesExhausted(
+    method: string,
+    path: string,
+    attempt: number,
+    errorClass: string,
+    status?: number,
+  ): void {
+    this.logger.warn(
+      {
+        method,
+        path: sanitizeRequestPath(path),
+        attempt,
+        maxRetries: this.retries,
+        errorClass,
+        ...(status !== undefined ? { status } : {}),
+      },
+      "engram-sdk: retries exhausted",
+    );
+  }
+
+  /** Log a request timeout (about to throw TimeoutError) at warn level. */
+  private logTimeout(method: string, path: string, attempt: number): void {
+    this.logger.warn(
+      {
+        method,
+        path: sanitizeRequestPath(path),
+        attempt,
+        timeoutMs: this.timeout,
+        errorClass: "TimeoutError",
+      },
+      "engram-sdk: request timed out",
+    );
   }
 
   // ============================================

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -42,6 +42,10 @@
 // Client
 export { EngramClient, createEngramClient } from "./client.js";
 
+// Client-side logging contract (structural — accepts a @centient/logger
+// `Logger` without making it a runtime dependency)
+export type { ClientLogger } from "./logging.js";
+
 // Resources (Knowledge API - for engram)
 export {
   BaseResource,

--- a/packages/sdk/src/logging.ts
+++ b/packages/sdk/src/logging.ts
@@ -66,5 +66,8 @@ export function sanitizeErrorClass(error: unknown): string {
   if (error instanceof Error) {
     return error.name || error.constructor.name;
   }
-  return typeof error;
+  // Non-Error throwables reduce to their typeof on purpose: stringifying the
+  // value (or its toString) could leak embedded content into a log line. The
+  // one refinement is `null`, whose typeof is the misleading "object".
+  return error === null ? "null" : typeof error;
 }

--- a/packages/sdk/src/logging.ts
+++ b/packages/sdk/src/logging.ts
@@ -1,0 +1,70 @@
+/**
+ * Client-side observability plumbing for the Engram SDK.
+ *
+ * The SDK has zero runtime dependencies by design, so the logger contract is
+ * a minimal STRUCTURAL interface rather than an import from @centient/logger.
+ * A real `@centient/logger` `Logger` satisfies {@link ClientLogger} directly
+ * (its context-first `debug`/`warn` overloads match the shape), but any object
+ * with the same two methods works.
+ *
+ * Sanitization contract: every value the client logs is routed through the
+ * helpers in this module. The client never logs headers, request bodies, or
+ * full URLs — only the HTTP method and the sanitized pathname (query strings
+ * and fragments are stripped, since they can carry search text, identifiers,
+ * or credential material).
+ */
+
+/**
+ * Minimal structural logger accepted by {@link EngramClientConfig.logger}.
+ *
+ * Shape-compatible with `@centient/logger`'s `Logger` (context object first,
+ * message second), without making `@centient/logger` a runtime dependency of
+ * the SDK. The client emits:
+ *
+ * - `debug` — one entry per retry (attempt number, delay, error class,
+ *   method + sanitized path).
+ * - `warn` — retries exhausted, and request timeouts.
+ *
+ * When no logger is injected the client is completely silent (no console
+ * fallback).
+ */
+export interface ClientLogger {
+  /** Per-retry diagnostics. */
+  debug(context: Record<string, unknown>, message: string): void;
+  /** Retries exhausted / request timed out. */
+  warn(context: Record<string, unknown>, message: string): void;
+}
+
+/**
+ * Default logger: discards everything. Guarantees zero logging (and zero
+ * console output) when the consumer does not inject a logger.
+ * @internal
+ */
+export const NOOP_CLIENT_LOGGER: ClientLogger = {
+  debug: () => {},
+  warn: () => {},
+};
+
+/**
+ * Sanitize a request path for logging: keep the pathname only, dropping the
+ * query string and fragment. Query strings can carry search text, identifiers,
+ * or credential material and must never reach a log line.
+ * @internal
+ */
+export function sanitizeRequestPath(path: string): string {
+  const cut = path.search(/[?#]/);
+  return cut === -1 ? path : path.slice(0, cut);
+}
+
+/**
+ * Reduce an unknown thrown value to its error class name for logging. Error
+ * messages are deliberately NOT logged — they can embed URLs (including query
+ * strings) or response fragments.
+ * @internal
+ */
+export function sanitizeErrorClass(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name || error.constructor.name;
+  }
+  return typeof error;
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3,6 +3,8 @@
  * Generated from OpenAPI 3.1 specification
  */
 
+import type { ClientLogger } from "./logging.js";
+
 // ============================================
 // Enums
 // ============================================
@@ -1402,6 +1404,21 @@ export interface EngramClientConfig {
   retries?: number;
   /** Base delay between retries in ms (default: 1000) */
   retryDelay?: number;
+  /**
+   * Optional logger for client-side request diagnostics.
+   *
+   * Structurally compatible with `@centient/logger`'s `Logger` (context object
+   * first, message second) — pass a `createLogger(...)` instance directly, or
+   * any object with matching `debug`/`warn` methods. The client logs:
+   *
+   * - `debug`: each retry (attempt number, delay, error class, method + path)
+   * - `warn`: retries exhausted, request timeouts
+   *
+   * Default: no-op — without a logger the client emits nothing (no console
+   * fallback). All logged context is sanitized: HTTP method + pathname only;
+   * never headers, request bodies, query strings, or credentials.
+   */
+  logger?: ClientLogger;
 }
 
 // ============================================

--- a/packages/sdk/tests/client-logging.test.ts
+++ b/packages/sdk/tests/client-logging.test.ts
@@ -109,6 +109,28 @@ describe("client logging", () => {
       expect(sanitizeRequestPath("/v1/export?apiKey=abc#x")).toBe("/v1/export");
     });
 
+    it("sanitizeErrorClass falls back to constructor.name when error.name is empty", () => {
+      class Nameless extends Error {
+        constructor() {
+          super("payload that must not be logged");
+          this.name = "";
+        }
+      }
+      expect(sanitizeErrorClass(new Nameless())).toBe("Nameless");
+    });
+
+    it("sanitizeErrorClass reduces non-Error throwables to a content-free tag", () => {
+      expect(sanitizeErrorClass(null)).toBe("null");
+      expect(sanitizeErrorClass(undefined)).toBe("undefined");
+      expect(sanitizeErrorClass("a-string-with-secret-sauce")).toBe("string");
+      expect(sanitizeErrorClass(42)).toBe("number");
+      // Plain objects and arrays deliberately reduce to "object": anything
+      // more specific would require stringifying the value, which could leak
+      // embedded content into a log line.
+      expect(sanitizeErrorClass({ password: "nope" })).toBe("object");
+      expect(sanitizeErrorClass(["nope"])).toBe("object");
+    });
+
     it("sanitizeErrorClass reduces errors to their class name only", () => {
       const err = new Error(`leak Authorization: Bearer ${credentialFixture}`);
       err.name = "FetchError";
@@ -363,19 +385,37 @@ describe("client logging", () => {
   });
 
   describe("quiet on success", () => {
-    it("logs nothing for successful requests", async () => {
+    function mockOkFetch() {
+      return vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ status: "ok" }),
+        text: () => Promise.resolve(JSON.stringify({ status: "ok" })),
+      });
+    }
+
+    it("logs nothing for successful requests via request()", async () => {
       const { entries, logger } = createFakeLogger();
       const client = makeClient(logger);
-      vi.stubGlobal(
-        "fetch",
-        vi.fn().mockResolvedValue({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({ status: "ok" }),
-        }),
-      );
+      vi.stubGlobal("fetch", mockOkFetch());
 
       await client.health();
+      expect(entries).toHaveLength(0);
+    });
+
+    it("logs nothing for successful _requestRaw / _requestRawBody / _requestFormData", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockOkFetch());
+
+      await client._requestRaw("GET", "/v1/export");
+      await client._requestRawBody(
+        "POST",
+        "/v1/sync/push",
+        "{}",
+        "application/x-ndjson",
+      );
+      await client._requestFormData("POST", "/v1/import", new FormData());
       expect(entries).toHaveLength(0);
     });
   });

--- a/packages/sdk/tests/client-logging.test.ts
+++ b/packages/sdk/tests/client-logging.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Client-side request logging tests.
+ *
+ * Verifies the optional `logger` on EngramClientConfig:
+ * - debug entry per retry (attempt #, delay, error class, method + path)
+ * - warn on retries exhausted and on TimeoutError
+ * - zero output when no logger is injected (no console fallback)
+ * - sanitization: no headers (X-API-Key / Authorization), no request bodies,
+ *   no query strings, and no credential material in any logged argument
+ *   (regex scan across everything the fake logger captured)
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EngramClient } from "../src/client.js";
+import { TimeoutError, NetworkError } from "../src/errors.js";
+import { sanitizeRequestPath, sanitizeErrorClass } from "../src/logging.js";
+
+interface CapturedEntry {
+  level: "debug" | "warn";
+  context: Record<string, unknown>;
+  message: string;
+}
+
+function createFakeLogger() {
+  const entries: CapturedEntry[] = [];
+  return {
+    entries,
+    logger: {
+      debug: (context: Record<string, unknown>, message: string) =>
+        entries.push({ level: "debug", context, message }),
+      warn: (context: Record<string, unknown>, message: string) =>
+        entries.push({ level: "warn", context, message }),
+    },
+  };
+}
+
+/** Serialize everything the fake logger captured, for secret-scan assertions. */
+function serializeEntries(entries: CapturedEntry[]): string {
+  return entries
+    .map((e) => JSON.stringify([e.level, e.context, e.message]))
+    .join("\n");
+}
+
+// Low-entropy placeholder bound to a neutrally-named var so the secret scanner
+// doesn't flag the fixture; the tests assert this string never appears in any
+// captured log argument.
+const credentialFixture = "fixture-credential-value-123";
+
+function mockServerErrorFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: () =>
+      Promise.resolve({ code: "INTERNAL_ERROR", message: "Server error" }),
+    text: () =>
+      Promise.resolve(
+        JSON.stringify({ code: "INTERNAL_ERROR", message: "Server error" }),
+      ),
+  });
+}
+
+function mockNetworkErrorFetch(error: Error = new TypeError("fetch failed")) {
+  return vi.fn().mockRejectedValue(error);
+}
+
+/** Fetch that never resolves and honors the abort signal (timeout path). */
+function mockHangingFetch() {
+  return vi.fn().mockImplementation((_url, options) => {
+    return new Promise((_resolve, reject) => {
+      const signal = options?.signal as AbortSignal | undefined;
+      if (signal) {
+        signal.addEventListener("abort", () => {
+          const abortError = new Error("The operation was aborted");
+          abortError.name = "AbortError";
+          reject(abortError);
+        });
+      }
+      // Never resolve — let the client timeout trigger.
+    });
+  });
+}
+
+function makeClient(logger?: {
+  debug(context: Record<string, unknown>, message: string): void;
+  warn(context: Record<string, unknown>, message: string): void;
+}) {
+  return new EngramClient({
+    baseUrl: "http://localhost:3100",
+    apiKey: credentialFixture,
+    userId: "user-1",
+    retries: 3,
+    retryDelay: 1,
+    logger,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("client logging", () => {
+  describe("sanitize helpers", () => {
+    it("sanitizeRequestPath strips query strings and fragments", () => {
+      expect(sanitizeRequestPath("/v1/notes?limit=5&q=secret")).toBe("/v1/notes");
+      expect(sanitizeRequestPath("/v1/notes#frag")).toBe("/v1/notes");
+      expect(sanitizeRequestPath("/v1/notes")).toBe("/v1/notes");
+      expect(sanitizeRequestPath("/v1/export?apiKey=abc#x")).toBe("/v1/export");
+    });
+
+    it("sanitizeErrorClass reduces errors to their class name only", () => {
+      const err = new Error(`leak Authorization: Bearer ${credentialFixture}`);
+      err.name = "FetchError";
+      expect(sanitizeErrorClass(err)).toBe("FetchError");
+      expect(sanitizeErrorClass(new TypeError("x"))).toBe("TypeError");
+      expect(sanitizeErrorClass("string-throw")).toBe("string");
+    });
+  });
+
+  describe("retry logging (debug)", () => {
+    it("logs each 5xx retry with attempt #, delay, error class, method and path", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+
+      await expect(client.health()).rejects.toThrow();
+
+      const retries = entries.filter((e) => e.level === "debug");
+      // retries=3 → attempts 1 and 2 are retried, attempt 3 exhausts.
+      expect(retries).toHaveLength(2);
+      retries.forEach((entry, i) => {
+        expect(entry.message).toBe("engram-sdk: retrying request");
+        expect(entry.context.method).toBe("GET");
+        expect(entry.context.path).toBe("/v1/health");
+        expect(entry.context.attempt).toBe(i + 1);
+        expect(entry.context.delayMs).toBe(1 * (i + 1));
+        expect(entry.context.status).toBe(500);
+        expect(typeof entry.context.errorClass).toBe("string");
+        expect(entry.context.errorClass).not.toBe("");
+      });
+    });
+
+    it("logs network-error retries with the error class", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockNetworkErrorFetch());
+
+      await expect(client.health()).rejects.toThrow(NetworkError);
+
+      const retries = entries.filter((e) => e.level === "debug");
+      expect(retries).toHaveLength(2);
+      for (const entry of retries) {
+        expect(entry.context.errorClass).toBe("TypeError");
+        expect(entry.context.method).toBe("GET");
+        expect(entry.context.path).toBe("/v1/health");
+      }
+    });
+  });
+
+  describe("exhaustion and timeout logging (warn)", () => {
+    it("logs warn when 5xx retries are exhausted", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+
+      await expect(client.health()).rejects.toThrow();
+
+      const warns = entries.filter((e) => e.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.message).toBe("engram-sdk: retries exhausted");
+      expect(warns[0]?.context.attempt).toBe(3);
+      expect(warns[0]?.context.maxRetries).toBe(3);
+      expect(warns[0]?.context.status).toBe(500);
+      expect(warns[0]?.context.method).toBe("GET");
+      expect(warns[0]?.context.path).toBe("/v1/health");
+    });
+
+    it("logs warn when network-error retries are exhausted", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockNetworkErrorFetch());
+
+      await expect(client.health()).rejects.toThrow(NetworkError);
+
+      const warns = entries.filter((e) => e.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.context.errorClass).toBe("TypeError");
+    });
+
+    it("logs warn on TimeoutError", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = new EngramClient({
+        baseUrl: "http://localhost:3100",
+        timeout: 1,
+        logger,
+      });
+      vi.stubGlobal("fetch", mockHangingFetch());
+
+      await expect(client.health()).rejects.toThrow(TimeoutError);
+
+      const warns = entries.filter((e) => e.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.message).toBe("engram-sdk: request timed out");
+      expect(warns[0]?.context.timeoutMs).toBe(1);
+      expect(warns[0]?.context.errorClass).toBe("TimeoutError");
+      expect(warns[0]?.context.method).toBe("GET");
+      expect(warns[0]?.context.path).toBe("/v1/health");
+    });
+  });
+
+  describe("raw request paths (_requestRaw / _requestRawBody / _requestFormData)", () => {
+    it("_requestRaw logs retry + exhaustion on 5xx", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+
+      await expect(client._requestRaw("GET", "/v1/export")).rejects.toThrow();
+
+      expect(entries.filter((e) => e.level === "debug")).toHaveLength(2);
+      const warns = entries.filter((e) => e.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.context.errorClass).toBe("HttpError");
+      expect(warns[0]?.context.status).toBe(500);
+      expect(warns[0]?.context.path).toBe("/v1/export");
+    });
+
+    it("_requestRawBody logs retry + exhaustion on 5xx", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+
+      await expect(
+        client._requestRawBody("POST", "/v1/sync/push", "{}", "application/x-ndjson"),
+      ).rejects.toThrow();
+
+      expect(entries.filter((e) => e.level === "debug")).toHaveLength(2);
+      const warns = entries.filter((e) => e.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.context.errorClass).toBe("HttpError");
+      expect(warns[0]?.context.path).toBe("/v1/sync/push");
+    });
+
+    it("_requestFormData logs retry + exhaustion on 5xx", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+
+      await expect(
+        client._requestFormData("POST", "/v1/import", new FormData()),
+      ).rejects.toThrow();
+
+      expect(entries.filter((e) => e.level === "debug")).toHaveLength(2);
+      const warns = entries.filter((e) => e.level === "warn");
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.context.errorClass).toBe("HttpError");
+      expect(warns[0]?.context.path).toBe("/v1/import");
+    });
+  });
+
+  describe("sanitization", () => {
+    it("never logs apiKey, X-API-Key, Authorization, query strings, or request bodies", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+
+      // Query-string path through the standard request pipeline.
+      await expect(
+        client.listNotes("session-1", { type: "decision", limit: 5 }),
+      ).rejects.toThrow();
+      // Query string with explicit credential material through the raw path.
+      await expect(
+        client._requestRaw(
+          "GET",
+          `/v1/export?apiKey=${credentialFixture}&token=${credentialFixture}#frag`,
+        ),
+      ).rejects.toThrow();
+      // Request body with sensitive content.
+      await expect(
+        client.createNote("session-1", {
+          type: "decision",
+          content: `body-secret-material ${credentialFixture}`,
+        }),
+      ).rejects.toThrow();
+
+      expect(entries.length).toBeGreaterThan(0);
+
+      const serialized = serializeEntries(entries);
+      // Header material must never appear.
+      expect(serialized).not.toMatch(/x-api-key/i);
+      expect(serialized).not.toMatch(/authorization/i);
+      expect(serialized).not.toMatch(/bearer/i);
+      // The credential value itself must never appear.
+      expect(serialized).not.toContain(credentialFixture);
+      // Query strings must be stripped — no key=value pairs, no raw '?'/'#'
+      // in any logged path.
+      expect(serialized).not.toMatch(/[?#]/);
+      expect(serialized).not.toContain("type=decision");
+      expect(serialized).not.toContain("limit=");
+      expect(serialized).not.toContain("apiKey=");
+      expect(serialized).not.toContain("token=");
+      // Request bodies must never appear.
+      expect(serialized).not.toContain("body-secret-material");
+      for (const entry of entries) {
+        expect(String(entry.context.path)).not.toMatch(/[?#]/);
+      }
+    });
+
+    it("does not leak secret material embedded in error messages (logs error class only)", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      const leakyError = new Error(
+        `connect failed for http://localhost:3100/v1/health?apiKey=${credentialFixture} ` +
+          `Authorization: Bearer ${credentialFixture} X-API-Key: ${credentialFixture}`,
+      );
+      leakyError.name = "FetchError";
+      vi.stubGlobal("fetch", mockNetworkErrorFetch(leakyError));
+
+      await expect(client.health()).rejects.toThrow(NetworkError);
+
+      expect(entries.length).toBeGreaterThan(0);
+      const serialized = serializeEntries(entries);
+      expect(serialized).not.toContain(credentialFixture);
+      expect(serialized).not.toMatch(/x-api-key/i);
+      expect(serialized).not.toMatch(/authorization/i);
+      // Only the class name survives.
+      const classes = entries.map((e) => e.context.errorClass);
+      expect(new Set(classes).size).toBeGreaterThan(0);
+      expect(classes).toContain("FetchError");
+    });
+  });
+
+  describe("no logger injected", () => {
+    it("emits nothing — no console fallback — on retries, exhaustion, or timeout", async () => {
+      const spies = (["log", "debug", "info", "warn", "error", "trace"] as const).map(
+        (m) => vi.spyOn(console, m).mockImplementation(() => {}),
+      );
+
+      const client = new EngramClient({
+        baseUrl: "http://localhost:3100",
+        apiKey: credentialFixture,
+        retries: 3,
+        retryDelay: 1,
+      });
+
+      vi.stubGlobal("fetch", mockServerErrorFetch());
+      await expect(client.health()).rejects.toThrow();
+
+      vi.stubGlobal("fetch", mockNetworkErrorFetch());
+      await expect(client.health()).rejects.toThrow(NetworkError);
+
+      const timeoutClient = new EngramClient({
+        baseUrl: "http://localhost:3100",
+        timeout: 1,
+      });
+      vi.stubGlobal("fetch", mockHangingFetch());
+      await expect(timeoutClient.health()).rejects.toThrow(TimeoutError);
+
+      for (const spy of spies) {
+        expect(spy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("quiet on success", () => {
+    it("logs nothing for successful requests", async () => {
+      const { entries, logger } = createFakeLogger();
+      const client = makeClient(logger);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        }),
+      );
+
+      await client.health();
+      expect(entries).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Hardening backlog ticket gap-none-sdk-client-logging (docs/hardening/BACKLOG.md) — phase 5 of the hardening pipeline.

## Gap

packages/sdk/src/client.ts performs zero logging — retries, timeouts, and network errors are invisible to consumers diagnosing hangs vs retry storms (wal/events/logger packages all instrument; the client is the blind spot).

## What changed

Implemented optional client-side logging for the Engram SDK client (commit ed3c859, pushed). Files touched: packages/sdk/src/logging.ts (new — structural ClientLogger interface, NOOP_CLIENT_LOGGER default, sanitizeRequestPath strips query strings/fragments, sanitizeErrorClass reduces errors to class name only), packages/sdk/src/types.ts (logger?: ClientLogger on EngramClientConfig), packages/sdk/src/client.ts (logger field defaulting to no-op; three private funnel helpers logRetry/logRetriesExhausted/logTimeout so sanitization is enforced in one place; instrumented all four request paths — request, _requestRaw, _requestRawBody, _requestFormData — debug per retry with attempt/delayMs/errorClass/method/sanitized path, warn on retries exhausted and on TimeoutError), packages/sdk/src/index.ts (export type ClientLogger), packages/sdk/tests/client-logging.test.ts (new, 14 tests: fake logger captures retry/exhaustion/timeout on every path; regex scan over all captured args asserts no X-API-Key, Authorization, Bearer, query strings, request bodies, or credential value — including a leaky-error-message case; console spies prove zero output with no logger injected; quiet-on-success), packages/sdk/README.md (new "Request logging" section documenting the option). Changeset added: yes (.changeset/remediate-gap-none-sdk-client-logging.md, minor for @centient/sdk; no package.json versions touched, no new dependency edges — @centient/sdk stays zero-runtime-dependency). All guards applied. make check passes (tsc 0 errors; 1233 passed, 14 skipped — the skips are pre-existing @centient/logger integration performance tests). Conservative readings: (1) spec named "ClientOptions" — the actual config type is EngramClientConfig; added there. (2) spec said "existing sanitize helpers" but packages/sdk has none (the only sanitize module lives in @centient/logger, which would create the forbidden dependency edge), so minimal sanitize helpers were created in packages/sdk/src/logging.ts and all log arguments routed through them. (3) "retries exhausted" warn fires whenever a retryable failure (5xx or network error) has no attempts remaining, even when retries<=1, so no retryable failure is traceless. (4) 5xx retries in the raw paths occur before an error instance exists, so errorClass is logged as "HttpError" with the numeric status alongside. (5) had to run git submodule update --init for scripts/release-toolkit in the worktree to make `make check` runnable (no source change, submodule pointer unchanged).

## Verification

- make check green: true
- adversarial refutation verdict: survived

Refuter summary: "Could not refute. Branch remediate/gap-none-sdk-client-logging (ed3c859) genuinely closes gap-none-sdk-client-logging: all four spec steps are implemented and traced through real code paths, all four guard bullets hold, and the acceptance criterion survived direct attack — I could not trigger any retry, exhaustion, or timeout that left no trace with a logger configured (including the three raw request paths whose timeout branches the committed suite does not exercise), and could not get secret material (apiKey value, X-API-Key/Authorization headers, query strings, request bodies, or secret-bearing error messages) into any captured log argument. Mutation testing proved the new tests fail when sanitization, the no-op default, or retry logging is broken. Full sdk suite: 446/446 after build; tsc clean; @centient/logger Logger structurally satisfies ClientLogger per a strict tsc check; packages/sdk stays zero-dependency. Two minor non-blocking observations noted (raw-path timeout test coverage; throwing-logger error replacement)."

## Guards

- [x] Zero logging when no logger injected (no console fallback)
- [x] No new hard dependency edges in packages/sdk/package.json without checking current dependency policy
- [x] Sanitization test covers X-API-Key, Authorization, query strings
- [x] README documents the option

🤖 Generated with [Claude Code](https://claude.com/claude-code)