### PR TITLE
chore(harvest): stage crucible source for archival safety

### DIFF
--- a/harvest/crucible/README.md
+++ b/harvest/crucible/README.md
@@ -15,6 +15,19 @@ zero-dependency rewrites, clock/randomness injection, `@centient` scaffold
 conventions, changesets, CLAUDE.md table rows). This staging is the safety net,
 not the port.
 
+> **These files are intentionally incomplete and do NOT compile or run as-is.**
+> They are byte-for-byte archival copies (see *Provenance* below), deliberately
+> kept verbatim so the `cmp`-verified provenance guarantee holds. Several modules
+> reference companion files that were **not** harvested (the broad orchestrator
+> type tree, `formatters.ts`), and the harvested test files import from their
+> **original crucible relative paths** (`../../src/...`) that do not exist under
+> `harvest/`. None of this is a defect: these copies are for reference and
+> archival survival only. Every unresolved reference is enumerated in
+> *Companion dependencies (not harvested)* below, and is resolved during the
+> live port in the destination-package PR — not in this staging area. Because
+> nothing here is in any build/test/lint/turbo/tsconfig scope, these dangling
+> imports never reach `make check`.
+
 ## Provenance
 
 All copies taken **verbatim** (byte-for-byte; verified with `cmp`) from crucible
@@ -36,16 +49,36 @@ Crucible source root for the paths below:
 | `packages/crucible/src/utils/atomic-io.ts` | 2026-06-12 | `@centient/wal` (atomic-io) | `atomicWrite` (UUID `.tmp` sibling + rename-over) and `atomicAppendLine` (single-syscall POSIX append ≤ PIPE_BUF). Crash-safe file I/O primitive — companion to the WAL package. |
 | `packages/crucible/tests/utils/atomic-io.test.ts` | 2026-06-12 | `@centient/wal` (atomic-io) | Full test suite for the atomic-io primitives. |
 
-## Companion type dependencies (resolved during the live port, not copied here)
+## Companion dependencies (not harvested) — resolved during the live port
 
-`dag.ts` imports `validateDAGDefinition` and DAG types from
-`packages/crucible/src/orchestrator/types.ts` (a barrel re-exporting
-`types/pipeline-state-model.ts`, `types/failure-model.ts`, etc., where
-`DAGDefinition` and `validateDAGDefinition` are actually defined). Those type
-modules are deliberately **not** copied — they are a broad orchestrator type
-tree, not part of "the DAG implementation." The `@centient/dag` port will
-re-declare or vendor the minimal `DAGDefinition` / validation surface it needs.
-The crucible commit hash above pins the exact source for that work.
+This section is the exhaustive list of references in the harvested files that do
+**not** resolve within `harvest/`. Each is deliberate; the crucible commit hash
+in *Provenance* pins the exact upstream source for the live port to consume.
+
+**Source-module imports (`src/`):**
+
+- `dag/dag.ts` imports `validateDAGDefinition` and the DAG types from
+  `./types.js` → originally `packages/crucible/src/orchestrator/types.ts` (a
+  barrel re-exporting `types/pipeline-state-model.ts`, `types/failure-model.ts`,
+  etc., where `DAGDefinition` and `validateDAGDefinition` are defined). That
+  broad orchestrator type tree is **not** part of "the DAG implementation," so
+  it is deliberately not copied. The `@centient/dag` port re-declares or vendors
+  the minimal `DAGDefinition` / validation surface it needs.
+- `dag/dag-renderer.ts` imports `PipelineStatus` from `./types.js` (same type
+  tree as above) and `statusBadge`, `truncate` from `./formatters.js`
+  (originally `packages/crucible/src/orchestrator/formatters.ts`, a small
+  presentation-helper module). Neither is harvested; the `@centient/dag` port
+  vendors or re-implements the two helper functions the renderer uses.
+
+**Test-file imports:** the harvested `*.test.ts` files are kept **verbatim** and
+therefore still import from their original crucible tree layout
+(`../../src/orchestrator/dag.js`, `../../src/state/circuit-breaker.js`,
+`../../src/utils/atomic-io.js`, `../src/cli-utils.js`, etc.). Those relative
+paths do not exist under `harvest/`, so the tests **will not run here** — they
+are included for reference and to preserve the full test surface. The
+destination-package PR re-points these imports at the ported module locations
+and adds them to that package's test scope. They are intentionally outside every
+`make check` scope here.
 
 `git-ops.ts` (the fourth harvest target from this sweep) is a **private** target
 and is staged in the `centient-labs/workspace` repo, not here — see workspace
@@ -53,9 +86,20 @@ PR `harvest/crucible-git-ops` and workspace issue #85.
 
 ## Destination subdirs in this staging
 
-| Subdir | Destination package |
-|---|---|
-| `resilience/` | `@centient/resilience` |
-| `cli-utils/` | `@centient/cli-utils` |
-| `dag/` | `@centient/dag` |
-| `wal-atomic/` | `@centient/wal` (atomic-io module) |
+The destination packages below are **planned, not yet created**. Each is a named
+extraction candidate in
+`docs/plans/2026-06-12-centralization-candidates.md` (the same sweep that
+authorized this harvest, section 0); the plan section is cited per row. The
+`@centient/wal` package already exists (see the CLAUDE.md packages table) and
+gains atomic-io as a new module. The other three (`@centient/resilience`,
+`@centient/cli-utils`, `@centient/dag`) do not appear in the CLAUDE.md packages
+table yet **by design** — they are created in their respective live-port PRs,
+which add their CLAUDE.md table rows at that time. Their absence from CLAUDE.md
+today is expected for archival-staging, not a discrepancy.
+
+| Subdir | Destination package | Plan section | Status |
+|---|---|---|---|
+| `resilience/` | `@centient/resilience` | §2.1 | planned (not yet created) |
+| `cli-utils/` | `@centient/cli-utils` | §2.10 | planned (not yet created) |
+| `dag/` | `@centient/dag` | §2.11 | planned (not yet created) |
+| `wal-atomic/` | `@centient/wal` (atomic-io module) | §2.12 | package exists; module to be added |

