### PR TITLE
docs(adr): reconcile ADR ledger — ADR-001 passphrase amendment, ADR-003 CI archival, ADR-002 roadmap tickets (Initiative 5)

### DIFF
--- a/docs/adr/001-key-provider-abstraction.md
+++ b/docs/adr/001-key-provider-abstraction.md
@@ -204,3 +204,88 @@ provider.deleteKey();                // boolean (if needed)
 2. **Resolution can fail** — `resolveKeyProvider()` returns a result type. Check `result.ok` before accessing `result.provider`. The error includes an actionable message (e.g., "Install the 1Password CLI").
 3. **Provider name available** — `result.provider.name` returns `"keychain"` or `"1password"` for display purposes.
 4. **Resolution method** — `result.method` is `"config"` or `"auto"` indicating how the provider was selected.
+
+---
+
+## Amendment 1 (2026-06-12): Passphrase provider
+
+**Status:** Accepted (extension) — **security properties PENDING RE-AUDIT**
+**Date:** 2026-06-12
+**Trigger:** Issue #67 merged the passphrase provider (PR #67, commit `b171141`); the hidden-input cap and signal-handling fixes landed in commit `895b88d`. ADR-001's `KeyProviderType` union, provider table, resolution order, and config schema were written before this provider existed and did not cover it. This amendment reconciles the record with the shipped code (`packages/secrets/src/key-providers/passphrase-provider.ts`, `cli/hidden-prompt.ts`, `cli/hidden-input.ts`). It is an **append**, not a rewrite of the original decision.
+
+### Why a third provider
+
+The original two providers each assume an external trust store: Keychain needs macOS + an interactive desktop session, 1Password needs the `op` binary plus either the desktop app or a service-account token. A headless **Linux** host with neither — a bare CI runner or a minimal cloud VM — had no way to unlock the vault. The passphrase provider closes that gap: it derives the 32-byte AES-256-GCM vault key from an operator-typed passphrase via scrypt, persisting only non-secret KDF metadata (salt, cost params) plus an HMAC verifier beside the vault. No key material is stored at rest.
+
+### `KeyProviderType` union (amended)
+
+The union shipped in `packages/secrets/src/key-providers/types.ts:17` is now:
+
+```typescript
+type KeyProviderType = "keychain" | "1password" | "passphrase";
+```
+
+(This is the authoritative union for the ADR; the original at line 70 above and the category-completeness aside in Consequences → Positive both predate this provider. The aside *anticipated* a "passphrase/KDF" provider; it does not constitute the type-level commitment — this amendment does.)
+
+### Provider table (amended)
+
+| Provider | Backend | Auth modes | Platform |
+|----------|---------|-----------|----------|
+| `KeychainProvider` | macOS `security` CLI | Touch ID / system password | macOS only |
+| `OnePasswordProvider` | `op` CLI | Desktop app, service account (`OP_SERVICE_ACCOUNT_TOKEN`), CLI session | Any (requires `op` binary) |
+| `PassphraseProvider` | scrypt KDF over a typed passphrase | Hidden interactive TTY prompt (`promptHiddenSync`) | Any (requires an interactive TTY at unlock time) |
+
+### Resolution order (amended)
+
+The order in `resolve.ts` now has a third tier. Explicit config (`secrets.provider`) is honored strictly as before — `"passphrase"` is a valid explicit value and `resolveExplicit()` constructs a `PassphraseProvider` unconditionally (TTY availability is only checked at prompt time, where a non-TTY fails closed via `HiddenPromptError`). Auto-detection now falls through to passphrase last:
+
+1. Explicit config (`secrets.provider`) — use it; fail if unavailable.
+2. Auto-detection: 1Password if `op` is available → else Keychain on macOS → **else `PassphraseProvider` when `process.stdin.isTTY === true`** (`PassphraseProvider.detect()`).
+3. If none detect, `resolveAuto()` returns `NO_PROVIDER` with an actionable message naming all three options.
+
+Passphrase is intentionally **last** in auto-detection: it requires a human at a keyboard, so it is the fallback for hosts with no OS key store, not a default for hosts that have one.
+
+### Config schema (amended)
+
+`secrets.provider` accepts `"passphrase"`. The provider needs no provider-specific config block (no analogue to `onePassword`) — its only external input is the vault path, which `resolveKeyProvider({ vaultPath })` already threads through. Metadata location is derived from the vault path (`vault.enc` → `vault.passphrase.json`, see `passphraseMetadataPathForVault`).
+
+```json
+{
+  "secrets": { "provider": "passphrase" }
+}
+```
+
+### Provider contract notes (passphrase-specific)
+
+- **`storeKey()` is unsupported.** A passphrase provider derives the key; it does not store a caller-supplied random key. `storeKey()` returns `false` and records an `UNSUPPORTED_OPERATION` diagnostic. Vault bootstrap uses the optional **`setupKey()`** method on the `KeyProvider` interface (`types.ts:57`), which prompts twice (entry + confirmation), writes the metadata sidecar, and returns the derived key. Migration *to* passphrase must therefore route through `setupKey()`, not `storeKey()`.
+- **Verifier, not stored key.** The metadata sidecar stores an HMAC-SHA256 verifier (`createHmac(key).update(PASSPHRASE_VERIFIER_CONTEXT)`), checked with `timingSafeEqual`, so a wrong passphrase fails with `PASSPHRASE_VERIFICATION_FAILED` rather than corrupting the vault. The verifier does not reveal the key.
+
+### Security-relevant properties — PENDING RE-AUDIT
+
+ADR-001 was affirmed at phase-2 spot-check (`docs/hardening/STATE.md`) **before** this provider existed, so the affirmation does not cover it. The following two properties from `895b88d` are the audit-critical ones and have **not** been through an adversarial `cl-adr-audit`; they are recorded here as claims to be refuted, not as verified facts. A scoped re-run is tracked in STATE.md phase 7.
+
+1. **64 KiB hidden-input cap.** `MAX_HIDDEN_INPUT_LENGTH = 65_536` (`cli/hidden-prompt.ts:52`) bounds accumulated hidden input; a hostile or broken input source feeding endless bytes with no submit cannot grow `state.input` without bound — the prompt throws `HiddenPromptError` and drops the reference. **To re-audit:** that the cap is actually reached on the unbounded-input path (not dead behind an earlier return) and that the dropped string carries the documented GC-residue caveat, not a stronger zeroing claim the immutable-string model cannot honor.
+2. **Deferred-one-tick signal handling.** Because the prompt is synchronous, an external `SIGINT`/`SIGTERM`/`SIGHUP` received while `readSync` blocks is queued by libuv and dispatched only after the prompt unwinds. Listeners are installed to suppress the immediate default kill (which would leave the terminal in raw mode with echo off), and their removal is **deferred one tick** via `setImmediate` so the queued dispatch is not dropped (`cli/hidden-prompt.ts:114-160`). **To re-audit:** that removing the listeners synchronously would in fact swallow the queued signal (the failure mode the deferral guards against), that the re-raise reaches the default disposition, and that no sibling handler can fire after the prompt completes.
+
+### Authority placement (P16)
+
+Where the passphrase-derived key lives relative to the untrusted side: the key is derived **inside the same process** that opens the vault and is held in the Node heap as a `Buffer` for the unlock window — identical residence to the Keychain- and 1Password-retrieved keys. The typed passphrase is returned as an immutable JS `string` that cannot be zeroed and lingers until GC (the transient `readSync` byte buffer **is** zeroed before return). **P16 consequence:** this provider is for a **protected trust domain that does not execute untrusted input** (an operator at an interactive terminal unlocking a host process). It is *not* suitable for a sandbox that runs PR-/agent-authored code or LLM-driven tool calls — co-resident untrusted code can read the derived `Buffer` and the residual passphrase string from the heap, exactly as it could the other providers' keys. The headless-unlock use case this provider enables is the operator/host side of the boundary, never the sandbox side. The interactive-TTY requirement is incidentally aligned with this: code running in an untrusted sandbox has no human at a keyboard to type the passphrase.
+
+### Updated file structure
+
+```
+packages/secrets/src/key-providers/
+├── types.ts                  # KeyProvider interface, KeyProviderType (now 3-member)
+├── keychain-provider.ts      # macOS Keychain (wraps vault-common.ts)
+├── onepassword-provider.ts   # 1Password op CLI
+├── passphrase-provider.ts    # scrypt KDF over a typed passphrase (Amendment 1)
+├── resolve.ts                # Config loading + auto-detection (3-tier)
+└── index.ts                  # Barrel exports
+packages/secrets/src/cli/
+├── hidden-prompt.ts          # synchronous hidden TTY read (64 KiB cap, signal handling)
+└── hidden-input.ts           # hidden-input state machine / parser
+```
+
+### Cross-reference
+
+The passphrase provider and its security properties are also the subject of the ADR-002 1.0 KeyProvider ↔ SecretsProvider reconciliation ticket; the `op` argv-visibility negative (Consequences → Negative above) has its own ticket. Both are linked from `docs/hardening/STATE.md` phase 7.

