### PR TITLE
docs(hardening): record phase 6 verification — backlog merged, clean-repro green

### DIFF
--- a/docs/hardening/BACKLOG.md
+++ b/docs/hardening/BACKLOG.md
@@ -2,14 +2,14 @@
 
 date: 2026-06-10 · source: docs/hardening/2026-06-10-dimensions.md ·
 committed: 6 tickets (1 high, 5 med) · deferred: see dimensions doc ·
-phase-5 status: all 6 implemented, PRs #71–#76 open (see STATE.md)
+phase-6 status: all 6 merged + post-merge clean-repro green (see STATE.md)
 
 Tickets use the cl-adr-code-align contract and are written to be executable
 without judgment calls. Ranked by impact × effort.
 
 ## T1 — gap-none-sse-run-error-handling (HIGH)
 
-**Status (2026-06-11): implemented — PR #73 open (refute-verified, make check green). Awaiting review/merge.**
+**Status (2026-06-11): merged (PR #73); acceptance holds in post-merge clean-repro.**
 
 ```json
 {
@@ -24,7 +24,7 @@ without judgment calls. Ranked by impact × effort.
 
 ## T2 — gap-none-retry-jitter (MED)
 
-**Status (2026-06-11): implemented — PR #71 open (refute-verified, make check green). Awaiting review/merge.**
+**Status (2026-06-11): merged (PR #71); acceptance holds in post-merge clean-repro.**
 
 ```json
 {
@@ -39,7 +39,7 @@ without judgment calls. Ranked by impact × effort.
 
 ## T3 — gap-none-request-nonjson-2xx (MED)
 
-**Status (2026-06-11): implemented — PR #76 open (refute-verified, make check green). Awaiting review/merge.**
+**Status (2026-06-11): merged (PR #76); acceptance holds in post-merge clean-repro.**
 
 ```json
 {
@@ -54,7 +54,7 @@ without judgment calls. Ranked by impact × effort.
 
 ## T4 — gap-none-sdk-client-logging (MED)
 
-**Status (2026-06-11): implemented — PR #75 open (refute-verified, make check green). Awaiting review/merge.**
+**Status (2026-06-11): merged (PR #75); acceptance holds in post-merge clean-repro.**
 
 ```json
 {
@@ -69,7 +69,7 @@ without judgment calls. Ranked by impact × effort.
 
 ## T5 — gap-none-publish-provenance (MED)
 
-**Status (2026-06-11): implemented — PR #74 open (refute-verified, make check green). Awaiting review/merge.**
+**Status (2026-06-11): merged (PR #74); acceptance holds in post-merge clean-repro.**
 
 ```json
 {
@@ -84,7 +84,7 @@ without judgment calls. Ranked by impact × effort.
 
 ## T6 — gap-none-docs-drift (MED)
 
-**Status (2026-06-11): implemented — PR #72 open (refute-verified, make check green). Awaiting review/merge.**
+**Status (2026-06-11): merged (PR #72); acceptance holds in post-merge clean-repro.**
 
 ```json
 {

--- a/docs/hardening/STATE.md
+++ b/docs/hardening/STATE.md
@@ -10,8 +10,29 @@ Campaign: workspace docs/plans/2026-06-10-hardening-master-plan.md (Wave 1).
 | 3 dimensions | done 2026-06-10 | 2026-06-10-dimensions.md | 8 dimensions, adversarially filtered. |
 | 4 triage | done 2026-06-10 | BACKLOG.md | |
 | 5 implement | done 2026-06-11 | PRs #71–#76 | All 6 tickets implemented in isolated worktrees, adversarially refute-verified (all survived round 1), one PR per ticket. T7 remains an operator decision. |
-| 6 verification | pending merges | — | Refute-verification done pre-merge on each branch; post-merge clean-repro re-check outstanding. |
+| 6 verification | done 2026-06-11 | (this file) | Post-merge clean-repro green on main @ dadfafe: fresh frozen-lockfile install, tsc 0 errors, 1257 passed / 14 skipped (logger 490, secrets 174, sdk 470, wal 63, events 60), claudemd-check OK. No ADR-anchored tickets, so no scoped cl-adr-audit re-run. |
 | 7 next-stage plan | not started | — | |
+
+## Phase 6 notes (2026-06-11)
+
+- All 6 ticket PRs (#71–#76) and the ledger PR (#77) merged by the
+  coordinator session. Acceptance criteria are encoded as tests (the
+  unhandledRejection traps, the backoffDelay source-grep guard, the
+  no-retry-on-parse-failure counts, the sanitization regex scans, the
+  claudemd-check drift gate, the publish fingerprint stamp) and all run
+  green in the post-merge clean-repro.
+- Merge-train incident, found and fixed during shepherding: #71 (jitter
+  test with json()-only inline mocks, merged first) and #76 (request()
+  reads bodies via response.text(), forked before #71 landed) were each
+  green alone but red together — main failed `make check` after f93ecdb.
+  Fix-forward PR #78 was opened, then closed as redundant when the
+  identical mock fix reached main inside #75's merge commit; #74/#75 were
+  refreshed by merge-from-main (no force-push), with #71's source-grep
+  guard rewritten on #75 to the equivalent two-part invariant so the
+  logged delay is the actual jittered sleep.
+- Out-of-pipeline PR #67 (passphrase provider) still open at phase-6
+  close — review rounds being shepherded; not part of the backlog.
+- T7 (release pending changesets) remains the operator decision.
 
 ## Phase 5 notes (2026-06-11)
 


### PR DESCRIPTION
Closes out phase 6 of the hardening pipeline in the ledger:

- Post-merge clean-repro on main @ dadfafe: fresh frozen-lockfile install, tsc 0 errors, **1257 passed / 14 skipped**, claudemd-check OK, publish stamp written.
- BACKLOG.md ticket statuses → merged (acceptances hold; they are encoded as tests and run in the clean-repro).
- Documents the #71×#76 merge-train semantic conflict and its resolution (fix-forward #78, superseded by #75's merge; #74/#75 refreshed by merge-from-main).
- Remaining open threads recorded: PR #67 (out-of-pipeline) and T7 (operator decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)