--- a/harvest/crucible/README.md
+++ b/harvest/crucible/README.md
@@ -1,0 +1,61 @@
+# Crucible Harvest — Archival-Safety Staging
+
+These are **archival-safety copies** of source modules harvested from the
+`crucible` repository ahead of its archival (operator decision, recorded in
+`docs/plans/2026-06-12-centralization-candidates.md` section 0).
+
+**These files are NOT wired into any build, test, lint, or turbo/tsconfig scope.**
+They sit at the repo root under `harvest/`, outside the `packages/*` pnpm
+workspace glob, so `make check` ignores them entirely. They exist only so the
+code survives crucible's archival in a versioned location.
+
+**The live ports happen in the destination package PRs** — not here. Each
+destination package owns the work of adapting these modules (ESM exports,
+zero-dependency rewrites, clock/randomness injection, `@centient` scaffold
+conventions, changesets, CLAUDE.md table rows). This staging is the safety net,
+not the port.
+
+## Provenance
+
+All copies taken **verbatim** (byte-for-byte; verified with `cmp`) from crucible
+at commit `d2dbf92c8f1c3ba128e7faccc4e5458677dcec40`, copy date **2026-06-12**.
+
+Crucible source root for the paths below:
+`/Users/owenjohnson/centient-labs/platform/crucible`
+
+| Source path @ crucible `d2dbf92` | Copy date | Destination package | Why harvested |
+|---|---|---|---|
+| `packages/crucible/src/state/circuit-breaker.ts` | 2026-06-12 | `@centient/resilience` | Pure CLOSED→OPEN→HALF_OPEN state machine (ADR-036). Reusable resilience primitive for any tiered persistence/fallback chain — no crucible-specific coupling. |
+| `packages/crucible/tests/state/circuit-breaker.test.ts` | 2026-06-12 | `@centient/resilience` | Full test suite for the circuit-breaker state machine. |
+| `packages/crucible/src/cli-utils.ts` | 2026-06-12 | `@centient/cli-utils` | Shared CLI helpers (`writeError` structured stderr, `detectTerminalCapabilities` for FORCE_COLOR/NO_COLOR/TERM=dumb — ADR-004 D4/D5). Generic terminal/CLI utility, no crucible domain logic. |
+| `packages/crucible/tests/cli-utils.test.ts` | 2026-06-12 | `@centient/cli-utils` | Full test suite for the CLI utilities. |
+| `packages/crucible/src/orchestrator/dag.ts` | 2026-06-12 | `@centient/dag` | Original DAG engine: cycle detection (DFS white/gray/black), topological sort (Kahn's algorithm), wave calculation, ready-queue resolution (ADR-021 D1/D10). Pure computation, no I/O. |
+| `packages/crucible/tests/orchestrator/dag.test.ts` | 2026-06-12 | `@centient/dag` | Full DAG-engine test suite. |
+| `packages/crucible/src/orchestrator/dag-renderer.ts` | 2026-06-12 | `@centient/dag` | Companion DAG presentation module (wave/graph rendering). Harvested alongside the engine so the DAG module surface survives intact. |
+| `packages/crucible/tests/orchestrator/dag-renderer.test.ts` | 2026-06-12 | `@centient/dag` | Full DAG-renderer test suite. |
+| `packages/crucible/src/utils/atomic-io.ts` | 2026-06-12 | `@centient/wal` (atomic-io) | `atomicWrite` (UUID `.tmp` sibling + rename-over) and `atomicAppendLine` (single-syscall POSIX append ≤ PIPE_BUF). Crash-safe file I/O primitive — companion to the WAL package. |
+| `packages/crucible/tests/utils/atomic-io.test.ts` | 2026-06-12 | `@centient/wal` (atomic-io) | Full test suite for the atomic-io primitives. |
+
+## Companion type dependencies (resolved during the live port, not copied here)
+
+`dag.ts` imports `validateDAGDefinition` and DAG types from
+`packages/crucible/src/orchestrator/types.ts` (a barrel re-exporting
+`types/pipeline-state-model.ts`, `types/failure-model.ts`, etc., where
+`DAGDefinition` and `validateDAGDefinition` are actually defined). Those type
+modules are deliberately **not** copied — they are a broad orchestrator type
+tree, not part of "the DAG implementation." The `@centient/dag` port will
+re-declare or vendor the minimal `DAGDefinition` / validation surface it needs.
+The crucible commit hash above pins the exact source for that work.
+
+`git-ops.ts` (the fourth harvest target from this sweep) is a **private** target
+and is staged in the `centient-labs/workspace` repo, not here — see workspace
+PR `harvest/crucible-git-ops` and workspace issue #85.
+
+## Destination subdirs in this staging
+
+| Subdir | Destination package |
+|---|---|
+| `resilience/` | `@centient/resilience` |
+| `cli-utils/` | `@centient/cli-utils` |
+| `dag/` | `@centient/dag` |
+| `wal-atomic/` | `@centient/wal` (atomic-io module) |

--- a/harvest/crucible/cli-utils/cli-utils.test.ts
+++ b/harvest/crucible/cli-utils/cli-utils.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for cli-utils.ts
+ *
+ * Covers:
+ * - writeError: structured three-part error output to stderr
+ * - createAnsiColors: ANSI color code generation
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeError, createAnsiColors, detectTerminalCapabilities } from "../src/cli-utils.js";
+
+// ---------------------------------------------------------------------------
+// writeError
+// ---------------------------------------------------------------------------
+
+describe("writeError", () => {
+  let stderrWrite: ReturnType<typeof vi.fn>;
+  const originalStderrWrite = process.stderr.write;
+
+  beforeEach(() => {
+    stderrWrite = vi.fn().mockReturnValue(true);
+    process.stderr.write = stderrWrite as unknown as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+  });
+
+  it("writes structured three-part error to stderr", () => {
+    writeError("something broke", "it should work", "restart the thing");
+
+    expect(stderrWrite).toHaveBeenCalledTimes(1);
+    const output = stderrWrite.mock.calls[0]?.[0] as string;
+    expect(output).toContain("[ERROR]");
+    expect(output).toContain("something broke");
+    expect(output).toContain("Expected:");
+    expect(output).toContain("it should work");
+    expect(output).toContain("Recovery:");
+    expect(output).toContain("restart the thing");
+  });
+
+  it("includes all three parameters in output", () => {
+    writeError("file not found", "file to exist at /tmp/x", "create the file");
+
+    const output = stderrWrite.mock.calls[0]?.[0] as string;
+    expect(output).toContain("file not found");
+    expect(output).toContain("file to exist at /tmp/x");
+    expect(output).toContain("create the file");
+  });
+
+  it("outputs a single multi-line string", () => {
+    writeError("a", "b", "c");
+
+    const output = stderrWrite.mock.calls[0]?.[0] as string;
+    const lines = output.trim().split("\n");
+    expect(lines.length).toBe(3);
+  });
+
+  it("returns void", () => {
+    const result = writeError("a", "b", "c");
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAnsiColors
+// ---------------------------------------------------------------------------
+
+describe("createAnsiColors", () => {
+  const originalEnv = { ...process.env };
+  const originalIsTTY = process.stdout.isTTY;
+
+  afterEach(() => {
+    if ("NO_COLOR" in originalEnv) {
+      process.env.NO_COLOR = originalEnv.NO_COLOR;
+    } else {
+      delete process.env.NO_COLOR;
+    }
+    if ("TERM" in originalEnv) {
+      process.env.TERM = originalEnv.TERM;
+    } else {
+      delete process.env.TERM;
+    }
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("returns empty strings for all codes when color is disabled", () => {
+    process.env.NO_COLOR = "1";
+    const colors = createAnsiColors();
+    expect(colors.reset).toBe("");
+    expect(colors.bright).toBe("");
+    expect(colors.dim).toBe("");
+    expect(colors.red).toBe("");
+    expect(colors.green).toBe("");
+    expect(colors.yellow).toBe("");
+    expect(colors.cyan).toBe("");
+  });
+
+  it("returns ANSI escape codes when color is enabled", () => {
+    delete process.env.NO_COLOR;
+    delete process.env.TERM;
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    const colors = createAnsiColors();
+    expect(colors.reset).toBe("\x1b[0m");
+    expect(colors.bright).toBe("\x1b[1m");
+    expect(colors.dim).toBe("\x1b[2m");
+    expect(colors.red).toBe("\x1b[31m");
+    expect(colors.green).toBe("\x1b[32m");
+    expect(colors.yellow).toBe("\x1b[33m");
+    expect(colors.cyan).toBe("\x1b[36m");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectTerminalCapabilities (T-D2a)
+// ---------------------------------------------------------------------------
+
+describe("detectTerminalCapabilities", () => {
+  const originalStdoutIsTTY = process.stdout.isTTY;
+  const originalStderrIsTTY = process.stderr.isTTY;
+  const originalStdoutColumns = process.stdout.columns;
+  const originalStderrColumns = process.stderr.columns;
+  const originalForceColor = process.env.FORCE_COLOR;
+  const originalNoColor = process.env.NO_COLOR;
+  const originalTerm = process.env.TERM;
+
+  function setStdout(isTTY: boolean | undefined, columns: number | undefined): void {
+    Object.defineProperty(process.stdout, "isTTY", { value: isTTY, writable: true, configurable: true });
+    Object.defineProperty(process.stdout, "columns", { value: columns, writable: true, configurable: true });
+  }
+
+  afterEach(() => {
+    // Restore env vars precisely (don't just delete — preserve originals)
+    if (originalForceColor !== undefined) process.env.FORCE_COLOR = originalForceColor;
+    else delete process.env.FORCE_COLOR;
+    if (originalNoColor !== undefined) process.env.NO_COLOR = originalNoColor;
+    else delete process.env.NO_COLOR;
+    if (originalTerm !== undefined) process.env.TERM = originalTerm;
+    else delete process.env.TERM;
+    Object.defineProperty(process.stdout, "isTTY", { value: originalStdoutIsTTY, writable: true, configurable: true });
+    Object.defineProperty(process.stdout, "columns", { value: originalStdoutColumns, writable: true, configurable: true });
+    Object.defineProperty(process.stderr, "isTTY", { value: originalStderrIsTTY, writable: true, configurable: true });
+    Object.defineProperty(process.stderr, "columns", { value: originalStderrColumns, writable: true, configurable: true });
+  });
+
+  it("TTY with 120 columns: hasColor=true, width=120", () => {
+    delete process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    delete process.env.TERM;
+    setStdout(true, 120);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(true);
+    expect(caps.width).toBe(120);
+    expect(caps.isTTY).toBe(true);
+  });
+
+  it("non-TTY: hasColor=false, width defaults to 80", () => {
+    delete process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    delete process.env.TERM;
+    setStdout(false, 0);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(false);
+    expect(caps.width).toBe(80);
+    expect(caps.isTTY).toBe(false);
+  });
+
+  it("FORCE_COLOR=1: hasColor=true even on non-TTY", () => {
+    process.env.FORCE_COLOR = "1";
+    delete process.env.NO_COLOR;
+    setStdout(false, 0);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(true);
+  });
+
+  it("NO_COLOR set: hasColor=false even on TTY", () => {
+    delete process.env.FORCE_COLOR;
+    process.env.NO_COLOR = "";
+    setStdout(true, 120);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(false);
+    expect(caps.width).toBe(120);
+  });
+
+  it("TERM=dumb: hasColor=false even on TTY", () => {
+    delete process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    process.env.TERM = "dumb";
+    setStdout(true, 120);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(false);
+    expect(caps.isDumb).toBe(true);
+  });
+
+  it("FORCE_COLOR wins over NO_COLOR (precedence: FORCE_COLOR > NO_COLOR)", () => {
+    process.env.FORCE_COLOR = "1";
+    process.env.NO_COLOR = "1";
+    setStdout(false, 0);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(true);
+  });
+
+  it("isTTY=undefined: hasColor=false, width=80", () => {
+    delete process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    delete process.env.TERM;
+    setStdout(undefined, undefined);
+    const caps = detectTerminalCapabilities("stdout");
+    expect(caps.hasColor).toBe(false);
+    expect(caps.width).toBe(80);
+  });
+
+  it("stream='stderr': reads from process.stderr, not process.stdout", () => {
+    delete process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    delete process.env.TERM;
+    // stdout is non-TTY
+    setStdout(false, 0);
+    // stderr is TTY with 100 columns
+    Object.defineProperty(process.stderr, "isTTY", { value: true, writable: true, configurable: true });
+    Object.defineProperty(process.stderr, "columns", { value: 100, writable: true, configurable: true });
+    const caps = detectTerminalCapabilities("stderr");
+    expect(caps.isTTY).toBe(true);
+    expect(caps.width).toBe(100);
+  });
+});

--- a/harvest/crucible/cli-utils/cli-utils.ts
+++ b/harvest/crucible/cli-utils/cli-utils.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared CLI Utilities
+ *
+ * Common utilities for all crucible CLI subcommands:
+ * - writeError: Structured three-part error output to stderr
+ * - detectTerminalCapabilities: FORCE_COLOR/NO_COLOR/TERM=dumb capability detection
+ *
+ * ADR-004 D4/D5: Shared writeError pattern and NO_COLOR convention.
+ */
+
+/**
+ * Write a structured error to stderr.
+ * Three-part layout: what went wrong, what was expected, how to recover.
+ * Returns void (does not exit). Exit code handling is the caller's responsibility.
+ */
+export function writeError(what: string, expected: string, recovery: string): void {
+  process.stderr.write(
+    `[ERROR] ${what}\n  Expected: ${expected}\n  Recovery: ${recovery}\n`,
+  );
+}
+
+/**
+ * Terminal capability flags for a given output stream.
+ * Used to make informed decisions about ANSI color, width, and formatting.
+ */
+export interface TerminalCapabilities {
+  isTTY: boolean;
+  hasColor: boolean;
+  isDumb: boolean;
+  width: number;
+}
+
+/**
+ * Detect terminal capabilities for the given stream.
+ * Precedence chain: FORCE_COLOR > NO_COLOR > TERM=dumb > isTTY > default.
+ *
+ * - FORCE_COLOR (any value): forces hasColor=true, isTTY from stream
+ * - NO_COLOR (any value): forces hasColor=false
+ * - TERM=dumb: forces hasColor=false and isDumb=true
+ * - isTTY===true: hasColor=true
+ * - default: hasColor=false
+ *
+ * Width uses a >0 check to handle non-TTY streams where columns may be 0.
+ */
+export function detectTerminalCapabilities(
+  stream: "stdout" | "stderr" = "stdout",
+): TerminalCapabilities {
+  const s = process[stream] as NodeJS.WriteStream;
+  const isTTY = s.isTTY ?? false;
+
+  let hasColor: boolean;
+  let isDumb = false;
+
+  if ("FORCE_COLOR" in process.env) {
+    hasColor = true;
+  } else if ("NO_COLOR" in process.env) {
+    hasColor = false;
+  } else if (process.env.TERM === "dumb") {
+    hasColor = false;
+    isDumb = true;
+  } else if (isTTY) {
+    hasColor = true;
+  } else {
+    hasColor = false;
+  }
+
+  const width = s.columns > 0 ? s.columns : 80;
+
+  return { isTTY, hasColor, isDumb, width };
+}
+
+/**
+ * ANSI color codes for CLI output.
+ * Evaluates detectTerminalCapabilities() once at creation time and returns plain properties.
+ * CLI processes do not change color state mid-execution, so caching is safe.
+ *
+ * ADR-004 D5: Shared ANSI constant, NO_COLOR-aware.
+ */
+export interface AnsiColors {
+  reset: string;
+  bright: string;
+  dim: string;
+  red: string;
+  green: string;
+  yellow: string;
+  cyan: string;
+}
+
+export function createAnsiColors(): AnsiColors {
+  const { hasColor: enabled } = detectTerminalCapabilities('stdout');
+  return {
+    reset: enabled ? "\x1b[0m" : "",
+    bright: enabled ? "\x1b[1m" : "",
+    dim: enabled ? "\x1b[2m" : "",
+    red: enabled ? "\x1b[31m" : "",
+    green: enabled ? "\x1b[32m" : "",
+    yellow: enabled ? "\x1b[33m" : "",
+    cyan: enabled ? "\x1b[36m" : "",
+  };
+}

--- a/harvest/crucible/dag/dag-renderer.test.ts
+++ b/harvest/crucible/dag/dag-renderer.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for dag-renderer.ts (expansion-docs).
+ *
+ * Covers:
+ * - ASCII art rendering (wide terminal)
+ * - Narrow terminal fallback
+ * - No-color mode
+ * - Mermaid flowchart output
+ * - Mermaid ID sanitization and collision handling
+ * - Status overlay (statusMap)
+ * - Multi-wave arrow rendering
+ * - Regression: --json and --show-waves behavior in cmdDag
+ */
+
+import { describe, it, expect } from "vitest";
+import { DAGEngine } from "../../src/orchestrator/dag.js";
+import { renderDagAscii, renderDagMermaid, MIN_COLUMN_WIDTH } from "../../src/orchestrator/dag-renderer.js";
+
+// ---------------------------------------------------------------------------
+// Test Fixtures
+// Local copies of DAG helpers (also in dag.test.ts) kept here deliberately
+// for test isolation — each test file should be independently runnable.
+// ---------------------------------------------------------------------------
+
+const STAGES = ["conceptualize", "architect", "implement", "review"];
+
+/** Simple linear DAG: a → b → c */
+function linearDAG() {
+  return {
+    version: 1,
+    pipelines: [
+      { id: "a", name: "Pipeline A", stages: STAGES, dependsOn: [] as string[] },
+      { id: "b", name: "Pipeline B", stages: STAGES, dependsOn: ["a"] },
+      { id: "c", name: "Pipeline C", stages: STAGES, dependsOn: ["b"] },
+    ],
+  };
+}
+
+/** Diamond DAG: a → b, a → c, b → d, c → d */
+function diamondDAG() {
+  return {
+    version: 1,
+    pipelines: [
+      { id: "a", name: "Pipeline A", stages: STAGES, dependsOn: [] as string[] },
+      { id: "b", name: "Pipeline B", stages: STAGES, dependsOn: ["a"] },
+      { id: "c", name: "Pipeline C", stages: STAGES, dependsOn: ["a"] },
+      { id: "d", name: "Pipeline D", stages: STAGES, dependsOn: ["b", "c"] },
+    ],
+  };
+}
+
+/** Single-node DAG */
+function singleDAG() {
+  return {
+    version: 1,
+    pipelines: [{ id: "solo", name: "Solo Pipeline", stages: STAGES }],
+  };
+}
+
+function loadDAG(data: unknown): DAGEngine {
+  const result = DAGEngine.load(data);
+  if (!result.ok) throw new Error(`DAG load failed: ${result.error.message}`);
+  return result.value;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("renderDagAscii", () => {
+  it("1. linearDAG wide terminal: contains box-drawing chars, node IDs, and arrows", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, { width: 120 });
+
+    // Box-drawing characters present
+    expect(output).toContain("┌");
+    expect(output).toContain("┐");
+    expect(output).toContain("└");
+    expect(output).toContain("┘");
+
+    // All node IDs present
+    expect(output).toContain("a");
+    expect(output).toContain("b");
+    expect(output).toContain("c");
+
+    // Arrows present between dependency pairs
+    expect(output).toContain("──→");
+  });
+
+  it("2. diamondDAG wide terminal: all 4 node IDs present, arrow connectors present", () => {
+    const dag = loadDAG(diamondDAG());
+    const output = renderDagAscii(dag, { width: 120 });
+
+    expect(output).toContain("a");
+    expect(output).toContain("b");
+    expect(output).toContain("c");
+    expect(output).toContain("d");
+
+    // At minimum a→b and b→d arrows should be present (same row)
+    expect(output).toContain("──→");
+  });
+
+  it("3. singleNodeDAG: renders without arrows", () => {
+    const dag = loadDAG(singleDAG());
+    const output = renderDagAscii(dag, { width: 120 });
+
+    expect(output).toContain("solo");
+    expect(output).toContain("┌");
+    // No arrows expected for single node
+    expect(output).not.toContain("→");
+  });
+
+  it("4. noColor: true — output contains no ANSI escape sequences", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, { width: 120, noColor: true });
+
+    expect(output).not.toContain("\x1b[");
+  });
+
+  it("5. narrowTerminal (width: 40): fallback — no box chars", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, { width: 40 });
+
+    // Fallback: no box-drawing characters
+    expect(output).not.toContain("┌");
+    expect(output).not.toContain("┘");
+
+    // But node IDs still present in simple list
+    expect(output).toContain("a");
+    expect(output).toContain("b");
+    expect(output).toContain("c");
+  });
+
+  it("6. MIN_COLUMN_WIDTH threshold: wave columns exceeding width triggers fallback", () => {
+    const dag = loadDAG(linearDAG());
+    // 3 waves × MIN_COLUMN_WIDTH = 3 × 14 = 42; width=40 → fallback
+    const output = renderDagAscii(dag, { width: 40 });
+    expect(output).not.toContain("┌");
+  });
+
+  it("7. statusMap overlay: running pipeline shows [*] badge in node box", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, {
+      width: 200,
+      statusMap: { a: "running", b: "complete", c: "ready" },
+    });
+
+    expect(output).toContain("[*]"); // running badge
+    expect(output).toContain("[+]"); // complete badge
+    expect(output).toContain("[ ]"); // ready badge
+  });
+
+  it("8. multi-wave arrow: 3-wave linear DAG has arrows between wave 1→2 and 2→3", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, { width: 200 });
+
+    // The output should have at least 2 arrow connectors (a→b and b→c)
+    const arrowCount = (output.match(/──→/g) ?? []).length;
+    expect(arrowCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("renderDagMermaid", () => {
+  it("1. mermaid linear: starts with 'flowchart TD', contains '-->' edges for each dep", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagMermaid(dag);
+
+    expect(output).toMatch(/^flowchart TD/);
+    // Edges: a→b and b→c
+    expect(output).toContain("-->");
+    // Both edges present (a→b and b→c)
+    const edgeCount = (output.match(/-->/g) ?? []).length;
+    expect(edgeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("2. mermaid with statusMap: contains ':::running' class annotation", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagMermaid(dag, {
+      statusMap: { a: "running", b: "complete", c: "ready" },
+    });
+
+    expect(output).toContain(":::running");
+    expect(output).toContain(":::complete");
+    expect(output).toContain(":::ready");
+    // Class definitions should be present
+    expect(output).toContain("classDef running");
+    expect(output).toContain("classDef complete");
+  });
+
+  it("3. mermaid sanitization: hyphens replaced with underscore", () => {
+    const dag = loadDAG({
+      version: 1,
+      pipelines: [
+        { id: "my-pipeline", name: "My Pipeline", stages: STAGES, dependsOn: [] as string[] },
+        { id: "my-pipe", name: "My Pipe", stages: STAGES, dependsOn: ["my-pipeline"] },
+      ],
+    });
+    const output = renderDagMermaid(dag);
+
+    // Sanitized IDs used in Mermaid output
+    expect(output).toContain("my_pipeline");
+    expect(output).toContain("my_pipe");
+    // Original IDs with hyphens should not appear as node IDs
+    expect(output).not.toContain("my-pipeline[");
+    expect(output).not.toContain("my-pipe[");
+  });
+
+  it("4. mermaid sanitization: multiple hyphenated IDs get distinct sanitized IDs", () => {
+    const dag = loadDAG({
+      version: 1,
+      pipelines: [
+        { id: "a-b", name: "A B", stages: STAGES, dependsOn: [] as string[] },
+        { id: "c-d", name: "C D", stages: STAGES, dependsOn: [] as string[] },
+      ],
+    });
+    const output = renderDagMermaid(dag);
+
+    // a-b sanitizes to a_b, c-d sanitizes to c_d — distinct IDs, no collision
+    expect(output).toContain("a_b");
+    expect(output).toContain("c_d");
+  });
+
+  it("mermaid diamond: all 4 nodes and 4 edges present", () => {
+    const dag = loadDAG(diamondDAG());
+    const output = renderDagMermaid(dag);
+
+    expect(output).toMatch(/^flowchart TD/);
+    expect(output).toContain("a[");
+    expect(output).toContain("b[");
+    expect(output).toContain("c[");
+    expect(output).toContain("d[");
+
+    // 4 edges: a→b, a→c, b→d, c→d
+    const edgeCount = (output.match(/-->/g) ?? []).length;
+    expect(edgeCount).toBe(4);
+  });
+
+  it("mermaid no statusMap: no classDef lines", () => {
+    const dag = loadDAG(linearDAG());
+    const output = renderDagMermaid(dag);
+
+    expect(output).not.toContain("classDef");
+  });
+});
+
+describe("MIN_COLUMN_WIDTH constant", () => {
+  it("is exported and equals 14", () => {
+    expect(MIN_COLUMN_WIDTH).toBe(14);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T-01: renderSimpleList with statusMap (narrow-terminal status overlay, ADR-059 D4)
+// ---------------------------------------------------------------------------
+
+/** Single-node DAG with id "a" for narrow-terminal badge tests */
+function singleNodeA() {
+  return {
+    version: 1,
+    pipelines: [{ id: "a", name: "Pipeline A", stages: STAGES }],
+  };
+}
+
+describe("renderSimpleList with statusMap", () => {
+  it("1. narrow path - running badge prepended", () => {
+    const dag = loadDAG(singleNodeA());
+    const output = renderDagAscii(dag, { width: 40, statusMap: { a: "running" } });
+
+    // statusBadge("running") === "[*]"
+    expect(output).toContain("[*]");
+  });
+
+  it("2. narrow path - complete badge", () => {
+    const dag = loadDAG(singleNodeA());
+    const output = renderDagAscii(dag, { width: 40, statusMap: { a: "complete" } });
+
+    // statusBadge("complete") === "[+]"
+    expect(output).toContain("[+]");
+  });
+
+  it("3. narrow path - failed badge", () => {
+    const dag = loadDAG(singleNodeA());
+    const output = renderDagAscii(dag, { width: 40, statusMap: { a: "failed" } });
+
+    // statusBadge("failed") === "[X]"
+    expect(output).toContain("[X]");
+  });
+
+  it("4. without statusMap - no badge, output matches pre-T-01 baseline", () => {
+    const dag = loadDAG(singleNodeA());
+    const output = renderDagAscii(dag, { width: 40 });
+
+    // Node ID should appear with leading spaces, no badge prefix
+    expect(output).toContain("  a");
+    // No status badge characters
+    expect(output).not.toContain("[*]");
+    expect(output).not.toContain("[+]");
+    expect(output).not.toContain("[X]");
+  });
+
+  it("5. partial statusMap - missing IDs get no badge", () => {
+    // linearDAG: a → b → c; only a has a status entry
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, { width: 40, statusMap: { a: "running" } });
+
+    // [*] badge appears exactly once (for a)
+    const badgeMatches = output.match(/\[\*\]/g) ?? [];
+    expect(badgeMatches).toHaveLength(1);
+
+    // Lines for b and c should not contain any badge chars
+    const lines = output.split("\n");
+    const bLine = lines.find((l) => l.includes("b"));
+    const cLine = lines.find((l) => l.includes("c"));
+    expect(bLine).toBeDefined();
+    expect(cLine).toBeDefined();
+    expect(bLine).not.toContain("[*]");
+    expect(bLine).not.toContain("[+]");
+    expect(bLine).not.toContain("[X]");
+    expect(cLine).not.toContain("[*]");
+    expect(cLine).not.toContain("[+]");
+    expect(cLine).not.toContain("[X]");
+  });
+
+  it("6. renderDagAscii narrow path (width < 60) forwards statusMap", () => {
+    const dag = loadDAG(singleNodeA());
+    // width: 40 < 60, so narrow path is taken
+    const output = renderDagAscii(dag, { width: 40, statusMap: { a: "running" } });
+
+    expect(output).toContain("[*]");
+    // Narrow path: no box-drawing chars
+    expect(output).not.toContain("┌");
+  });
+
+  it("7. renderDagAscii narrow path (waveCount x MIN_COLUMN_WIDTH > width) - statusMap forwarded", () => {
+    // linearDAG has 3 waves; 3 × 14 = 42 > 40, so narrow path is taken
+    const dag = loadDAG(linearDAG());
+    const output = renderDagAscii(dag, { width: 40, statusMap: { a: "complete" } });
+
+    // statusBadge("complete") === "[+]"
+    expect(output).toContain("[+]");
+    // Narrow path: no box-drawing chars
+    expect(output).not.toContain("┌");
+  });
+
+  it("8. renderDagAscii wide terminal path - statusMap used in nodeLabel, not in renderSimpleList", () => {
+    const dag = loadDAG(singleNodeA());
+    // width: 200, single wave (1 × 14 = 14 <= 200), so wide path is taken
+    const output = renderDagAscii(dag, { width: 200, statusMap: { a: "running" } });
+
+    // Badge appears in the node box label
+    expect(output).toContain("[*]");
+    // Wide path: box-drawing chars present
+    expect(output).toContain("┌");
+  });
+});

--- a/harvest/crucible/dag/dag-renderer.ts
+++ b/harvest/crucible/dag/dag-renderer.ts
@@ -1,0 +1,267 @@
+/**
+ * DAG Renderer (expansion-docs)
+ *
+ * Renders a DAGEngine as ASCII art (box-drawing characters) or Mermaid
+ * flowchart syntax for terminal and external visualization.
+ *
+ * Pure rendering functions -- no I/O, no process access.
+ *
+ * @module orchestrator/dag-renderer
+ */
+
+import type { DAGEngine } from "./dag.js";
+import type { PipelineStatus } from "./types.js";
+import { statusBadge, truncate } from "./formatters.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum column width for a node box (inner content + 2 border chars). */
+export const MIN_COLUMN_WIDTH = 14;
+
+/** Maximum pipeline ID display length before truncation. */
+const MAX_ID_DISPLAY_LENGTH = 30;
+
+/** Width of the arrow connector section between wave columns. */
+const ARROW_WIDTH = 5; // " ──→ "
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DagRenderOpts {
+  /** Terminal width for layout. Default: 80. */
+  width?: number;
+  /** Disable ANSI color output. */
+  noColor?: boolean;
+  /**
+   * Pipeline status map for status overlay.
+   * Keyed by pipeline ID → PipelineStatus.
+   */
+  statusMap?: Record<string, PipelineStatus>;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the DAG as ASCII art (box-drawing characters).
+ * Returns a multi-line string — caller writes to stdout.
+ *
+ * Layout: wave columns left-to-right. Each wave is a vertical
+ * stack of node boxes. Arrows connect dependency → dependent nodes.
+ *
+ * Falls back to simple list format when width < 60 OR
+ * waveCount × MIN_COLUMN_WIDTH > width.
+ */
+export function renderDagAscii(dag: DAGEngine, opts?: DagRenderOpts): string {
+  const width = opts?.width ?? 80;
+  const statusMap = opts?.statusMap;
+
+  const waves = dag.getAllWaves();
+  const waveCount = waves.length;
+
+  if (waveCount === 0) {
+    return "  (empty DAG)\n";
+  }
+
+  // Narrow-terminal fallback: width < 60 OR wave columns exceed available width
+  if (width < 60 || waveCount * MIN_COLUMN_WIDTH > width) {
+    return renderSimpleList(dag, statusMap);
+  }
+
+  // Build node label (with optional status badge)
+  function nodeLabel(id: string): string {
+    const displayId = truncate(id, MAX_ID_DISPLAY_LENGTH);
+    if (statusMap && statusMap[id] !== undefined) {
+      return statusBadge(statusMap[id]!) + " " + displayId;
+    }
+    return displayId;
+  }
+
+  // Compute inner width for each wave column
+  // inner = max label length in wave; box width = inner + 2 (for │...│)
+  const innerWidths = waves.map((wave) => {
+    const maxLabel = Math.max(
+      MIN_COLUMN_WIDTH - 2, // subtract 2 for border chars
+      ...wave.map((id) => nodeLabel(id).length),
+    );
+    return maxLabel;
+  });
+
+  const maxRows = Math.max(...waves.map((w) => w.length));
+  const lines: string[] = [];
+
+  for (let row = 0; row < maxRows; row++) {
+    let topLine = "";
+    let midLine = "";
+    let botLine = "";
+
+    for (let waveIdx = 0; waveIdx < waveCount; waveIdx++) {
+      const innerW = innerWidths[waveIdx]!;
+      const nodeId = waves[waveIdx]![row];
+
+      if (nodeId !== undefined) {
+        const label = nodeLabel(nodeId);
+        // Pad label to exactly innerW characters
+        const paddedLabel =
+          label.length >= innerW
+            ? label.slice(0, innerW)
+            : label + " ".repeat(innerW - label.length);
+
+        topLine += "┌" + "─".repeat(innerW) + "┐";
+        midLine += "│" + paddedLabel + "│";
+        botLine += "└" + "─".repeat(innerW) + "┘";
+      } else {
+        const fullW = innerW + 2; // +2 for border chars
+        topLine += " ".repeat(fullW);
+        midLine += " ".repeat(fullW);
+        botLine += " ".repeat(fullW);
+      }
+
+      // Arrow connector between wave columns
+      if (waveIdx < waveCount - 1) {
+        const currNodeId = waves[waveIdx]![row];
+        const nextNodeId = waves[waveIdx + 1]![row];
+
+        // Show arrow if both nodes exist and next depends on current
+        const hasArrow =
+          currNodeId !== undefined &&
+          nextNodeId !== undefined &&
+          (dag.getDependencies(nextNodeId) as readonly string[]).includes(currNodeId);
+
+        const connector = hasArrow ? " ──→ " : " ".repeat(ARROW_WIDTH);
+        topLine += " ".repeat(ARROW_WIDTH);
+        midLine += connector;
+        botLine += " ".repeat(ARROW_WIDTH);
+      }
+    }
+
+    lines.push(topLine, midLine, botLine);
+    if (row < maxRows - 1) {
+      lines.push(""); // blank gap between node rows
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Render the DAG as Mermaid flowchart syntax (flowchart TD).
+ * Returns Mermaid source — caller wraps in code block if needed.
+ *
+ * Status annotations: when statusMap is present, each node gets a CSS
+ * class based on its status for styling in rendered output.
+ */
+export function renderDagMermaid(dag: DAGEngine, opts?: DagRenderOpts): string {
+  const statusMap = opts?.statusMap;
+  const pipelines = dag.getPipelines();
+
+  // Build sanitized ID map with collision detection
+  const sanitizedIds = buildSanitizedIdMap(pipelines.map((p) => p.id));
+
+  const lines: string[] = ["flowchart TD"];
+
+  // Node declarations
+  for (const p of pipelines) {
+    const safeId = sanitizedIds.get(p.id)!;
+    const rawLabel = p.name ?? p.id;
+    // Escape characters that would break Mermaid ["label"] syntax
+    const label = rawLabel.replace(/"/g, "#quot;").replace(/\[/g, "#91;").replace(/]/g, "#93;");
+    const statusClass =
+      statusMap && statusMap[p.id] !== undefined
+        ? `:::${statusMap[p.id]}`
+        : "";
+    lines.push(`    ${safeId}["${label}"]${statusClass}`);
+  }
+
+  // Edges
+  for (const p of pipelines) {
+    const deps = p.dependsOn ?? [];
+    for (const dep of deps) {
+      const fromId = sanitizedIds.get(dep);
+      const toId = sanitizedIds.get(p.id);
+      if (fromId && toId) {
+        lines.push(`    ${fromId} --> ${toId}`);
+      }
+    }
+  }
+
+  // Class definitions (always include when statusMap provided)
+  if (statusMap) {
+    lines.push(`    classDef running fill:#ffd700`);
+    lines.push(`    classDef complete fill:#90ee90`);
+    lines.push(`    classDef failed fill:#ff6b6b`);
+    lines.push(`    classDef ready fill:#e0e0e0`);
+    lines.push(`    classDef blocked fill:#ff9966`);
+    lines.push(`    classDef skipped fill:#cccccc`);
+    lines.push(`    classDef awaiting_merge fill:#99ccff`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the DAG as a simple text list (narrow-terminal fallback).
+ * Returns content only — no header/footer.
+ *
+ * Accepts an optional statusMap to prepend status badges to each pipeline line,
+ * matching the overlay behavior of the wide-terminal ASCII art mode (ADR-059 D4).
+ *
+ * @param dag - The DAG engine instance containing pipeline definitions.
+ * @param statusMap - Optional map of pipeline ID to status for badge rendering.
+ */
+function renderSimpleList(
+  dag: DAGEngine,
+  statusMap?: Record<string, PipelineStatus>,
+): string {
+  const pipelines = dag.getPipelines();
+  const lines: string[] = [];
+
+  for (const p of pipelines) {
+    const badge =
+      statusMap?.[p.id] !== undefined ? statusBadge(statusMap[p.id]!) + " " : "";
+    const deps = p.dependsOn ?? [];
+    if (deps.length === 0) {
+      lines.push(`  ${badge}${p.id}`);
+    } else {
+      lines.push(`  ${badge}${deps.join(", ")} \u2500\u2500 ${p.id}`);
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Sanitize pipeline IDs for Mermaid node identifiers.
+ * Replaces non-alphanumeric/underscore characters with `_`.
+ * Appends `_N` suffix on collision (e.g., `a-b` and `a_b` → `a_b` and `a_b_0`).
+ */
+function buildSanitizedIdMap(ids: string[]): Map<string, string> {
+  const result = new Map<string, string>();
+  const usedIds = new Set<string>();
+
+  for (const id of ids) {
+    let safeId = id.replace(/[^a-zA-Z0-9_]/g, "_");
+
+    if (usedIds.has(safeId)) {
+      // Find a unique suffix
+      let suffix = 0;
+      while (usedIds.has(`${safeId}_${suffix}`)) {
+        suffix++;
+      }
+      safeId = `${safeId}_${suffix}`;
+    }
+
+    usedIds.add(safeId);
+    result.set(id, safeId);
+  }
+
+  return result;
+}

--- a/harvest/crucible/dag/dag.test.ts
+++ b/harvest/crucible/dag/dag.test.ts
@@ -1,0 +1,1204 @@
+/**
+ * Unit tests for DAGEngine (ADR-021 T4).
+ *
+ * Covers:
+ * - DAG loading and validation
+ * - Cycle detection (positive and negative)
+ * - Topological sort correctness
+ * - Wave calculation
+ * - Ready-queue resolution
+ * - Edge cases: single pipeline, empty deps, diamond, complex DAG
+ * - Error cases: missing deps, self-reference, invalid schema
+ */
+
+import { describe, it, expect } from "vitest";
+import { DAGEngine } from "../../src/orchestrator/dag.js";
+import type { Chain, PipelineStatus } from "../../src/orchestrator/types.js";
+
+// ---------------------------------------------------------------------------
+// Test Fixtures
+// ---------------------------------------------------------------------------
+
+const STAGES = ["conceptualize", "architect", "implement", "review"];
+
+/** Simple linear DAG: A -> B -> C */
+function linearDAG() {
+  return {
+    version: 1,
+    pipelines: [
+      { id: "a", name: "Pipeline A", stages: STAGES, dependsOn: [] as string[] },
+      { id: "b", name: "Pipeline B", stages: STAGES, dependsOn: ["a"] },
+      { id: "c", name: "Pipeline C", stages: STAGES, dependsOn: ["b"] },
+    ],
+  };
+}
+
+/** Diamond DAG: A -> B, A -> C, B -> D, C -> D */
+function diamondDAG() {
+  return {
+    version: 1,
+    pipelines: [
+      { id: "a", name: "Pipeline A", stages: STAGES, dependsOn: [] as string[] },
+      { id: "b", name: "Pipeline B", stages: STAGES, dependsOn: ["a"] },
+      { id: "c", name: "Pipeline C", stages: STAGES, dependsOn: ["a"] },
+      { id: "d", name: "Pipeline D", stages: STAGES, dependsOn: ["b", "c"] },
+    ],
+  };
+}
+
+/** Parallel DAG: A, B, C (no dependencies) */
+function parallelDAG() {
+  return {
+    version: 1,
+    pipelines: [
+      { id: "a", name: "Pipeline A", stages: STAGES },
+      { id: "b", name: "Pipeline B", stages: STAGES },
+      { id: "c", name: "Pipeline C", stages: STAGES },
+    ],
+  };
+}
+
+/** Single pipeline */
+function singleDAG() {
+  return {
+    version: 1,
+    pipelines: [{ id: "solo", name: "Solo Pipeline", stages: STAGES }],
+  };
+}
+
+/** Complex 4-wave DAG resembling a real orchestration */
+function complexDAG() {
+  return {
+    version: 1,
+    pipelines: [
+      { id: "w0-a", name: "Wave 0 A", stages: STAGES },
+      { id: "w0-b", name: "Wave 0 B", stages: STAGES },
+      { id: "w1-a", name: "Wave 1 A", stages: STAGES, dependsOn: ["w0-a"] },
+      { id: "w1-b", name: "Wave 1 B", stages: STAGES, dependsOn: ["w0-a", "w0-b"] },
+      { id: "w2-a", name: "Wave 2 A", stages: STAGES, dependsOn: ["w1-a", "w1-b"] },
+      { id: "w3-a", name: "Wave 3 A", stages: STAGES, dependsOn: ["w2-a"] },
+    ],
+  };
+}
+
+function makeStatuses(
+  entries: Array<[string, PipelineStatus]>,
+): Map<string, PipelineStatus> {
+  return new Map(entries);
+}
+
+// ---------------------------------------------------------------------------
+// Loading & Validation
+// ---------------------------------------------------------------------------
+
+describe("DAGEngine", () => {
+  describe("load", () => {
+    it("loads a valid linear DAG", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.size).toBe(3);
+      }
+    });
+
+    it("loads a valid diamond DAG", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+    });
+
+    it("loads a valid parallel DAG", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+    });
+
+    it("loads a single pipeline DAG", () => {
+      const result = DAGEngine.load(singleDAG());
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.size).toBe(1);
+      }
+    });
+
+    it("rejects null input", () => {
+      const result = DAGEngine.load(null);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+      }
+    });
+
+    it("rejects missing version", () => {
+      const result = DAGEngine.load({ pipelines: [] });
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects empty pipelines", () => {
+      const result = DAGEngine.load({ version: 1, pipelines: [] });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+      }
+    });
+
+    it("accepts pipeline without stages (optional field)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "a", name: "A", dependsOn: [] }],
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects pipeline with invalid stages type", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "a", name: "A", stages: "not-an-array" }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+        expect(result.error.message).toContain("stages");
+      }
+    });
+
+    it("rejects missing dependency reference", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", name: "A", stages: STAGES, dependsOn: ["nonexistent"] },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_MISSING_DEPENDENCY");
+        expect(result.error.message).toContain("nonexistent");
+      }
+    });
+
+    it("rejects self-reference", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "a", name: "A", stages: STAGES, dependsOn: ["a"] }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+        expect(result.error.message).toContain("cannot depend on itself");
+      }
+    });
+
+    it("rejects duplicate pipeline IDs", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", name: "A", stages: STAGES },
+          { id: "a", name: "A2", stages: STAGES },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain("Duplicate");
+      }
+    });
+
+    // Pipeline ID kebab-case validation
+    it("accepts valid kebab-case IDs", () => {
+      for (const id of ["a", "my-pipeline", "pipeline-123", "w0-a", "abc"]) {
+        const result = DAGEngine.load({
+          version: 1,
+          pipelines: [{ id, name: id, stages: STAGES }],
+        });
+        expect(result.ok, `expected "${id}" to be accepted`).toBe(true);
+      }
+    });
+
+    it("rejects uppercase pipeline IDs", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "My-Pipeline", name: "P", stages: STAGES }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+        expect(result.error.message).toContain("kebab-case");
+      }
+    });
+
+    it("rejects IDs with special characters", () => {
+      for (const id of ["my_pipeline", "my.pipeline", "my pipeline", "my@pipe"]) {
+        const result = DAGEngine.load({
+          version: 1,
+          pipelines: [{ id, name: id, stages: STAGES }],
+        });
+        expect(result.ok, `expected "${id}" to be rejected`).toBe(false);
+        if (!result.ok) {
+          expect(result.error.message).toContain("kebab-case");
+        }
+      }
+    });
+
+    it("rejects IDs starting or ending with hyphens", () => {
+      for (const id of ["-leading", "trailing-", "-both-"]) {
+        const result = DAGEngine.load({
+          version: 1,
+          pipelines: [{ id, name: id, stages: STAGES }],
+        });
+        expect(result.ok, `expected "${id}" to be rejected`).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("DAG_INVALID");
+        }
+      }
+    });
+
+    it("rejects IDs over 63 characters", () => {
+      const longId = "a".repeat(64);
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: longId, name: "Long", stages: STAGES }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain("63 character limit");
+      }
+    });
+
+    it("accepts IDs exactly 63 characters", () => {
+      const id63 = "a".repeat(63);
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: id63, name: "Max", stages: STAGES }],
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cycle Detection
+  // -------------------------------------------------------------------------
+
+  describe("cycle detection", () => {
+    it("passes acyclic graphs", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+    });
+
+    it("detects direct cycle (A -> B -> A)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", name: "A", stages: STAGES, dependsOn: ["b"] },
+          { id: "b", name: "B", stages: STAGES, dependsOn: ["a"] },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_CYCLE_DETECTED");
+        expect(result.error.message).toContain("Cycle detected");
+      }
+    });
+
+    it("detects indirect cycle (A -> B -> C -> A)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", name: "A", stages: STAGES, dependsOn: ["c"] },
+          { id: "b", name: "B", stages: STAGES, dependsOn: ["a"] },
+          { id: "c", name: "C", stages: STAGES, dependsOn: ["b"] },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_CYCLE_DETECTED");
+      }
+    });
+
+    it("detects cycle in subgraph (isolated cycle with acyclic branch)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "root", name: "Root", stages: STAGES },
+          { id: "x", name: "X", stages: STAGES, dependsOn: ["y"] },
+          { id: "y", name: "Y", stages: STAGES, dependsOn: ["x"] },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_CYCLE_DETECTED");
+      }
+    });
+
+    it("provides readable cycle error message", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "alpha", name: "Alpha", stages: STAGES, dependsOn: ["beta"] },
+          { id: "beta", name: "Beta", stages: STAGES, dependsOn: ["alpha"] },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toMatch(/Cycle detected:.*->/);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Topological Sort
+  // -------------------------------------------------------------------------
+
+  describe("topological sort", () => {
+    it("produces valid ordering for linear DAG", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const order = result.value.getTopologicalOrder();
+      expect(order).toEqual(["a", "b", "c"]);
+    });
+
+    it("produces valid ordering for diamond DAG", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const order = result.value.getTopologicalOrder();
+
+      // A must come before B and C; B and C must come before D
+      const indexOf = (id: string) => order.indexOf(id);
+      expect(indexOf("a")).toBeLessThan(indexOf("b"));
+      expect(indexOf("a")).toBeLessThan(indexOf("c"));
+      expect(indexOf("b")).toBeLessThan(indexOf("d"));
+      expect(indexOf("c")).toBeLessThan(indexOf("d"));
+    });
+
+    it("produces deterministic ordering for parallel pipelines", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // All are wave 0 with no deps; should be sorted alphabetically
+      const order = result.value.getTopologicalOrder();
+      expect(order).toEqual(["a", "b", "c"]);
+    });
+
+    it("single pipeline returns that pipeline", () => {
+      const result = DAGEngine.load(singleDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getTopologicalOrder()).toEqual(["solo"]);
+    });
+
+    it("respects all dependency constraints in complex DAG", () => {
+      const result = DAGEngine.load(complexDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const order = result.value.getTopologicalOrder();
+      const indexOf = (id: string) => order.indexOf(id);
+
+      // Wave 0 before wave 1
+      expect(indexOf("w0-a")).toBeLessThan(indexOf("w1-a"));
+      expect(indexOf("w0-a")).toBeLessThan(indexOf("w1-b"));
+      expect(indexOf("w0-b")).toBeLessThan(indexOf("w1-b"));
+
+      // Wave 1 before wave 2
+      expect(indexOf("w1-a")).toBeLessThan(indexOf("w2-a"));
+      expect(indexOf("w1-b")).toBeLessThan(indexOf("w2-a"));
+
+      // Wave 2 before wave 3
+      expect(indexOf("w2-a")).toBeLessThan(indexOf("w3-a"));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Wave Calculation
+  // -------------------------------------------------------------------------
+
+  describe("wave calculation", () => {
+    it("assigns wave 0 to independent pipelines", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getWave("a")).toBe(0);
+      expect(result.value.getWave("b")).toBe(0);
+      expect(result.value.getWave("c")).toBe(0);
+      expect(result.value.getWaveCount()).toBe(1);
+    });
+
+    it("assigns sequential waves to linear DAG", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getWave("a")).toBe(0);
+      expect(result.value.getWave("b")).toBe(1);
+      expect(result.value.getWave("c")).toBe(2);
+      expect(result.value.getWaveCount()).toBe(3);
+    });
+
+    it("assigns correct waves for diamond DAG", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getWave("a")).toBe(0);
+      expect(result.value.getWave("b")).toBe(1);
+      expect(result.value.getWave("c")).toBe(1);
+      expect(result.value.getWave("d")).toBe(2);
+      expect(result.value.getWaveCount()).toBe(3);
+    });
+
+    it("assigns correct waves for complex DAG", () => {
+      const result = DAGEngine.load(complexDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getWave("w0-a")).toBe(0);
+      expect(result.value.getWave("w0-b")).toBe(0);
+      expect(result.value.getWave("w1-a")).toBe(1);
+      expect(result.value.getWave("w1-b")).toBe(1);
+      expect(result.value.getWave("w2-a")).toBe(2);
+      expect(result.value.getWave("w3-a")).toBe(3);
+      expect(result.value.getWaveCount()).toBe(4);
+    });
+
+    it("getPipelinesInWave returns correct sets", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getPipelinesInWave(0)).toEqual(["a"]);
+      expect(result.value.getPipelinesInWave(1).sort()).toEqual(["b", "c"]);
+      expect(result.value.getPipelinesInWave(2)).toEqual(["d"]);
+    });
+
+    it("getAllWaves returns all waves as arrays", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const waves = result.value.getAllWaves();
+      expect(waves).toHaveLength(3);
+      expect(waves[0]).toEqual(["a"]);
+      expect(waves[1]).toEqual(["b"]);
+      expect(waves[2]).toEqual(["c"]);
+    });
+
+    it("single pipeline is wave 0", () => {
+      const result = DAGEngine.load(singleDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getWave("solo")).toBe(0);
+      expect(result.value.getWaveCount()).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ready Queue (getReadyPipelines)
+  // -------------------------------------------------------------------------
+
+  describe("getReadyPipelines", () => {
+    it("returns all independent pipelines when nothing is running", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "ready"],
+        ["b", "ready"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready.sort()).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns root nodes for linear DAG", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "ready"],
+        ["b", "ready"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready).toEqual(["a"]);
+    });
+
+    it("unblocks B when A completes in linear DAG", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "complete"],
+        ["b", "ready"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready).toEqual(["b"]);
+    });
+
+    it("diamond: D not ready until both B and C complete", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // B complete, C still running
+      const statuses1 = makeStatuses([
+        ["a", "complete"],
+        ["b", "complete"],
+        ["c", "running"],
+        ["d", "ready"],
+      ]);
+      expect(result.value.getReadyPipelines(statuses1)).toEqual([]);
+
+      // Both B and C complete
+      const statuses2 = makeStatuses([
+        ["a", "complete"],
+        ["b", "complete"],
+        ["c", "complete"],
+        ["d", "ready"],
+      ]);
+      expect(result.value.getReadyPipelines(statuses2)).toEqual(["d"]);
+    });
+
+    it("excludes running pipelines", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "running"],
+        ["b", "ready"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready.sort()).toEqual(["b", "c"]);
+    });
+
+    it("excludes blocked and failed pipelines", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "blocked"],
+        ["b", "failed"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready).toEqual(["c"]);
+    });
+
+    it("excludes completed pipelines", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "complete"],
+        ["b", "complete"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready).toEqual(["c"]);
+    });
+
+    it("returns empty when all are done", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "complete"],
+        ["b", "complete"],
+        ["c", "complete"],
+      ]);
+
+      expect(result.value.getReadyPipelines(statuses)).toEqual([]);
+    });
+
+    it("excludes skipped pipelines", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([
+        ["a", "skipped"],
+        ["b", "ready"],
+        ["c", "ready"],
+      ]);
+
+      const ready = result.value.getReadyPipelines(statuses);
+      expect(ready.sort()).toEqual(["b", "c"]);
+    });
+
+    it("returns empty for empty status map", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const statuses = makeStatuses([]);
+      expect(result.value.getReadyPipelines(statuses)).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dependency Queries
+  // -------------------------------------------------------------------------
+
+  describe("dependency queries", () => {
+    it("getDependencies returns direct deps", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getDependencies("d")).toEqual(["b", "c"]);
+      expect(result.value.getDependencies("a")).toEqual([]);
+    });
+
+    it("getDependents returns direct dependents", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getDependents("a").sort()).toEqual(["b", "c"]);
+      expect(result.value.getDependents("d")).toEqual([]);
+    });
+
+    it("getTransitiveDependents returns all downstream", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getTransitiveDependents("a").sort()).toEqual(["b", "c"]);
+      expect(result.value.getTransitiveDependents("b")).toEqual(["c"]);
+      expect(result.value.getTransitiveDependents("c")).toEqual([]);
+    });
+
+    it("getTransitiveDependents handles diamond correctly", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const transitive = result.value.getTransitiveDependents("a").sort();
+      expect(transitive).toEqual(["b", "c", "d"]);
+    });
+
+    it("getDependencies returns empty for unknown pipeline", () => {
+      const result = DAGEngine.load(singleDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getDependencies("nonexistent")).toEqual([]);
+    });
+
+    it("getPipeline returns entry or undefined", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const entry = result.value.getPipeline("a");
+      expect(entry).toBeDefined();
+      expect(entry?.name).toBe("Pipeline A");
+      expect(result.value.getPipeline("nope")).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Chain Detection (ADR-026 D1)
+  // -------------------------------------------------------------------------
+
+  describe("getChains", () => {
+    it("linear DAG A → B → C produces one chain [A, B, C]", () => {
+      const result = DAGEngine.load(linearDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains("test-dag");
+      expect(chains).toHaveLength(1);
+
+      const chain = chains[0]!;
+      expect(chain.id).toBe("a");
+      expect(chain.dagId).toBe("test-dag");
+      expect(chain.pipelines).toEqual(["a", "b", "c"]);
+      expect(chain.head).toBe("a");
+      expect(chain.tail).toBe("c");
+    });
+
+    it("disconnected DAG [A] [B] [C] produces three single-member chains", () => {
+      const result = DAGEngine.load(parallelDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains("test-dag");
+      expect(chains).toHaveLength(3);
+
+      // Each chain should have exactly one member
+      for (const chain of chains) {
+        expect(chain.pipelines).toHaveLength(1);
+        expect(chain.head).toBe(chain.tail);
+        expect(chain.head).toBe(chain.id);
+        expect(chain.dagId).toBe("test-dag");
+      }
+
+      // All pipelines covered, no duplicates
+      const allPipelines = chains.flatMap((c: Chain) => c.pipelines).sort();
+      expect(allPipelines).toEqual(["a", "b", "c"]);
+    });
+
+    it("single pipeline produces single-member chain", () => {
+      const result = DAGEngine.load(singleDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains("test-dag");
+      expect(chains).toHaveLength(1);
+
+      const chain = chains[0]!;
+      expect(chain.id).toBe("solo");
+      expect(chain.pipelines).toEqual(["solo"]);
+      expect(chain.head).toBe("solo");
+      expect(chain.tail).toBe("solo");
+    });
+
+    it("diamond DAG A → {B, C} → D produces 4 single-member chains", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains("test-dag");
+      expect(chains).toHaveLength(4);
+
+      // Each chain should be single-member (fan-out and fan-in break chains)
+      for (const chain of chains) {
+        expect(chain.pipelines).toHaveLength(1);
+        expect(chain.head).toBe(chain.tail);
+        expect(chain.id).toBe(chain.head);
+        expect(chain.dagId).toBe("test-dag");
+      }
+
+      // No pipeline in more than one chain; union = {a, b, c, d}
+      const allPipelines = chains.flatMap((c: Chain) => c.pipelines).sort();
+      expect(allPipelines).toEqual(["a", "b", "c", "d"]);
+
+      // Verify no duplicates
+      const uniquePipelines = new Set(allPipelines);
+      expect(uniquePipelines.size).toBe(4);
+    });
+
+    it("mixed topology {A → B → C, D → E} produces two parallel chains", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+          { id: "c", stages: STAGES, dependsOn: ["b"] },
+          { id: "d", stages: STAGES },
+          { id: "e", stages: STAGES, dependsOn: ["d"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains("test-dag");
+      expect(chains).toHaveLength(2);
+
+      // Find each chain by head
+      const chainA = chains.find((c: Chain) => c.head === "a")!;
+      const chainD = chains.find((c: Chain) => c.head === "d")!;
+      expect(chainA).toBeDefined();
+      expect(chainD).toBeDefined();
+
+      expect(chainA.pipelines).toEqual(["a", "b", "c"]);
+      expect(chainA.tail).toBe("c");
+
+      expect(chainD.pipelines).toEqual(["d", "e"]);
+      expect(chainD.tail).toBe("e");
+
+      // All pipelines covered
+      const allPipelines = chains.flatMap((c: Chain) => c.pipelines).sort();
+      expect(allPipelines).toEqual(["a", "b", "c", "d", "e"]);
+    });
+
+    it("convergence {A → B, C → B} produces 3 single-member chains", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "c", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a", "c"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains("test-dag");
+      expect(chains).toHaveLength(3);
+
+      // Convergence breaks chains: B has in-degree 2, so no chain extends to B
+      // A has out-degree 1, but its dependent B has in-degree 2 — breaks chain
+      for (const chain of chains) {
+        expect(chain.pipelines).toHaveLength(1);
+        expect(chain.head).toBe(chain.tail);
+      }
+
+      const allPipelines = chains.flatMap((c: Chain) => c.pipelines).sort();
+      expect(allPipelines).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // chainMode and id validation (ADR-026 D6)
+  // -------------------------------------------------------------------------
+
+  describe("chainMode and id validation", () => {
+    it("loads DAG with id + chainMode: 'commit' and getChains() returns multi-member chains", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+          { id: "c", stages: STAGES, dependsOn: ["b"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const def = result.value.getDefinition();
+      expect(def.id).toBe("my-dag");
+      expect(def.chainMode).toBe("commit");
+
+      // getChains uses the DAG id when no explicit dagId is passed
+      const chains = result.value.getChains();
+      expect(chains).toHaveLength(1);
+      expect(chains[0]!.dagId).toBe("my-dag");
+      expect(chains[0]!.pipelines).toEqual(["a", "b", "c"]);
+    });
+
+    it("loads DAG with chainMode: 'pr' and getChains() still works", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "pr",
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const def = result.value.getDefinition();
+      expect(def.chainMode).toBe("pr");
+
+      // getChains() still returns chain structure (engine decides behavior based on chainMode)
+      const chains = result.value.getChains();
+      expect(chains).toHaveLength(1);
+      expect(chains[0]!.pipelines).toEqual(["a", "b"]);
+    });
+
+    it("rejects DAG with chainMode: 'commit' but no id", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        chainMode: "commit",
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+        ],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+        expect(result.error.message).toContain("id is required");
+        expect(result.error.message).toContain("commit");
+      }
+    });
+
+    it("defaults dagId to empty string when DAG has no id", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const chains = result.value.getChains();
+      expect(chains[0]!.dagId).toBe("");
+    });
+
+    it("accepts chainMode: 'pr' without id", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        chainMode: "pr",
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("accepts DAG without chainMode (backwards compatible)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // conflictStrategy validation (ADR-026 D5, Phase 3)
+  // -------------------------------------------------------------------------
+
+  describe("conflictStrategy validation", () => {
+    it("accepts DAG with conflictStrategy: 'manual'", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: "manual",
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getDefinition().conflictStrategy).toBe("manual");
+    });
+
+    it("accepts DAG with conflictStrategy: 'auto-rerun'", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: "auto-rerun",
+        pipelines: [
+          { id: "a", stages: STAGES },
+          { id: "b", stages: STAGES, dependsOn: ["a"] },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getDefinition().conflictStrategy).toBe("auto-rerun");
+    });
+
+    it("rejects DAG with invalid conflictStrategy", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: "invalid",
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      } as unknown as Parameters<typeof DAGEngine.load>[0]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.error.code).toBe("DAG_INVALID");
+      expect(result.error.message).toContain("conflictStrategy");
+      expect(result.error.message).toContain("invalid");
+      expect(result.error.component).toBe("orchestrator/types");
+      expect(result.error.recovery).toContain("manual");
+      expect(result.error.recovery).toContain("auto-rerun");
+    });
+
+    it("rejects DAG with conflictStrategy: null", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: null,
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      } as unknown as Parameters<typeof DAGEngine.load>[0]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.error.code).toBe("DAG_INVALID");
+    });
+
+    it('rejects DAG with conflictStrategy: ""', () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: "",
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      } as unknown as Parameters<typeof DAGEngine.load>[0]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.error.code).toBe("DAG_INVALID");
+    });
+
+    it("rejects DAG with conflictStrategy: 123", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: 123,
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      } as unknown as Parameters<typeof DAGEngine.load>[0]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.error.code).toBe("DAG_INVALID");
+    });
+
+    it("rejects DAG with conflictStrategy: true", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        conflictStrategy: true,
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      } as unknown as Parameters<typeof DAGEngine.load>[0]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.error.code).toBe("DAG_INVALID");
+    });
+
+    it("accepts DAG without conflictStrategy (backwards compatible)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        id: "my-dag",
+        chainMode: "commit",
+        pipelines: [
+          { id: "a", stages: STAGES },
+        ],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getDefinition().conflictStrategy).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Definition Access
+  // -------------------------------------------------------------------------
+
+  describe("definition access", () => {
+    it("getDefinition returns the original definition", () => {
+      const dag = linearDAG();
+      const result = DAGEngine.load(dag);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const def = result.value.getDefinition();
+      expect(def.version).toBe(1);
+      expect(def.pipelines).toHaveLength(3);
+    });
+
+    it("getPipelines returns all entries", () => {
+      const result = DAGEngine.load(diamondDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.getPipelines()).toHaveLength(4);
+    });
+
+    it("size reflects pipeline count", () => {
+      const result = DAGEngine.load(complexDAG());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.size).toBe(6);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // stageTimeoutMinutes validation
+  // -------------------------------------------------------------------------
+
+  describe("stageTimeoutMinutes validation", () => {
+    it("accepts valid positive integer", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "my-pipeline", stageTimeoutMinutes: 90 }],
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("accepts absence (no stageTimeoutMinutes field)", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "my-pipeline" }],
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects zero", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "my-pipeline", stageTimeoutMinutes: 0 }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+        expect(result.error.message).toContain("positive integer");
+      }
+    });
+
+    it("rejects negative value", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "my-pipeline", stageTimeoutMinutes: -10 }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+      }
+    });
+
+    it("rejects float", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        pipelines: [{ id: "my-pipeline", stageTimeoutMinutes: 1.5 }],
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DAG_INVALID");
+      }
+    });
+
+    it("rejects string value", () => {
+      const result = DAGEngine.load({
+        version: 1,
+        // @ts-expect-error testing runtime validation
+        pipelines: [{ id: "my-pipeline", stageTimeoutMinutes: "90" }],
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/harvest/crucible/dag/dag.ts
+++ b/harvest/crucible/dag/dag.ts
@@ -1,0 +1,563 @@
+/**
+ * DAG Engine (ADR-021 Decision 1, 10)
+ *
+ * Loads, validates, and processes Directed Acyclic Graph definitions for
+ * multi-pipeline orchestration. Provides:
+ *
+ * - Cycle detection via DFS (white/gray/black coloring)
+ * - Topological sort via Kahn's algorithm
+ * - Wave calculation (groups pipelines by execution wave)
+ * - Ready-queue resolution (pipelines whose deps are all satisfied)
+ *
+ * Pure computation -- no I/O. DAG JSON is passed in as a parsed object.
+ *
+ * @module orchestrator/dag
+ */
+
+import type {
+  Chain,
+  DAGDefinition,
+  DAGPipelineEntry,
+  OrchestratorError,
+  PipelineStatus,
+  Result,
+} from "./types.js";
+import { validateDAGDefinition } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Adjacency representation for internal graph operations. */
+interface AdjacencyGraph {
+  /** Map from pipeline ID to set of IDs it depends on (incoming edges). */
+  inEdges: Map<string, Set<string>>;
+  /** Map from pipeline ID to set of IDs that depend on it (outgoing edges). */
+  outEdges: Map<string, Set<string>>;
+  /** All pipeline IDs in the graph. */
+  nodes: Set<string>;
+}
+
+/** DFS node coloring for cycle detection. */
+type NodeColor = "white" | "gray" | "black";
+
+// ---------------------------------------------------------------------------
+// DAGEngine
+// ---------------------------------------------------------------------------
+
+export class DAGEngine {
+  private readonly definition: DAGDefinition;
+  private readonly graph: AdjacencyGraph;
+  private readonly pipelineMap: Map<string, DAGPipelineEntry>;
+  private readonly sortedOrder: string[];
+  private readonly waves: Map<string, number>;
+
+  private constructor(
+    definition: DAGDefinition,
+    graph: AdjacencyGraph,
+    pipelineMap: Map<string, DAGPipelineEntry>,
+    sortedOrder: string[],
+    waves: Map<string, number>,
+  ) {
+    this.definition = definition;
+    this.graph = graph;
+    this.pipelineMap = pipelineMap;
+    this.sortedOrder = sortedOrder;
+    this.waves = waves;
+  }
+
+  /**
+   * Load and validate a DAG definition, then build the engine.
+   *
+   * Performs full validation: schema, cycle detection, topological sort,
+   * and wave calculation. Returns a ready-to-use DAGEngine or an error.
+   */
+  static load(input: unknown): Result<DAGEngine, OrchestratorError> {
+    // 1. Schema validation (delegates to types.ts)
+    const validated = validateDAGDefinition(input);
+    if (!validated.ok) {
+      return validated;
+    }
+    const definition = validated.value;
+
+    // 2. Build adjacency graph
+    const pipelineMap = new Map<string, DAGPipelineEntry>();
+    for (const entry of definition.pipelines) {
+      pipelineMap.set(entry.id, entry);
+    }
+
+    const graph = buildAdjacencyGraph(definition.pipelines);
+
+    // 3. Cycle detection
+    const cycleResult = detectCycle(graph);
+    if (cycleResult !== null) {
+      return {
+        ok: false,
+        error: {
+          code: "DAG_CYCLE_DETECTED",
+          message: `Cycle detected: ${cycleResult.join(" -> ")}`,
+          component: "orchestrator/dag",
+          recovery: "Remove circular dependencies from the DAG definition",
+        },
+      };
+    }
+
+    // 4. Topological sort
+    const sortResult = topologicalSort(graph);
+    if (!sortResult.ok) {
+      return sortResult;
+    }
+
+    // 5. Wave calculation
+    const waves = calculateWaves(graph);
+
+    return {
+      ok: true,
+      value: new DAGEngine(definition, graph, pipelineMap, sortResult.value, waves),
+    };
+  }
+
+  /** The validated DAG definition. */
+  getDefinition(): DAGDefinition {
+    return this.definition;
+  }
+
+  /** All pipeline entries in the DAG. */
+  getPipelines(): readonly DAGPipelineEntry[] {
+    return this.definition.pipelines;
+  }
+
+  /** Get a pipeline entry by ID. */
+  getPipeline(id: string): DAGPipelineEntry | undefined {
+    return this.pipelineMap.get(id);
+  }
+
+  /** All pipeline IDs in topological order. */
+  getTopologicalOrder(): readonly string[] {
+    return this.sortedOrder;
+  }
+
+  /** Get the wave number for a pipeline. */
+  getWave(pipelineId: string): number | undefined {
+    return this.waves.get(pipelineId);
+  }
+
+  /** Total number of execution waves. */
+  getWaveCount(): number {
+    if (this.waves.size === 0) return 0;
+    let max = 0;
+    for (const wave of this.waves.values()) {
+      if (wave > max) max = wave;
+    }
+    return max + 1;
+  }
+
+  /** Get all pipeline IDs in a specific wave. */
+  getPipelinesInWave(wave: number): string[] {
+    const result: string[] = [];
+    for (const [id, w] of this.waves) {
+      if (w === wave) result.push(id);
+    }
+    return result;
+  }
+
+  /** Get all waves as an array of arrays (wave index -> pipeline IDs). */
+  getAllWaves(): string[][] {
+    const waveCount = this.getWaveCount();
+    const result: string[][] = [];
+    for (let i = 0; i < waveCount; i++) {
+      result.push(this.getPipelinesInWave(i));
+    }
+    return result;
+  }
+
+  /** Get direct dependencies of a pipeline. */
+  getDependencies(pipelineId: string): readonly string[] {
+    const entry = this.pipelineMap.get(pipelineId);
+    return entry?.dependsOn ?? [];
+  }
+
+  /** Get direct dependents of a pipeline (pipelines that depend on it). */
+  getDependents(pipelineId: string): string[] {
+    const out = this.graph.outEdges.get(pipelineId);
+    return out ? [...out] : [];
+  }
+
+  /**
+   * Identify linear chains in the DAG (ADR-026 D1).
+   *
+   * A chain is a maximal sequence of pipeline nodes where each node
+   * (except the head) has exactly one predecessor with exactly one successor.
+   * Fan-out and convergence points break chains.
+   *
+   * Every pipeline belongs to exactly one chain. Single-pipeline chains
+   * are valid (pipelines at fan-out/convergence points, or isolated nodes).
+   *
+   * @param dagId - DAG identifier for the Chain.dagId field. Falls back to
+   *   DAGDefinition.id or empty string if neither is set.
+   * @returns Deterministic Chain[] — same DAG always produces same chains.
+   */
+  getChains(dagId?: string): Chain[] {
+    const effectiveDagId = dagId ?? this.definition.id ?? "";
+    const assigned = new Set<string>();
+    const chains: Chain[] = [];
+
+    // Traverse in topological order for determinism
+    for (const nodeId of this.sortedOrder) {
+      if (assigned.has(nodeId)) continue;
+
+      // Start a new chain with this node as head
+      const members: string[] = [nodeId];
+      assigned.add(nodeId);
+
+      // Extend forward: follow the single outgoing edge if conditions met.
+      // Per-pipeline chainMode: "pr" overrides break the chain — a PR-mode
+      // pipeline cannot extend or be extended by a commit chain (ADR-026 D6).
+      let current = nodeId;
+      const headEntry = this.pipelineMap.get(nodeId);
+      const headIsPr = headEntry?.chainMode === "pr";
+
+      // If the head itself is PR-mode, don't try to extend at all
+      if (!headIsPr) {
+        while (true) {
+          const outEdges = this.graph.outEdges.get(current);
+          // Current node must have exactly 1 dependent
+          if (!outEdges || outEdges.size !== 1) break;
+
+          const next = [...outEdges][0]!;
+          // Next node must have exactly 1 dependency
+          const inEdges = this.graph.inEdges.get(next);
+          if (!inEdges || inEdges.size !== 1) break;
+
+          // Next must not already be assigned (safety check)
+          if (assigned.has(next)) break;
+
+          // Per-pipeline chainMode: "pr" breaks the chain
+          const nextEntry = this.pipelineMap.get(next);
+          if (nextEntry?.chainMode === "pr") break;
+
+          members.push(next);
+          assigned.add(next);
+          current = next;
+        }
+      }
+
+      chains.push({
+        id: members[0]!,
+        dagId: effectiveDagId,
+        pipelines: members,
+        head: members[0]!,
+        tail: members[members.length - 1]!,
+      });
+    }
+
+    return chains;
+  }
+
+  /**
+   * Get the chain that contains a specific pipeline.
+   *
+   * Returns undefined if the pipeline is not in the DAG.
+   */
+  getChainForPipeline(pipelineId: string, dagId?: string): Chain | undefined {
+    const chains = this.getChains(dagId);
+    return chains.find((c) => c.pipelines.includes(pipelineId));
+  }
+
+  /**
+   * Get all transitive dependents of a pipeline (direct + indirect).
+   *
+   * Uses BFS from the given pipeline following outgoing edges.
+   */
+  getTransitiveDependents(pipelineId: string): string[] {
+    const visited = new Set<string>();
+    const queue = [pipelineId];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const dependents = this.graph.outEdges.get(current);
+      if (!dependents) continue;
+
+      for (const dep of dependents) {
+        if (!visited.has(dep)) {
+          visited.add(dep);
+          queue.push(dep);
+        }
+      }
+    }
+
+    return [...visited];
+  }
+
+  /**
+   * Get pipelines ready to execute.
+   *
+   * A pipeline is "ready" when:
+   * - Its status is "ready"
+   * - All its dependencies are in the `completed` set
+   * - It is not in the `running`, `blocked`, `failed`, or `skipped` sets
+   *
+   * @param statuses - Map of pipeline ID to current status
+   * @returns Array of pipeline IDs ready to start
+   */
+  getReadyPipelines(
+    statuses: ReadonlyMap<string, PipelineStatus>,
+  ): string[] {
+    const ready: string[] = [];
+
+    for (const id of this.graph.nodes) {
+      const status = statuses.get(id);
+      if (status !== "ready") continue;
+
+      const entry = this.pipelineMap.get(id);
+      const deps = entry?.dependsOn ?? [];
+      const allDepsComplete = deps.every(
+        (dep) => statuses.get(dep) === "complete",
+      );
+
+      if (allDepsComplete) {
+        ready.push(id);
+      }
+    }
+
+    return ready;
+  }
+
+  /** Total number of pipelines in the DAG. */
+  get size(): number {
+    return this.graph.nodes.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Adjacency Graph Construction
+// ---------------------------------------------------------------------------
+
+function buildAdjacencyGraph(pipelines: DAGPipelineEntry[]): AdjacencyGraph {
+  const nodes = new Set<string>();
+  const inEdges = new Map<string, Set<string>>();
+  const outEdges = new Map<string, Set<string>>();
+
+  for (const p of pipelines) {
+    nodes.add(p.id);
+    if (!inEdges.has(p.id)) inEdges.set(p.id, new Set());
+    if (!outEdges.has(p.id)) outEdges.set(p.id, new Set());
+  }
+
+  for (const p of pipelines) {
+    for (const dep of p.dependsOn ?? []) {
+      inEdges.get(p.id)!.add(dep);
+      outEdges.get(dep)!.add(p.id);
+    }
+  }
+
+  return { nodes, inEdges, outEdges };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Cycle Detection (DFS white/gray/black)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect cycles using DFS with three-color marking.
+ *
+ * - White: unvisited
+ * - Gray: currently in the DFS stack (being explored)
+ * - Black: fully explored
+ *
+ * If we encounter a gray node during DFS, a cycle exists.
+ *
+ * @returns The cycle path (array of IDs) if a cycle exists, null otherwise.
+ */
+function detectCycle(graph: AdjacencyGraph): string[] | null {
+  const color = new Map<string, NodeColor>();
+  const parent = new Map<string, string | null>();
+
+  for (const node of graph.nodes) {
+    color.set(node, "white");
+  }
+
+  for (const node of graph.nodes) {
+    if (color.get(node) === "white") {
+      const cycle = dfsVisit(node, graph, color, parent);
+      if (cycle !== null) return cycle;
+    }
+  }
+
+  return null;
+}
+
+function dfsVisit(
+  node: string,
+  graph: AdjacencyGraph,
+  color: Map<string, NodeColor>,
+  parent: Map<string, string | null>,
+): string[] | null {
+  color.set(node, "gray");
+
+  const neighbors = graph.outEdges.get(node);
+  if (neighbors) {
+    for (const neighbor of neighbors) {
+      if (color.get(neighbor) === "gray") {
+        // Found a cycle -- reconstruct the path
+        return reconstructCycle(node, neighbor, parent);
+      }
+
+      if (color.get(neighbor) === "white") {
+        parent.set(neighbor, node);
+        const cycle = dfsVisit(neighbor, graph, color, parent);
+        if (cycle !== null) return cycle;
+      }
+    }
+  }
+
+  color.set(node, "black");
+  return null;
+}
+
+/**
+ * Reconstruct cycle path from DFS parent chain.
+ *
+ * We found an edge from `from` to `to` where `to` is gray (in the current
+ * DFS path). Walk back from `from` via `parent` until we reach `to`.
+ */
+function reconstructCycle(
+  from: string,
+  to: string,
+  parent: Map<string, string | null>,
+): string[] {
+  const path: string[] = [to, from];
+  let current = from;
+
+  while (current !== to) {
+    const p = parent.get(current);
+    if (p === null || p === undefined) break;
+    path.push(p);
+    current = p;
+  }
+
+  path.reverse();
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Topological Sort (Kahn's Algorithm)
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a topological ordering using Kahn's algorithm.
+ *
+ * Repeatedly removes nodes with zero in-degree. If all nodes are removed,
+ * the result is a valid topological order. If not, a cycle exists (should
+ * already be caught by detectCycle, but this is a safety net).
+ */
+function topologicalSort(
+  graph: AdjacencyGraph,
+): Result<string[], OrchestratorError> {
+  // Working copy of in-degree counts
+  const inDegree = new Map<string, number>();
+  for (const node of graph.nodes) {
+    inDegree.set(node, graph.inEdges.get(node)?.size ?? 0);
+  }
+
+  // Seed queue with zero in-degree nodes
+  const queue: string[] = [];
+  for (const [node, degree] of inDegree) {
+    if (degree === 0) queue.push(node);
+  }
+
+  // Sort for deterministic ordering among peers
+  queue.sort();
+
+  const sorted: string[] = [];
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    sorted.push(node);
+
+    const dependents = graph.outEdges.get(node);
+    if (dependents) {
+      // Collect newly freed nodes, then sort for determinism
+      const newlyFree: string[] = [];
+      for (const dep of dependents) {
+        const newDegree = (inDegree.get(dep) ?? 1) - 1;
+        inDegree.set(dep, newDegree);
+        if (newDegree === 0) {
+          newlyFree.push(dep);
+        }
+      }
+      newlyFree.sort();
+      queue.push(...newlyFree);
+    }
+  }
+
+  if (sorted.length !== graph.nodes.size) {
+    return {
+      ok: false,
+      error: {
+        code: "DAG_CYCLE_DETECTED",
+        message: `Topological sort failed: ${graph.nodes.size - sorted.length} nodes remain (cycle detected)`,
+        component: "orchestrator/dag",
+        recovery: "Remove circular dependencies from the DAG definition",
+      },
+    };
+  }
+
+  return { ok: true, value: sorted };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Wave Calculation
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate execution waves.
+ *
+ * Wave 0: pipelines with no dependencies.
+ * Wave N: pipelines whose max dependency wave is N-1.
+ *
+ * This is the longest-path distance from any root node.
+ */
+function calculateWaves(graph: AdjacencyGraph): Map<string, number> {
+  const waves = new Map<string, number>();
+
+  // Working copy of in-degrees
+  const inDegree = new Map<string, number>();
+  for (const node of graph.nodes) {
+    inDegree.set(node, graph.inEdges.get(node)?.size ?? 0);
+  }
+
+  // Seed with wave 0 (no dependencies)
+  const queue: string[] = [];
+  for (const [node, degree] of inDegree) {
+    if (degree === 0) {
+      waves.set(node, 0);
+      queue.push(node);
+    }
+  }
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    const nodeWave = waves.get(node) ?? 0;
+    const dependents = graph.outEdges.get(node);
+
+    if (dependents) {
+      for (const dep of dependents) {
+        // Wave = max(current wave assignment, parent wave + 1)
+        const currentWave = waves.get(dep) ?? 0;
+        const candidateWave = nodeWave + 1;
+        if (candidateWave > currentWave) {
+          waves.set(dep, candidateWave);
+        }
+
+        const newDegree = (inDegree.get(dep) ?? 1) - 1;
+        inDegree.set(dep, newDegree);
+        if (newDegree === 0) {
+          queue.push(dep);
+        }
+      }
+    }
+  }
+
+  return waves;
+}

--- a/harvest/crucible/resilience/circuit-breaker.test.ts
+++ b/harvest/crucible/resilience/circuit-breaker.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Tests for Pipeline Circuit Breaker (ADR-036 Decision 5)
+ *
+ * Tests the pure state machine for the 3-tier persistence fallback:
+ * - State transitions: closed -> open -> half_open -> closed
+ * - Exponential backoff with 2x multiplier and cap
+ * - checkCircuit auto-transition from open -> half_open
+ * - retryAfterMs calculation
+ *
+ * Zero infrastructure dependencies -- all functions are pure.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createCircuitBreakerState,
+  getDefaultCircuitBreakerConfig,
+  checkCircuit,
+  recordSuccess,
+  recordFailure,
+} from "../../src/state/circuit-breaker.js";
+import type {
+  CircuitBreakerState,
+  CircuitBreakerConfig,
+} from "../../src/state/circuit-breaker.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_TIME = new Date("2026-02-09T12:00:00.000Z");
+
+/** Create a Date offset from a base time by the given milliseconds. */
+function offsetMs(base: Date, ms: number): Date {
+  return new Date(base.getTime() + ms);
+}
+
+/** Shorthand for config with overrides. */
+function cfg(
+  overrides?: Partial<CircuitBreakerConfig>,
+): CircuitBreakerConfig {
+  return { ...getDefaultCircuitBreakerConfig(), ...overrides };
+}
+
+/** Trip the circuit open by recording enough failures. */
+function tripOpen(
+  state: CircuitBreakerState,
+  config: CircuitBreakerConfig = getDefaultCircuitBreakerConfig(),
+  now: Date = BASE_TIME,
+): CircuitBreakerState {
+  let current = state;
+  for (let i = 0; i < config.failureThreshold; i++) {
+    current = recordFailure(current, config, now);
+  }
+  return current;
+}
+
+// ============================================================
+// createCircuitBreakerState
+// ============================================================
+
+describe("createCircuitBreakerState", () => {
+  it("should create a closed state with zero counters", () => {
+    const state = createCircuitBreakerState();
+    expect(state.state).toBe("closed");
+    expect(state.failureCount).toBe(0);
+    expect(state.totalOpens).toBe(0);
+    expect(state.lastOpenedAt).toBeNull();
+    expect(state.lastFailureAt).toBeNull();
+    expect(state.lastSuccessAt).toBeNull();
+  });
+
+  it("should initialize currentOpenDurationMs to default", () => {
+    const state = createCircuitBreakerState();
+    expect(state.currentOpenDurationMs).toBe(60_000);
+  });
+});
+
+// ============================================================
+// getDefaultCircuitBreakerConfig
+// ============================================================
+
+describe("getDefaultCircuitBreakerConfig", () => {
+  it("should return expected calibration defaults", () => {
+    const config = getDefaultCircuitBreakerConfig();
+    expect(config.failureThreshold).toBe(3);
+    expect(config.openDurationMs).toBe(60_000);
+    expect(config.backoffMultiplier).toBe(2);
+    expect(config.maxOpenDurationMs).toBe(300_000);
+  });
+});
+
+// ============================================================
+// recordFailure
+// ============================================================
+
+describe("recordFailure", () => {
+  it("should increment failure count without transition below threshold", () => {
+    const state = createCircuitBreakerState();
+    const config = cfg({ failureThreshold: 3 });
+
+    const updated = recordFailure(state, config, BASE_TIME);
+
+    expect(updated.state).toBe("closed");
+    expect(updated.failureCount).toBe(1);
+    expect(updated.lastFailureAt).toBe(BASE_TIME.toISOString());
+  });
+
+  it("should stay closed after threshold minus one failures", () => {
+    const config = cfg({ failureThreshold: 3 });
+    let state = createCircuitBreakerState();
+
+    state = recordFailure(state, config, BASE_TIME);
+    state = recordFailure(state, config, BASE_TIME);
+
+    expect(state.state).toBe("closed");
+    expect(state.failureCount).toBe(2);
+  });
+
+  it("should transition closed -> open at failure threshold", () => {
+    const config = cfg({ failureThreshold: 3 });
+    const state = tripOpen(createCircuitBreakerState(), config);
+
+    expect(state.state).toBe("open");
+    expect(state.failureCount).toBe(3);
+    expect(state.totalOpens).toBe(1);
+    expect(state.lastOpenedAt).toBe(BASE_TIME.toISOString());
+  });
+
+  it("should set currentOpenDurationMs to openDurationMs on first trip", () => {
+    const config = cfg({ failureThreshold: 1, openDurationMs: 45_000 });
+    const state = recordFailure(createCircuitBreakerState(), config, BASE_TIME);
+
+    expect(state.currentOpenDurationMs).toBe(45_000);
+  });
+
+  it("should transition half_open -> open on any failure", () => {
+    const config = cfg();
+    const halfOpen: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "half_open",
+      currentOpenDurationMs: 60_000,
+      totalOpens: 1,
+    };
+
+    const updated = recordFailure(halfOpen, config, BASE_TIME);
+
+    expect(updated.state).toBe("open");
+    expect(updated.totalOpens).toBe(2);
+    expect(updated.lastOpenedAt).toBe(BASE_TIME.toISOString());
+  });
+
+  it("should increase backoff when re-opening from half_open", () => {
+    const config = cfg({ backoffMultiplier: 2, maxOpenDurationMs: 300_000 });
+    const halfOpen: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "half_open",
+      currentOpenDurationMs: 60_000,
+    };
+
+    const updated = recordFailure(halfOpen, config, BASE_TIME);
+
+    expect(updated.currentOpenDurationMs).toBe(120_000); // 60_000 * 2
+  });
+
+  it("should cap backoff at maxOpenDurationMs", () => {
+    const config = cfg({ backoffMultiplier: 2, maxOpenDurationMs: 100_000 });
+    const halfOpen: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "half_open",
+      currentOpenDurationMs: 80_000,
+    };
+
+    const updated = recordFailure(halfOpen, config, BASE_TIME);
+
+    // 80_000 * 2 = 160_000, capped at 100_000
+    expect(updated.currentOpenDurationMs).toBe(100_000);
+  });
+
+  it("should increment failure count in open state without changing state", () => {
+    const config = cfg();
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      failureCount: 5,
+      lastOpenedAt: BASE_TIME.toISOString(),
+    };
+
+    const updated = recordFailure(openState, config, BASE_TIME);
+
+    expect(updated.state).toBe("open");
+    expect(updated.failureCount).toBe(6);
+  });
+});
+
+// ============================================================
+// recordSuccess
+// ============================================================
+
+describe("recordSuccess", () => {
+  it("should reset failure count in closed state", () => {
+    const state: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      failureCount: 2,
+    };
+
+    const updated = recordSuccess(state, BASE_TIME);
+
+    expect(updated.state).toBe("closed");
+    expect(updated.failureCount).toBe(0);
+    expect(updated.lastSuccessAt).toBe(BASE_TIME.toISOString());
+  });
+
+  it("should transition half_open -> closed on success", () => {
+    const halfOpen: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "half_open",
+      failureCount: 3,
+      currentOpenDurationMs: 120_000,
+    };
+
+    const updated = recordSuccess(halfOpen, BASE_TIME);
+
+    expect(updated.state).toBe("closed");
+    expect(updated.failureCount).toBe(0);
+    expect(updated.lastSuccessAt).toBe(BASE_TIME.toISOString());
+  });
+
+  it("should reset backoff to default on successful recovery", () => {
+    const halfOpen: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "half_open",
+      currentOpenDurationMs: 240_000, // elevated from prior trips
+    };
+
+    const updated = recordSuccess(halfOpen, BASE_TIME);
+
+    expect(updated.currentOpenDurationMs).toBe(60_000); // reset to default
+  });
+
+  it("should handle success in open state gracefully", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+    };
+
+    const updated = recordSuccess(openState, BASE_TIME);
+
+    expect(updated.state).toBe("open"); // no transition
+    expect(updated.lastSuccessAt).toBe(BASE_TIME.toISOString());
+  });
+});
+
+// ============================================================
+// checkCircuit
+// ============================================================
+
+describe("checkCircuit", () => {
+  it("should allow calls when closed", () => {
+    const state = createCircuitBreakerState();
+
+    const { result, updatedState } = checkCircuit(state, BASE_TIME);
+
+    expect(result.allowed).toBe(true);
+    expect(result.state).toBe("closed");
+    expect(updatedState).toBe(state); // no mutation
+  });
+
+  it("should allow calls when half_open", () => {
+    const state: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "half_open",
+    };
+
+    const { result } = checkCircuit(state, BASE_TIME);
+
+    expect(result.allowed).toBe(true);
+    expect(result.state).toBe("half_open");
+  });
+
+  it("should block calls when open and duration not elapsed", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      lastOpenedAt: BASE_TIME.toISOString(),
+      currentOpenDurationMs: 60_000,
+    };
+
+    const now = offsetMs(BASE_TIME, 30_000); // 30s into 60s open period
+    const { result, updatedState } = checkCircuit(openState, now);
+
+    expect(result.allowed).toBe(false);
+    expect(result.state).toBe("open");
+    expect(result.retryAfterMs).toBe(30_000); // 60s - 30s remaining
+    expect(result.reason).toContain("open");
+    expect(updatedState.state).toBe("open"); // no transition yet
+  });
+
+  it("should transition open -> half_open when duration elapsed", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      lastOpenedAt: BASE_TIME.toISOString(),
+      currentOpenDurationMs: 60_000,
+    };
+
+    const now = offsetMs(BASE_TIME, 60_000); // exactly at open duration
+    const { result, updatedState } = checkCircuit(openState, now);
+
+    expect(result.allowed).toBe(true);
+    expect(result.state).toBe("half_open");
+    expect(updatedState.state).toBe("half_open");
+  });
+
+  it("should transition open -> half_open when well past duration", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      lastOpenedAt: BASE_TIME.toISOString(),
+      currentOpenDurationMs: 60_000,
+    };
+
+    const now = offsetMs(BASE_TIME, 120_000); // 2x the duration
+    const { result, updatedState } = checkCircuit(openState, now);
+
+    expect(result.allowed).toBe(true);
+    expect(result.state).toBe("half_open");
+    expect(updatedState.state).toBe("half_open");
+  });
+
+  it("should handle open state with null lastOpenedAt gracefully", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      lastOpenedAt: null, // edge case
+    };
+
+    const { result } = checkCircuit(openState, BASE_TIME);
+
+    expect(result.allowed).toBe(false);
+    expect(result.state).toBe("open");
+    expect(result.reason).toContain("no open timestamp");
+  });
+
+  it("should calculate correct retryAfterMs at various points", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      lastOpenedAt: BASE_TIME.toISOString(),
+      currentOpenDurationMs: 60_000,
+    };
+
+    // At 0s: retry after 60s
+    const { result: r0 } = checkCircuit(openState, BASE_TIME);
+    expect(r0.retryAfterMs).toBe(60_000);
+
+    // At 15s: retry after 45s
+    const { result: r15 } = checkCircuit(openState, offsetMs(BASE_TIME, 15_000));
+    expect(r15.retryAfterMs).toBe(45_000);
+
+    // At 59s: retry after 1s
+    const { result: r59 } = checkCircuit(openState, offsetMs(BASE_TIME, 59_000));
+    expect(r59.retryAfterMs).toBe(1_000);
+  });
+
+  it("should use currentOpenDurationMs (with backoff) not base openDurationMs", () => {
+    const openState: CircuitBreakerState = {
+      ...createCircuitBreakerState(),
+      state: "open",
+      lastOpenedAt: BASE_TIME.toISOString(),
+      currentOpenDurationMs: 120_000, // elevated from backoff
+    };
+
+    // At 60s: base would allow, but backoff requires 120s
+    const now60 = offsetMs(BASE_TIME, 60_000);
+    const { result: r60 } = checkCircuit(openState, now60);
+    expect(r60.allowed).toBe(false);
+    expect(r60.retryAfterMs).toBe(60_000); // 120s - 60s
+
+    // At 120s: backoff elapsed
+    const now120 = offsetMs(BASE_TIME, 120_000);
+    const { result: r120 } = checkCircuit(openState, now120);
+    expect(r120.allowed).toBe(true);
+    expect(r120.state).toBe("half_open");
+  });
+});
+
+// ============================================================
+// Integration: Full Lifecycle
+// ============================================================
+
+describe("Full lifecycle: closed -> open -> half_open -> closed", () => {
+  it("should complete a full trip-and-recovery cycle", () => {
+    const config = cfg({
+      failureThreshold: 3,
+      openDurationMs: 60_000,
+    });
+
+    // 1. Start closed
+    let state = createCircuitBreakerState();
+    expect(state.state).toBe("closed");
+
+    // 2. Three failures -> open
+    state = recordFailure(state, config, BASE_TIME);
+    state = recordFailure(state, config, BASE_TIME);
+    state = recordFailure(state, config, BASE_TIME);
+    expect(state.state).toBe("open");
+    expect(state.totalOpens).toBe(1);
+
+    // 3. Check at 30s: still blocked
+    const { result: r30, updatedState: s30 } = checkCircuit(
+      state, offsetMs(BASE_TIME, 30_000),
+    );
+    expect(r30.allowed).toBe(false);
+    expect(r30.retryAfterMs).toBe(30_000);
+    state = s30;
+
+    // 4. Check at 60s: transitions to half_open
+    const { result: r60, updatedState: s60 } = checkCircuit(
+      state, offsetMs(BASE_TIME, 60_000),
+    );
+    expect(r60.allowed).toBe(true);
+    expect(r60.state).toBe("half_open");
+    state = s60;
+
+    // 5. Success in half_open -> closed
+    state = recordSuccess(state, offsetMs(BASE_TIME, 61_000));
+    expect(state.state).toBe("closed");
+    expect(state.failureCount).toBe(0);
+  });
+
+  it("should escalate backoff on repeated trip cycles", () => {
+    const config = cfg({
+      failureThreshold: 1,
+      openDurationMs: 10_000,
+      backoffMultiplier: 2,
+      maxOpenDurationMs: 100_000,
+    });
+
+    let state = createCircuitBreakerState();
+    let t = BASE_TIME;
+
+    // Trip 1: open duration = 10s
+    state = recordFailure(state, config, t);
+    expect(state.state).toBe("open");
+    expect(state.currentOpenDurationMs).toBe(10_000);
+
+    // Wait and recover
+    t = offsetMs(t, 10_000);
+    const { updatedState: halfOpen1 } = checkCircuit(state, t);
+    state = recordSuccess(halfOpen1, t);
+    expect(state.state).toBe("closed");
+    expect(state.currentOpenDurationMs).toBe(60_000); // reset to default
+
+    // Trip 2: open again, gets base openDurationMs
+    state = recordFailure(state, config, t);
+    expect(state.state).toBe("open");
+    expect(state.currentOpenDurationMs).toBe(10_000);
+
+    // Wait and probe, but fail -> backoff = 20s
+    t = offsetMs(t, 10_000);
+    const { updatedState: halfOpen2 } = checkCircuit(state, t);
+    state = recordFailure(halfOpen2, config, t);
+    expect(state.state).toBe("open");
+    expect(state.currentOpenDurationMs).toBe(20_000); // 10_000 * 2
+
+    // Wait and probe, but fail again -> backoff = 40s
+    t = offsetMs(t, 20_000);
+    const { updatedState: halfOpen3 } = checkCircuit(state, t);
+    state = recordFailure(halfOpen3, config, t);
+    expect(state.state).toBe("open");
+    expect(state.currentOpenDurationMs).toBe(40_000); // 20_000 * 2
+
+    // Wait and probe, but fail again -> backoff = 80s
+    t = offsetMs(t, 40_000);
+    const { updatedState: halfOpen4 } = checkCircuit(state, t);
+    state = recordFailure(halfOpen4, config, t);
+    expect(state.state).toBe("open");
+    expect(state.currentOpenDurationMs).toBe(80_000); // 40_000 * 2
+
+    // Wait and probe, but fail again -> backoff = 100s (capped)
+    t = offsetMs(t, 80_000);
+    const { updatedState: halfOpen5 } = checkCircuit(state, t);
+    state = recordFailure(halfOpen5, config, t);
+    expect(state.state).toBe("open");
+    expect(state.currentOpenDurationMs).toBe(100_000); // capped at max
+  });
+
+  it("should track totalOpens across multiple trip cycles", () => {
+    const config = cfg({ failureThreshold: 1, openDurationMs: 1_000 });
+    let state = createCircuitBreakerState();
+    let t = BASE_TIME;
+
+    // Trip 1
+    state = recordFailure(state, config, t);
+    expect(state.totalOpens).toBe(1);
+
+    // Recover
+    t = offsetMs(t, 1_000);
+    const { updatedState: ho1 } = checkCircuit(state, t);
+    state = recordSuccess(ho1, t);
+
+    // Trip 2
+    state = recordFailure(state, config, t);
+    expect(state.totalOpens).toBe(2);
+
+    // Probe fails -> re-open (counted as trip 3)
+    t = offsetMs(t, 1_000);
+    const { updatedState: ho2 } = checkCircuit(state, t);
+    state = recordFailure(ho2, config, t);
+    expect(state.totalOpens).toBe(3);
+  });
+});
+
+describe("Edge cases", () => {
+  it("should handle success resetting failures before threshold", () => {
+    const config = cfg({ failureThreshold: 3 });
+    let state = createCircuitBreakerState();
+
+    // Fail twice, then succeed
+    state = recordFailure(state, config, BASE_TIME);
+    state = recordFailure(state, config, BASE_TIME);
+    expect(state.failureCount).toBe(2);
+
+    state = recordSuccess(state, BASE_TIME);
+    expect(state.failureCount).toBe(0);
+    expect(state.state).toBe("closed");
+
+    // Need 3 more failures to trip
+    state = recordFailure(state, config, BASE_TIME);
+    state = recordFailure(state, config, BASE_TIME);
+    expect(state.state).toBe("closed");
+
+    state = recordFailure(state, config, BASE_TIME);
+    expect(state.state).toBe("open");
+  });
+
+  it("should handle failure threshold of 1", () => {
+    const config = cfg({ failureThreshold: 1 });
+    const state = recordFailure(createCircuitBreakerState(), config, BASE_TIME);
+
+    expect(state.state).toBe("open");
+    expect(state.failureCount).toBe(1);
+    expect(state.totalOpens).toBe(1);
+  });
+
+  it("should preserve immutability -- original state unchanged", () => {
+    const config = cfg({ failureThreshold: 1 });
+    const original = createCircuitBreakerState();
+
+    const afterFailure = recordFailure(original, config, BASE_TIME);
+
+    // Original should be unchanged
+    expect(original.state).toBe("closed");
+    expect(original.failureCount).toBe(0);
+    expect(original.totalOpens).toBe(0);
+
+    // New state should reflect failure
+    expect(afterFailure.state).toBe("open");
+    expect(afterFailure.failureCount).toBe(1);
+  });
+});