--- a/docs/adr/003-ci-archival-and-local-gates.md
+++ b/docs/adr/003-ci-archival-and-local-gates.md
@@ -1,0 +1,59 @@
+# ADR-003: CI Archival and Local Makefile Gates
+
+**Status:** Accepted
+**Date:** 2026-06-12 (records a decision made 2026-03-30)
+**Deciders:** Owen Johnson
+**Principles:** P2 (No Silent Degradation), P3 (Transparent Evolution), P13 (Auditability as a First-Class Feature), P16 (Authority Outside the Sandbox)
+**Supersedes:** none
+**Related:** ADR-001, ADR-002; `docs/hardening/2026-06-10-dimensions.md` (F5, F6, Deferred line 59-60); `docs/hardening/BACKLOG.md` (T5)
+
+## Context
+
+On 2026-03-30, commit `cef5ad7` ("chore: standardize local CI with Makefiles, archive GitHub Actions") moved this monorepo off GitHub-Actions-hosted CI. The two workflows — build/test on PR and Changesets-driven publish — were moved to `docs/archive/` (`2026-03-29-github-actions-ci.yml`, `2026-03-29-github-actions-release.yml`) rather than deleted, and verification became a local `make check` (lint + full test suite + `claudemd-check`) plus a local `make publish`.
+
+This was a deliberate org-level decision, not drift. It was never written down as an ADR. The hardening phase-3 dimensions audit (`2026-06-10-dimensions.md`) flagged the absence twice: as supply-chain findings F5/F6 (no automated release gate; npm provenance attestation lost with the archived workflow's `NPM_CONFIG_PROVENANCE=true`) and in the Deferred ledger lines 59-60 ("the CI-archival decision (cef5ad7) has no ADR; the local-CI-via-Makefiles standard should be written down"). Initiative 1 of `docs/plans/2026-06-12-next-stage.md` then demonstrated, concretely, that an undocumented local gate is a gate that can be sidestepped silently — making this ADR urgent rather than housekeeping.
+
+### Why CI was archived
+
+The hosted CI was providing little that the local gate did not, while adding a second source of truth for "is the repo green" that could disagree with `make check`, plus a hosted-runner attack surface for a repo whose privileged action (npm publish) is performed by a single maintainer on a trusted workstation. Consolidating to one local gate removes the divergence and shrinks the surface (P16: the publish authority stays on the maintainer's protected workstation, never on a hosted runner that executes PR-authored build scripts).
+
+## Decision
+
+1. **Local `make check` is the canonical gate.** `make check` (lint + full vitest suite across all packages + `claudemd-check`) is the single authoritative "is this green" signal. It must pass before any commit and before any publish. There is no hosted CI that can independently report green or red; the local gate is the source of truth.
+
+2. **Local `make publish` is the only documented publish path.** Releases are cut from a trusted maintainer workstation via `make publish`, which runs build + check before `changeset publish`. Direct `pnpm changeset publish` is forbidden (it bypasses the gate). npm 2FA and an `npm whoami` preflight are the human-in-the-loop controls.
+
+3. **Archived, not deleted.** The two workflow files stay in `docs/archive/` as the executable record of what hosted CI did — specifically the `NPM_CONFIG_PROVENANCE=true` and `id-token: write` settings that local publishing cannot reproduce. They are the template for restoring attestation if a CI publisher returns (see Consequences → Dormant condition).
+
+4. **No re-introduction of hosted CI without a superseding ADR.** Re-adding a GitHub Actions publisher is a reversal of this decision and requires its own ADR (or an amendment here), not an incidental PR. The `2026-06-12-next-stage.md` non-goals reaffirm this.
+
+## Consequences
+
+### Positive
+
+- **One source of truth for green/red** — no divergence between a hosted runner and `make check`.
+- **Smaller privileged-action surface** (P16) — publish authority lives on the maintainer's protected workstation, not a hosted runner that executes untrusted PR build scripts.
+- **The gate is in the repo** — `make check` is readable, runnable, and diffable by every contributor; there is no opaque hosted config.
+
+### Negative
+
+- **No automatic enforcement on PRs** — a contributor (or an agent) can open a PR whose `make check` they never ran. The gate is only as strong as the discipline (and, for releases, the `make publish` dependency wiring) that invokes it. This is the structural weakness that Initiative 1 exists to close.
+- **Provenance attestation lost (F6).** The archived release workflow set `NPM_CONFIG_PROVENANCE=true`; local `make publish` cannot produce npm provenance because provenance requires a supported CI OIDC provider (`id-token: write`). Public `@centient/*` packages currently ship **unattested**. Per BACKLOG.md T5, this is documented and explicitly declined (`--provenance=false` recorded in the release flow) rather than silently dropped, with restoration tracked as the dormant condition below.
+
+### Incident — the Initiative-1 gate-sequencing bypass (2026-06-11/12)
+
+The sdk 2.0.0 / secrets 0.7.0 release reached npm with `make claudemd-check` failing on `main`. **Root cause** (recorded in `docs/hardening/STATE.md`, phase-7 entry): the Changesets "version" step bumps `package.json` versions *after* `make check` runs, and nothing in the version flow rewrote the `CLAUDE.md` package table — so the published commit left `main` red on the version-drift gate (sdk 1.7.1→2.0.0, secrets 0.6.0→0.7.0 undocumented in the table) while the packages still published. The local gate was either run pre-bump or bypassed via a direct `changeset publish`. This is the canonical demonstration of the Negative above: a local gate with no structural enforcement is a gate that can be sidestepped silently (P2, P13). **The fix is in flight as PR #87** (`feat/release-gate-integrity`, Initiative 1): mechanical `CLAUDE.md` version sync chained into the version step, and `make publish` re-running `make check` in the same invocation with a clean-tree / on-`origin/main` guard so a stale or skipped check cannot reach npm. This ADR records the incident as the motivating consequence; PR #87 carries the remediation.
+
+### Dormant condition — restore attestation when a CI publisher returns
+
+If a hosted (or otherwise OIDC-capable) **publish** step is ever reintroduced — even a minimal `workflow_dispatch` job that runs only the publish while tests stay local — npm provenance attestation **must** be restored at that time: set `NPM_CONFIG_PROVENANCE=true` and `id-token: write`, mirroring the archived `2026-03-29-github-actions-release.yml` template in `docs/archive/`. This is the dormant T5 follow-up (`BACKLOG.md` T5 item 1, "restore attestation when a CI publisher returns"). It stays dormant under this ADR; the trigger is the return of a CI publisher, and reintroducing one is itself gated on a superseding ADR per Decision 4.
+
+## References
+
+- Commit `cef5ad7` — "chore: standardize local CI with Makefiles, archive GitHub Actions" (2026-03-30)
+- `docs/archive/2026-03-29-github-actions-ci.yml`, `docs/archive/2026-03-29-github-actions-release.yml`
+- `docs/hardening/2026-06-10-dimensions.md` — F5, F6, Deferred lines 59-60
+- `docs/hardening/BACKLOG.md` — T5 (`gap-none-publish-provenance`)
+- `docs/plans/2026-06-12-next-stage.md` — Initiative 1 (release-gate integrity), non-goals (no CI re-introduction)
+- PR #87 — `feat/release-gate-integrity` (Initiative-1 remediation, in flight)
+- `.agent/procedures/commits.md` — release/publish flow

--- a/docs/hardening/2026-06-10-dimensions.md
+++ b/docs/hardening/2026-06-10-dimensions.md
@@ -58,3 +58,7 @@ disproportionate for this repo.
   (ticket belongs to release-toolkit repo).
 - Org-level: the CI-archival decision (cef5ad7) has no ADR; the
   local-CI-via-Makefiles standard should be written down in `standards`.
+  **Closed 2026-06-12 — written up as `docs/adr/003-ci-archival-and-local-gates.md`**
+  (decision cef5ad7, the local Makefile-gate standard, the Initiative-1
+  gate-sequencing bypass as a Consequences entry, and the dormant
+  restore-attestation-when-CI-returns condition).

--- a/docs/hardening/STATE.md
+++ b/docs/hardening/STATE.md
@@ -13,6 +13,24 @@ Campaign: workspace docs/plans/2026-06-10-hardening-master-plan.md (Wave 1).
 | 6 verification | done 2026-06-11 | (this file) | Post-merge clean-repro green on main @ dadfafe: fresh frozen-lockfile install, tsc 0 errors, 1257 passed / 14 skipped (logger 490, secrets 174, sdk 470, wal 63, events 60), claudemd-check OK. No ADR-anchored tickets, so no scoped cl-adr-audit re-run. |
 | 7 next-stage plan | done 2026-06-12 | docs/plans/2026-06-12-next-stage.md | 7 ordered initiatives + deferred-again ledger. Status updates since phase 6: #67 merged (b171141); T7 resolved — sdk 2.0.0 + secrets 0.7.0 published 2026-06-11; the release exposed a structural gate gap (publish bumps versions AFTER check, leaving main red on claudemd-check) — fix-forward PR #82, structural fix is initiative 1. |
 
+## Phase 7 notes (2026-06-12)
+
+- Initiative 5 (ADR ledger reconciliation) merged: ADR-001 Amendment 1
+  (passphrase provider), ADR-003 (CI archival + local gates), ADR-002 1.0
+  roadmap tickets opened (#98 factory+policy stack, #99 audit sink+HMAC
+  [folds #9], #100 SecretsProvider rename + KeyProvider reconciliation
+  [folds #8], #101 threat-model doc [inputs #80, #11]; plus #102 op-argv
+  key exposure, #103 perf-benchmark baselines). #8 and #9 are flagged for
+  the coordinator to close as duplicates of #100/#99. **Scoped re-audit
+  required:** ADR-001's
+  phase-2 spot-check predates the passphrase provider (PR #67 / b171141,
+  hardening fixes 895b88d), so its "affirm" verdict does NOT cover the
+  passphrase path. A future `cl-adr-audit` run **scoped to ADR-001** must
+  refute the two security claims recorded in Amendment 1 (the 64 KiB
+  hidden-input cap and the deferred-one-tick signal handling) against the
+  shipped code. Do NOT run that audit in this seat — it is the next
+  audit-cycle's task. #67/T7 are resolved (see the phase-7 table entry).
+
 ## Phase 6 notes (2026-06-11)
 
 - All 6 ticket PRs (#71–#76) and the ledger PR (#77) merged by the


### PR DESCRIPTION
## Summary

Initiative 5 of `docs/plans/2026-06-12-next-stage.md` — ADR ledger reconciliation. **Documentation + GitHub issues only; no changeset.** Three documented decisions had drifted from reality; this brings the record back in line and gives the ADR-002 1.0 roadmap a backlog presence.

- **ADR-001 — Amendment 1 (passphrase provider):** appended (not a rewrite). Adds `"passphrase"` to the `KeyProviderType` union *in the amendment proper* (`type KeyProviderType = "keychain" | "1password" | "passphrase"`), extends the provider table, the now-3-tier resolution order, and the config schema. Cites #67 / `b171141` and `895b88d`. Records the **64 KiB hidden-input cap** (`MAX_HIDDEN_INPUT_LENGTH`) and the **deferred-one-tick signal handling** as security-relevant properties **PENDING RE-AUDIT** (the phase-2 spot-check predates this provider). States the **P16** placement: the passphrase-derived key lives process-internal in the unlock window — a protected trust domain — and is *not* for a sandbox that runs untrusted code.
- **ADR-003 (new) — CI archival + local Makefile gates:** decision `cef5ad7`, the local-`make check`/`make publish` standard, the **Initiative-1 gate-sequencing bypass** as a Consequences entry (root cause cited from STATE.md phase-7; remediation in flight as **PR #87**), and the dormant **restore-attestation-when-a-CI-publisher-returns** condition (BACKLOG.md T5 item 1).
- **dimensions doc lines 59-60:** annotated to link ADR-003 (minimal edit — STATE.md phase-7 was already updated on another in-flight branch, so I only added the scoped re-run line that was absent from `origin/main`).
- **STATE.md phase-7 notes:** the scoped `cl-adr-audit` re-run requirement for ADR-001 (passphrase path; do NOT run in this seat) + the roadmap ticket map.

## Tracking issues opened (6, ≥5 required)

Each names its ADR section + design principles by number and is executable cold (file paths + acceptance criteria in the body):

- **#98** — ADR-002 1.0 Pillar 1: `SecretsClient` factory + policy stack (P9/P10/P3/P5)
- **#99** — ADR-002 1.0 Pillar 3: audit sink (OTel+OCSF) + HMAC chaining (P13/P4/P2) — **folds #9**
- **#100** — ADR-002 1.0: `SecretsProvider` rename + ADR-001 `KeyProvider` reconciliation (P10/P6/P3/P16) — **folds #8**
- **#101** — ADR-002 1.0: published threat-model doc `docs/threat-model.md` (P15/P16/P13/P11) — inputs **#80**, **#11**
- **#102** — ADR-001 negative: vault key hex visible in `ps` via `op item create/edit` argv → 1Password Connect/SDK (P15/P16)
- **#103** — Deferred-Again ledger: perf-benchmark baselines for the 14 `PERF_TESTS`-gated benchmarks (P14)

**@coordinator:** please close **#8** as a duplicate of #100 and **#9** as a duplicate of #99 (both folded, referenced from the respective tickets).

## Design notes

- The amendment is an **append** — the original ADR-001 decision text (incl. the line-70 2-member union and the line-138 category-completeness aside) is untouched; the amendment is declared the authoritative union and explicitly notes the line-138 aside does not constitute the type-level commitment (per the acceptance criterion).
- The amendment matches the shipped code exactly: `types.ts:17` (3-member union), `resolve.ts` (passphrase last in auto-detect, unconditional under explicit config with TTY checked at prompt time), `passphrase-provider.ts` (`storeKey` unsupported → `setupKey`, HMAC verifier), `cli/hidden-prompt.ts` (cap + signals).

## Test evidence

`make check` green: tsc 0 errors, vitest 1296 passed / 14 skipped, claudemd-check OK (all package versions match). No code touched — docs + issues only, so no changeset.

## Followups

- Future `cl-adr-audit` scoped to ADR-001 to refute the two PENDING-RE-AUDIT passphrase security claims (tracked in STATE.md phase-7; not this seat).
- Coordinator: close #8/#9 as duplicates.
- ADR-002 1.0 roadmap execution (#98–#101) is a future major-version effort — explicit non-goal of the next-stage spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
