### PR TITLE
test(sdk): fix red main — jitter test mocks need text() after #76

### DIFF
--- a/packages/sdk/tests/client.test.ts
+++ b/packages/sdk/tests/client.test.ts
@@ -1163,17 +1163,20 @@ describe("EngramClient", () => {
       mockFetch = vi.fn().mockImplementation(() => {
         callCount++;
         if (callCount < 2) {
+          const body = { code: "INTERNAL_ERROR", message: "boom" };
           return Promise.resolve({
             ok: false,
             status: 500,
-            json: () =>
-              Promise.resolve({ code: "INTERNAL_ERROR", message: "boom" }),
+            json: () => Promise.resolve(body),
+            text: () => Promise.resolve(JSON.stringify(body)),
           });
         }
+        const okBody = { status: "ok" };
         return Promise.resolve({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ status: "ok" }),
+          json: () => Promise.resolve(okBody),
+          text: () => Promise.resolve(JSON.stringify(okBody)),
         });
       });
       vi.stubGlobal("fetch", mockFetch);


### PR DESCRIPTION
**Main is currently red** — `make check` fails on `tests/client.test.ts > Retry Backoff Jitter > retry path sleeps the jittered duration from backoffDelay` with `NetworkError: Failed to GET /v1/health: response.text is not a function`. Reproduced on a clean `origin/main` checkout (f93ecdb).

Cause: a semantic conflict in the merge train. #71 (merged first) added a jitter test with inline fetch mocks exposing only `json()`; #76 (forked before #71 landed, merged after) rewrote `request()` to read response bodies via `response.text()`. Each PR was green on its own branch; their union fails.

Fix: the inline mocks now expose `text()` alongside `json()`, matching the shared `mockFetchResponse` helper that #76 already updated. Test-only change.

Verified on this branch: `make check` green — tsc 0 errors, 453/453 sdk tests (1236 total workspace), claudemd-check OK.

**Recommend merging this before anything else** — the maintainer bot's in-container `make check` will fail every review round on every PR until main is green (this also blocks re-reviews of #67/#71 responses and the refreshed #74/#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)