--- a/harvest/crucible/resilience/circuit-breaker.ts
+++ b/harvest/crucible/resilience/circuit-breaker.ts
@@ -1,0 +1,340 @@
+/**
+ * Pipeline Circuit Breaker (ADR-036 Decision 5)
+ *
+ * Pure state machine for the 3-tier persistence fallback chain
+ * (Crystal > WAL > in-memory). This module manages state transitions
+ * only -- the actual persistence tier composition happens at a higher level.
+ *
+ * State machine: CLOSED -> OPEN -> HALF_OPEN -> CLOSED
+ *
+ * This is the persistence fallback chain, distinct from the 4-tier
+ * data-availability degradation in the agents subcommand (ADR-038).
+ *
+ * Defaults are CALIBRATION ITEMS -- adjust after 3 empirical pipeline runs:
+ *   - Failure threshold: 3
+ *   - Open duration: 60s
+ *   - Backoff multiplier: 2x
+ *   - Max open duration: 5 min
+ *
+ * All functions are pure -- no I/O, no side effects. Time is injected
+ * via `now: Date` parameter (same pattern as health-monitor.ts).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Circuit breaker states. */
+export type CircuitState = "closed" | "open" | "half_open";
+
+/** Circuit breaker configuration. */
+export interface CircuitBreakerConfig {
+  /** Number of consecutive failures before opening (default: 3). */
+  failureThreshold: number;
+  /** Time in ms before transitioning from open to half-open (default: 60000). */
+  openDurationMs: number;
+  /** Backoff multiplier for successive open periods (default: 2). */
+  backoffMultiplier: number;
+  /** Maximum open duration in ms (default: 300000 = 5 min). */
+  maxOpenDurationMs: number;
+}
+
+/** Circuit breaker state snapshot. */
+export interface CircuitBreakerState {
+  /** Current state of the circuit. */
+  state: CircuitState;
+  /** Number of consecutive failures in current closed period. */
+  failureCount: number;
+  /** Timestamp when the circuit was last opened (ISO 8601). */
+  lastOpenedAt: string | null;
+  /** Timestamp of the last failure (ISO 8601). */
+  lastFailureAt: string | null;
+  /** Timestamp of the last success (ISO 8601). */
+  lastSuccessAt: string | null;
+  /** Current open duration (increases with backoff). */
+  currentOpenDurationMs: number;
+  /** Total number of times the circuit has opened. */
+  totalOpens: number;
+}
+
+/** Result of checking whether a call should proceed. */
+export interface CircuitCheckResult {
+  /** Whether the call is allowed. */
+  allowed: boolean;
+  /** Current circuit state. */
+  state: CircuitState;
+  /** Reason if not allowed. */
+  reason?: string;
+  /** Time remaining in ms until half-open transition (if open). */
+  retryAfterMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants (CALIBRATION ITEMS)
+// ---------------------------------------------------------------------------
+
+/** Default failure threshold before opening. */
+const DEFAULT_FAILURE_THRESHOLD = 3;
+
+/** Default open duration: 60s. */
+const DEFAULT_OPEN_DURATION_MS = 60_000;
+
+/** Default backoff multiplier: 2x. */
+const DEFAULT_BACKOFF_MULTIPLIER = 2;
+
+/** Default maximum open duration cap: 5 minutes. */
+const DEFAULT_MAX_OPEN_DURATION_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the default circuit breaker configuration.
+ *
+ * All values are CALIBRATION ITEMS (ADR-036 calibration plan):
+ * - failureThreshold: 3 (observe Crystal API reliability; increase if too sensitive)
+ * - openDurationMs: 60s (observe recovery times; increase if premature retries)
+ * - backoffMultiplier: 2x
+ * - maxOpenDurationMs: 5 min
+ */
+export function getDefaultCircuitBreakerConfig(): CircuitBreakerConfig {
+  return {
+    failureThreshold: DEFAULT_FAILURE_THRESHOLD,
+    openDurationMs: DEFAULT_OPEN_DURATION_MS,
+    backoffMultiplier: DEFAULT_BACKOFF_MULTIPLIER,
+    maxOpenDurationMs: DEFAULT_MAX_OPEN_DURATION_MS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create initial circuit breaker state (closed, no failures).
+ */
+export function createCircuitBreakerState(): CircuitBreakerState {
+  return {
+    state: "closed",
+    failureCount: 0,
+    lastOpenedAt: null,
+    lastFailureAt: null,
+    lastSuccessAt: null,
+    currentOpenDurationMs: DEFAULT_OPEN_DURATION_MS,
+    totalOpens: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure State Machine Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a call should be allowed through the circuit.
+ *
+ * - CLOSED: always allowed
+ * - OPEN: blocked until openDuration elapses, then transitions to HALF_OPEN
+ * - HALF_OPEN: allowed (one test call)
+ *
+ * Pure function -- takes state + current time, returns result + updated state.
+ * The open duration is read from `state.currentOpenDurationMs` (which already
+ * accounts for backoff), so no config is needed here.
+ *
+ * @param state - Current circuit breaker state
+ * @param now - Current timestamp (injected for testability)
+ * @returns Check result and (potentially transitioned) updated state
+ */
+export function checkCircuit(
+  state: CircuitBreakerState,
+  now: Date,
+): { result: CircuitCheckResult; updatedState: CircuitBreakerState } {
+  if (state.state === "closed") {
+    return {
+      result: { allowed: true, state: "closed" },
+      updatedState: state,
+    };
+  }
+
+  if (state.state === "half_open") {
+    return {
+      result: { allowed: true, state: "half_open" },
+      updatedState: state,
+    };
+  }
+
+  // state === "open"
+  if (state.lastOpenedAt === null) {
+    // Should not happen, but handle gracefully
+    return {
+      result: {
+        allowed: false,
+        state: "open",
+        reason: "Circuit is open (no open timestamp recorded).",
+      },
+      updatedState: state,
+    };
+  }
+
+  const openedAt = new Date(state.lastOpenedAt);
+  const elapsedMs = now.getTime() - openedAt.getTime();
+  const requiredMs = state.currentOpenDurationMs;
+
+  if (elapsedMs >= requiredMs) {
+    // Enough time has passed -- transition to HALF_OPEN
+    const updatedState: CircuitBreakerState = {
+      ...state,
+      state: "half_open",
+    };
+
+    return {
+      result: { allowed: true, state: "half_open" },
+      updatedState,
+    };
+  }
+
+  // Still in open period -- reject with retry-after
+  const retryAfterMs = requiredMs - elapsedMs;
+  return {
+    result: {
+      allowed: false,
+      state: "open",
+      reason: `Circuit is open. Retry after ${retryAfterMs}ms.`,
+      retryAfterMs,
+    },
+    updatedState: state,
+  };
+}
+
+/**
+ * Record a successful call.
+ *
+ * - CLOSED: reset failure count
+ * - HALF_OPEN: transition to CLOSED (circuit recovered), reset backoff
+ * - OPEN: no-op (should not reach here, but handle gracefully)
+ *
+ * Pure function.
+ *
+ * @param state - Current circuit breaker state
+ * @param now - Current timestamp (injected for testability)
+ * @returns Updated circuit breaker state
+ */
+export function recordSuccess(
+  state: CircuitBreakerState,
+  now: Date,
+): CircuitBreakerState {
+  const nowIso = now.toISOString();
+
+  if (state.state === "half_open") {
+    // Recovery successful -- close the circuit, reset backoff
+    return {
+      ...state,
+      state: "closed",
+      failureCount: 0,
+      lastSuccessAt: nowIso,
+      currentOpenDurationMs: DEFAULT_OPEN_DURATION_MS,
+    };
+  }
+
+  if (state.state === "closed") {
+    // Reset failure count on success
+    return {
+      ...state,
+      failureCount: 0,
+      lastSuccessAt: nowIso,
+    };
+  }
+
+  // OPEN state -- should not happen, but handle gracefully
+  return {
+    ...state,
+    lastSuccessAt: nowIso,
+  };
+}
+
+/**
+ * Record a failed call.
+ *
+ * - CLOSED: increment failure count. If >= threshold, transition to OPEN.
+ * - HALF_OPEN: transition back to OPEN (recovery failed), increase backoff.
+ * - OPEN: increment failure count but do not change state.
+ *
+ * Pure function.
+ *
+ * @param state - Current circuit breaker state
+ * @param cbConfig - Circuit breaker configuration
+ * @param now - Current timestamp (injected for testability)
+ * @returns Updated circuit breaker state
+ */
+export function recordFailure(
+  state: CircuitBreakerState,
+  cbConfig: CircuitBreakerConfig,
+  now: Date,
+): CircuitBreakerState {
+  const nowIso = now.toISOString();
+
+  if (state.state === "half_open") {
+    // Any failure in HALF_OPEN re-opens with increased backoff
+    const newBackoff = computeBackoff(
+      state.currentOpenDurationMs,
+      cbConfig.backoffMultiplier,
+      cbConfig.maxOpenDurationMs,
+    );
+
+    return {
+      ...state,
+      state: "open",
+      failureCount: state.failureCount + 1,
+      lastFailureAt: nowIso,
+      lastOpenedAt: nowIso,
+      currentOpenDurationMs: newBackoff,
+      totalOpens: state.totalOpens + 1,
+    };
+  }
+
+  if (state.state === "closed") {
+    const newFailureCount = state.failureCount + 1;
+
+    if (newFailureCount >= cbConfig.failureThreshold) {
+      // Threshold exceeded -- trip open
+      return {
+        ...state,
+        state: "open",
+        failureCount: newFailureCount,
+        lastFailureAt: nowIso,
+        lastOpenedAt: nowIso,
+        currentOpenDurationMs: cbConfig.openDurationMs,
+        totalOpens: state.totalOpens + 1,
+      };
+    }
+
+    // Below threshold -- stay closed
+    return {
+      ...state,
+      failureCount: newFailureCount,
+      lastFailureAt: nowIso,
+    };
+  }
+
+  // OPEN state -- record failure but don't change state
+  return {
+    ...state,
+    failureCount: state.failureCount + 1,
+    lastFailureAt: nowIso,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the next backoff duration with exponential increase, capped at max.
+ */
+function computeBackoff(
+  currentMs: number,
+  multiplier: number,
+  maxMs: number,
+): number {
+  return Math.min(currentMs * multiplier, maxMs);
+}

--- a/harvest/crucible/wal-atomic/atomic-io.test.ts
+++ b/harvest/crucible/wal-atomic/atomic-io.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for atomic-io.ts.
+ *
+ * Verifies:
+ *   - atomicWrite creates files with correct content
+ *   - atomicWrite is idempotent (overwrites existing files)
+ *   - atomicWrite auto-creates parent directories
+ *   - atomicWrite cleans up .tmp file on write failure
+ *   - atomicAppendLine appends content with newline
+ *   - atomicAppendLine auto-creates parent directories
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { readFile, rm, stat, chmod } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { atomicWrite, atomicAppendLine } from "../../src/utils/atomic-io.js";
+
+function tempDir(): string {
+  return join(tmpdir(), `atomic-io-test-${randomUUID()}`);
+}
+
+describe("atomicWrite", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of dirs) {
+      await rm(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("writes content to a new file", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "test.json");
+
+    await atomicWrite(filePath, '{"ok":true}');
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe('{"ok":true}');
+  });
+
+  it("overwrites existing file content", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "test.txt");
+
+    await atomicWrite(filePath, "first");
+    await atomicWrite(filePath, "second");
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe("second");
+  });
+
+  it("auto-creates parent directories", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "nested", "deep", "file.txt");
+
+    await atomicWrite(filePath, "hello");
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe("hello");
+  });
+
+  it("does not leave .tmp file on success", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "file.txt");
+
+    await atomicWrite(filePath, "content");
+    // Verify no .tmp files remain
+    const { readdir } = await import("node:fs/promises");
+    const files = await readdir(dir);
+    expect(files.filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+
+  it("writes empty string", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "empty.txt");
+
+    await atomicWrite(filePath, "");
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe("");
+  });
+
+  it("preserves multi-line content exactly", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "multiline.txt");
+    const expected = "line1\nline2\nline3";
+
+    await atomicWrite(filePath, expected);
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe(expected);
+  });
+});
+
+describe("atomicWrite error cleanup", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of dirs) {
+      // Restore write permissions before cleanup
+      await chmod(d, 0o755).catch(() => undefined);
+      await rm(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("cleans up temp file on write error and re-throws", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    // Create the directory, then make it read-only so writeFile fails
+    const { mkdir: mkdirFs, chmod: chmodFs } = await import("node:fs/promises");
+    await mkdirFs(dir, { recursive: true });
+    await chmodFs(dir, 0o444); // read-only — writeFile will fail with EACCES
+
+    const filePath = join(dir, "write-fail.txt");
+
+    // atomicWrite should throw (cannot write temp file)
+    await expect(atomicWrite(filePath, "content")).rejects.toThrow();
+
+    // Restore write permissions to check for leftover temp files
+    await chmodFs(dir, 0o755);
+    const { readdir } = await import("node:fs/promises");
+    const files = await readdir(dir);
+    // No .tmp files should remain — the cleanup path removed them (or write
+    // never created them because it failed immediately)
+    expect(files.filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+
+  it("cleans up temp file on rename error and re-throws", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    // Create the directory
+    const { mkdir: mkdirFs } = await import("node:fs/promises");
+    await mkdirFs(dir, { recursive: true });
+
+    // Write to a temp file in dir, then try to rename to a target in a
+    // non-writable subdirectory — rename will fail with ENOENT/EACCES.
+    // Strategy: filePath targets a nested dir that doesn't exist, but the
+    // temp file is written in the parent (same dir as filePath).
+    // atomicWrite calls mkdir(dir) which succeeds, writes the tmp file,
+    // then tries to rename. We create the tmp file in dir successfully,
+    // but make the target a directory (not a file) so rename fails.
+    const targetDir = join(dir, "subdir");
+    await mkdirFs(targetDir);
+    // Target path IS an existing directory — rename(file, dir) fails on POSIX
+    const filePath = targetDir;
+
+    await expect(atomicWrite(filePath, "content")).rejects.toThrow();
+
+    // No .tmp files should remain in dir after cleanup
+    const { readdir } = await import("node:fs/promises");
+    const files = await readdir(dir);
+    expect(files.filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+});
+
+describe("atomicAppendLine", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const d of dirs) {
+      await rm(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("creates file and appends a line with newline", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "log.jsonl");
+
+    await atomicAppendLine(filePath, '{"event":"start"}');
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe('{"event":"start"}\n');
+  });
+
+  it("appends multiple lines in order", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "log.jsonl");
+
+    await atomicAppendLine(filePath, "line1");
+    await atomicAppendLine(filePath, "line2");
+    await atomicAppendLine(filePath, "line3");
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe("line1\nline2\nline3\n");
+  });
+
+  it("auto-creates parent directories", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "nested", "log.txt");
+
+    await atomicAppendLine(filePath, "entry");
+    const content = await readFile(filePath, "utf8");
+    expect(content).toBe("entry\n");
+  });
+
+  it("file exists and has correct size after append", async () => {
+    const dir = tempDir();
+    dirs.push(dir);
+    const filePath = join(dir, "size.txt");
+
+    await atomicAppendLine(filePath, "hello");
+    const s = await stat(filePath);
+    // "hello\n" = 6 bytes
+    expect(s.size).toBe(6);
+  });
+});

--- a/harvest/crucible/wal-atomic/atomic-io.ts
+++ b/harvest/crucible/wal-atomic/atomic-io.ts
@@ -1,0 +1,73 @@
+/**
+ * Atomic I/O Utilities
+ *
+ * Provides crash-safe file write helpers using the write-to-tmp-then-rename
+ * pattern. On POSIX systems, rename(2) is atomic — a reader never observes
+ * a partial file.
+ *
+ * ## Functions
+ *
+ * - `atomicWrite(filePath, content)` — overwrite a file atomically.
+ *   Writes to a UUID-named `.tmp` sibling, then renames over the target.
+ *   Cleans up the `.tmp` file on any write/rename error.
+ *
+ * - `atomicAppendLine(filePath, line)` — append a single line atomically.
+ *   Uses Node's `appendFile` which issues a single `write(2)` syscall for
+ *   small payloads — atomic on Linux (POSIX write ≤ PIPE_BUF = 4 KiB).
+ *   Ensures the parent directory exists before writing.
+ *
+ * ## Limitations
+ *
+ * `atomicAppendLine` is safe for single-line appends of ≤ 4 KiB on Linux.
+ * For multi-line or large payloads, prefer `atomicWrite` with the full
+ * accumulated content (read-then-write pattern).
+ *
+ * @module utils/atomic-io
+ */
+
+import { writeFile, rename, unlink, appendFile, mkdir } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+/**
+ * Write `content` to `filePath` atomically.
+ *
+ * Writes to a UUID-named `.tmp` sibling in the same directory, then renames
+ * it over the target. If any step fails, the `.tmp` file is deleted and the
+ * original (if any) is left untouched.
+ *
+ * Creates the parent directory recursively if it does not exist.
+ *
+ * @param filePath - Absolute or relative path to the destination file
+ * @param content  - UTF-8 content to write
+ */
+export async function atomicWrite(filePath: string, content: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const tmp = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(tmp, content, "utf8");
+    await rename(tmp, filePath);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+    throw err;
+  }
+}
+
+/**
+ * Append a single JSON-serializable line to `filePath` atomically.
+ *
+ * Uses `fs.appendFile` which issues a single `write(2)` syscall — this is
+ * atomic on Linux/POSIX for payloads ≤ PIPE_BUF (4 KiB). The parent
+ * directory is created recursively if absent.
+ *
+ * For batched writes or payloads > 4 KiB, use `atomicWrite` instead.
+ *
+ * @param filePath - Absolute or relative path to the JSONL file
+ * @param line     - A single line of content (newline is appended automatically)
+ */
+export async function atomicAppendLine(filePath: string, line: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  await appendFile(filePath, line + "\n", "utf8");
+}


### PR DESCRIPTION
## Summary

Crucible-harvest, time-sensitive: this blocks crucible's archival (operator
decision, recorded in `docs/plans/2026-06-12-centralization-candidates.md`
section 0). Stages **byte-for-byte (cmp-verified) archival-safety copies** of
crucible's reusable modules under `harvest/crucible/` so the code survives
archival in a versioned location. The live ports happen in the destination
package PRs — this is the safety net only.

Provenance: all copies taken verbatim from `platform/crucible` @
`d2dbf92c8f1c3ba128e7faccc4e5458677dcec40`, copy date 2026-06-12. Full
provenance table in `harvest/crucible/README.md`.

## What's staged (one subdir per destination)

| Subdir | Source @ `d2dbf92` | Destination |
|---|---|---|
| `resilience/` | `src/state/circuit-breaker.ts` + tests | `@centient/resilience` |
| `cli-utils/` | `src/cli-utils.ts` + tests | `@centient/cli-utils` |
| `dag/` | `src/orchestrator/dag.ts` + `dag-renderer.ts` + tests | `@centient/dag` |
| `wal-atomic/` | `src/utils/atomic-io.ts` + tests | `@centient/wal` |

`cli-utils` lives at `src/cli-utils.ts` in crucible (not `src/utils/`). The DAG
engine (`dag.ts`) is the cycle-detection / Kahn topo-sort / wave-calculation
core; `dag-renderer.ts` is harvested alongside it so the module surface stays
intact.

## Design notes

- **Out of every build scope.** `harvest/` sits at the repo root, outside the
  `packages/*` pnpm workspace glob and every turbo/tsconfig/lint input. No glob
  changes were needed — confirmed `make check` does not pick it up.
- **No new package, no CLAUDE.md row, no changeset.** This PR adds no
  `@centient` package and changes no existing package behavior — it stages
  copies only. `claudemd-check` iterates `packages/*/` and is unaffected.
- **Type deps deferred to the port.** `dag.ts` imports `validateDAGDefinition`
  / `DAGDefinition` from crucible's `orchestrator/types.ts` barrel; that broad
  type tree is intentionally not copied (it isn't "the DAG implementation"). The
  `@centient/dag` port vendors the minimal surface it needs; the commit hash
  pins the source.

## Test evidence

`make check` green on this branch:
- tsc: 0 errors
- vitest: 1296 passed, 14 skipped (1310 total)
- claudemd-check: all versions match, resource count 31 OK

## Followups

- Live port PRs (consumer migration): `@centient/resilience` (circuit-breaker),
  `@centient/cli-utils`, `@centient/dag`, and the `@centient/wal` atomic-io
  module — each adapts its `harvest/crucible/<subdir>/` copy to `@centient`
  scaffold conventions (ESM exports, zero-dep, changeset, CLAUDE.md row).
- Remove `harvest/crucible/` once all four live ports have landed.
- Private target `git-ops.ts` is staged separately in `centient-labs/workspace`
  (PR `harvest/crucible-git-ops`, linked on workspace issue #85) — not in this
  public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
