### PR TITLE
feat(sdk-python): 0.34.0 parity — Phase A (truthful de-scoping) + Phase B (core)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SUMMARY := . $(TOOLKIT)/common.sh && . $(TOOLKIT)/summary.sh
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install ensure-deps build lint test check clean publish claudemd-check
+.PHONY: help install ensure-deps build lint test python-test check clean publish claudemd-check
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -36,7 +36,10 @@ test: ensure-deps ## Run tests
 CHECK_STAMP := .logs/.check-stamp
 TREE_FINGERPRINT := { git rev-parse HEAD; git status --porcelain; git diff HEAD; } | git hash-object --stdin
 
-check: lint test claudemd-check ## Run full CI gate (lint + test + docs drift)
+python-test: ## Run the sdk-python core unit suite (mocked transport)
+	@$(SUMMARY) && run_summarized generic "./scripts/run-python-tests.sh" .logs/python-test.log
+
+check: lint test python-test claudemd-check ## Run full CI gate (lint + test + python + docs drift)
 	@mkdir -p .logs && $(TREE_FINGERPRINT) > $(CHECK_STAMP)
 
 clean: ## Remove build artifacts
@@ -82,3 +85,8 @@ claudemd-check: ## Check CLAUDE.md package table matches actual versions
 # 2026-06-11  Hard-gate publish on check via tree fingerprint stamp;
 #             explicitly decline npm provenance (NPM_CONFIG_PROVENANCE=false)
 #             for local publishes — unsupported without a CI OIDC provider
+# 2026-06-12  Add python-test (sdk-python pytest via scripts/run-python-tests.sh)
+#             and wire it into `check` (next-stage Initiative 3, Phase B). Only
+#             the .PHONY + check + new python-test lines were touched, to keep
+#             the merge with the in-flight publish-target restructure (PR #87)
+#             trivial.

--- a/packages/sdk-python/.gitignore
+++ b/packages/sdk-python/.gitignore
@@ -1,0 +1,14 @@
+# Local development virtualenv (see README "Development")
+.venv/
+venv/
+
+# Python build / cache artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## Unreleased
+
+### Parity correction — TypeScript SDK 2.0.0
+
+> **Correction.** Earlier releases of this CHANGELOG (the 1.0.0 entry below)
+> claimed *"Full API parity"* with the TypeScript SDK. That claim was true at
+> the time but went stale when `@centient/sdk` moved 1.7.1 → 2.0.0 underneath
+> this package. **There is no full-API-parity guarantee.** Parity is now tracked
+> explicitly in the support matrix below and in `README.md`. This package does
+> not claim parity it does not have.
+
+#### Support matrix (vs `@centient/sdk` 2.0.0)
+
+| TS SDK surface | Python? | Notes |
+|----------------|---------|-------|
+| Sessions, notes, scratch, coordination | yes | `client.sessions` and sub-resources |
+| Crystals (CRUD, search, ACL, share, fork, hierarchy, versions, trash, merge, clusters) | yes | `client.crystals` |
+| `expected_version` CAS on `crystals.update` | yes | **new** — mirrors TS `expectedVersion`; 409 maps to `CrystalVersionConflictError` |
+| `skip_embedding` on `crystals.create` / `crystals.update` | yes | **new** — mirrors TS `skipEmbedding`; server-floor caveats documented |
+| `MaintenanceResource` (`vacuum`, `tombstone_cleanup`, `changelog_compact`) | yes | **new** — handles bare (non-enveloped) bodies |
+| `MIN_SERVER_VERSION` + `check_server_compatibility()` | yes | **new** — mirrors `client.ts` (floor `0.31.0`) |
+| Edges, session links, terrafirma, entities, extraction, events | yes | |
+| Export / import | yes | |
+| Blobs, audit | yes | Python-only bonus surfaces (not in TS SDK) |
+| `SyncResource` (NDJSON push/pull, peers, conflicts — TS 2.0.0 `{success,data}` envelopes) | no | **not yet ported** — Phase C follow-up (next-stage spec Initiative 3) |
+| `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users` resources | no | **not yet ported** — Phase C |
+| Flat client methods (`createSession`, `search`, …) | no | out of scope by design — Python is resource-only |
+
+#### Added (0.34.0 core)
+
+- `expected_version` field on `UpdateKnowledgeCrystalParams` — optimistic-concurrency
+  (CAS) check, serializes to `expectedVersion`. On version mismatch the server
+  returns HTTP 409 (`OPERATION_VERSION_CONFLICT`), surfaced as the new
+  `CrystalVersionConflictError` carrying the server-reported `current_version`.
+- `skip_embedding` field on `CreateKnowledgeCrystalParams` and
+  `UpdateKnowledgeCrystalParams` — serializes to `skipEmbedding`. Server-floor
+  caveats (>= 0.34.0 on create, >= 0.31.0 on update) documented on the fields.
+- `CrystalVersionConflictError` (409) in `engram.errors`.
+- `MaintenanceResource` / `SyncMaintenanceResource` (`client.maintenance`) with
+  `vacuum()`, `tombstone_cleanup()`, `changelog_compact()` — these endpoints
+  return **bare** (non-enveloped) bodies; the resource validates the bare shape
+  and raises loudly on a wrapped / contract-drift body.
+- `MIN_SERVER_VERSION = "0.31.0"` constant and `check_server_compatibility()`
+  on both clients — calls `/health`, compares against the floor, fails closed on
+  an unknown / below-floor version (mirrors `packages/sdk/src/client.ts`).
+- pytest mocked-transport coverage for all of the above (maintenance bare-body
+  parsing + envelope rejection, CAS 409 routing, wire-field serialization,
+  compatibility gating). Wired into `make check` via `make python-test`.
+
 ## 1.0.0 Stable (2026-03-11)
 
 **First stable release.** This version graduates engram-py from Alpha to Production/Stable.
@@ -22,6 +71,12 @@ Semantic versioning (SemVer) guarantees apply from this version onwards.
 - **Stability guarantees**: SemVer policy, supported Python versions, API freeze scope documented in README.
 
 ### TypeScript SDK Parity
+
+> **⚠️ Stale claim — see the "Parity correction" entry at the top of this file.**
+> The "Full API parity" statement below was accurate against the TS SDK *as of
+> 2026-03-11* but no longer holds: `@centient/sdk` advanced to 2.0.0
+> afterwards. Treat the support matrix in the Unreleased section as the source
+> of truth, not this paragraph.
 
 Full API parity achieved for all 16 core resources (Sessions, Coordination, Crystals, Export/Import, Terrafirma).
 Python SDK also includes bonus features: **BlobsResource** and **AuditResource** (not in TS SDK).

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -4,13 +4,40 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/engram-py.svg)](https://pypi.org/project/engram-py/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Python SDK for Engram Memory Server (v1.0.0 Stable). Provides both async and sync clients with full type coverage via Pydantic v2 models.
+Python SDK for Engram Memory Server (v1.0.0 Stable). Provides both async and sync clients, typed via Pydantic v2 models.
+
+> **Parity scope:** This SDK does **not** claim full API parity with the
+> TypeScript SDK (`@centient/sdk`). Coverage is tracked explicitly in the
+> [TypeScript SDK parity](#typescript-sdk-parity) matrix below. The two SDKs are
+> independent clients of the same Engram REST contract.
 
 > **Unified Type Model:** Knowledge items and crystals use a single
 > `KnowledgeCrystal` type backed by the `knowledge_crystals` table. The old
 > deprecated types (`KnowledgeItem`, `Crystal`, `KnowledgeEdge`,
 > `CreateKnowledgeParams`, `CreateCrystalParams`) have been removed.
 > Use the unified types from `engram.types.knowledge_crystal`.
+
+## TypeScript SDK parity
+
+This SDK is a resource-only client of the Engram REST API. It tracks the
+TypeScript SDK (`@centient/sdk`) feature-by-feature rather than promising
+blanket parity — when the two drift, this matrix is the source of truth (vs
+`@centient/sdk` 2.0.0):
+
+| TS SDK surface | Python? | Notes |
+|----------------|---------|-------|
+| Sessions, notes, scratch, coordination | yes | `client.sessions` and sub-resources |
+| Crystals (CRUD, search, ACL, share, fork, hierarchy, versions, trash, merge, clusters) | yes | `client.crystals` |
+| `expected_version` CAS on `crystals.update` | yes | mirrors TS `expectedVersion`; 409 maps to `CrystalVersionConflictError` |
+| `skip_embedding` on `crystals.create` / `crystals.update` | yes | mirrors TS `skipEmbedding`; server-floor caveats on the fields |
+| Maintenance (`client.maintenance.vacuum` / `tombstone_cleanup` / `changelog_compact`) | yes | bare (non-enveloped) response bodies |
+| `MIN_SERVER_VERSION` + `check_server_compatibility()` | yes | mirrors `client.ts`; floor `0.31.0` |
+| Edges, session links, terrafirma, entities, extraction, events | yes | |
+| Export / import | yes | |
+| Blobs, audit | yes | Python-only bonus surfaces (not in TS SDK) |
+| Sync resource (NDJSON push/pull, peers, conflicts) | **no** | not yet ported (next-stage spec Initiative 3, Phase C) |
+| `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users` | **no** | not yet ported (Phase C) |
+| Flat client methods (`createSession`, `search`, …) | **no** | out of scope by design — Python is resource-only |
 
 ## Installation
 
@@ -658,6 +685,70 @@ print(f"Forked crystal ID: {forked.id}")
 client.crystals.generate_embedding(crystal_id)
 ```
 
+### Optimistic Concurrency (CAS) and Skip-Embedding
+
+```python
+from engram import UpdateKnowledgeCrystalParams, CrystalVersionConflictError
+
+# Compare-and-set update: only succeeds if the server's current version matches.
+try:
+    client.crystals.update(
+        crystal_id,
+        UpdateKnowledgeCrystalParams(title="New title", expected_version=local.version),
+    )
+except CrystalVersionConflictError as err:
+    fresh = client.crystals.get(crystal_id)
+    # merge local edits onto `fresh`, then retry with
+    # expected_version=err.current_version
+    print(f"Conflict — server is at version {err.current_version}")
+
+# Skip embedding regeneration for a meaningless-to-search field (heartbeat etc.).
+# Requires engram-server >= 0.31.0 on update / >= 0.34.0 on create; older
+# servers silently ignore the flag (no-op, correctness unaffected).
+client.crystals.update(
+    crystal_id,
+    UpdateKnowledgeCrystalParams(type_metadata={"last_seen": "..."}, skip_embedding=True),
+)
+```
+
+### Server Compatibility
+
+```python
+# Check the connected server against the SDK's minimum floor (0.31.0).
+info = client.check_server_compatibility()
+if not info["compatible"]:
+    print(f"Server {info['server_version']} is below {info['min_required']}")
+```
+
+`check_server_compatibility()` calls `/health`, reads the server `version`, and
+returns `{"compatible", "server_version", "min_required"}`. It fails closed: an
+unknown or below-floor version reports `compatible=False`. `expected_version`
+CAS needs >= 0.30.0, `skip_embedding`-on-update needs >= 0.31.0, and
+`skip_embedding`-on-create / `maintenance.vacuum()` need >= 0.34.0.
+
+### Maintenance
+
+```python
+from engram import MaintenanceParams, VacuumParams
+
+# Hard-delete tombstoned rows older than 30 days (dry-run first)
+preview = client.maintenance.tombstone_cleanup(MaintenanceParams(days=30, dry_run=True))
+print(f"Would delete {preview.deleted} rows")
+
+# Compact the changelog
+compacted = client.maintenance.changelog_compact(MaintenanceParams(days=90))
+
+# Reclaim dead-tuple space (requires engram-server >= 0.34.0).
+# Pass VacuumParams(full=True) for VACUUM FULL — admin key required, takes an
+# ACCESS EXCLUSIVE lock; run it in a maintenance window.
+vac = client.maintenance.vacuum()
+print(f"Vacuumed: {vac.vacuumed}")
+```
+
+Maintenance endpoints return **bare** (non-enveloped) response bodies; the SDK
+validates the bare shape and raises an `EngramError` if a server wraps the
+result in the standard `{ data }` envelope (a contract regression).
+
 ### Note Lifecycle
 
 ```python
@@ -709,7 +800,9 @@ The SDK provides resource-based access to all Engram APIs:
 | Blobs | `client.blobs` | Binary blob upload, download, metadata, GC |
 | Audit | `client.audit` | Audit event ingestion, querying, stats, pruning |
 | Export/Import | `client.export_import` | Data export (streaming), import (multipart), preview |
+| Maintenance | `client.maintenance` | Tombstone cleanup, changelog compaction, tombstone-table vacuum (bare bodies) |
 | Health | `client.health()` / `client.health_ready()` / `client.health_detailed()` | Server health checks |
+| Compatibility | `client.check_server_compatibility()` | Verify the server meets `MIN_SERVER_VERSION` (0.31.0) |
 | Embeddings | `client.embed()` / `client.embed_batch()` / `client.embedding_info()` | Text embedding generation |
 
 ## Unified Types
@@ -754,6 +847,7 @@ except ValidationError as e:
 |-----------|-------------|-------------|
 | `NotFoundError` | 404 | Resource not found |
 | `SessionExistsError` | 409 | Session already exists |
+| `CrystalVersionConflictError` | 409 | `expected_version` CAS mismatch (carries `current_version`) |
 | `ValidationError` | 400 | Invalid request parameters |
 | `UnauthorizedError` | 401 | Missing or invalid API key |
 | `NetworkError` | - | Connection failure |
@@ -762,13 +856,32 @@ except ValidationError as e:
 
 ## Development
 
-```bash
-# Install dev dependencies
-pip install -e ".[dev]"
+Use a local virtualenv under this package directory (it is gitignored):
 
-# Run tests
-pytest tests/ -v
+```bash
+cd packages/sdk-python
+
+# Create and populate a local venv
+python3 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/pip install -e ".[dev]"
+
+# Run the unit suite (mocked transport — no live server needed)
+.venv/bin/python -m pytest tests/ -v -m "not integration"
 ```
+
+The framework-integration example tests
+(`test_integration_langchain.py`, `test_integration_crewai.py`,
+`test_integration_autogen.py`) exercise the optional `examples/` adapters and
+are **not** part of the gate; the monorepo's `make python-test` target runs the
+core unit suite (`-m "not integration"`, excluding those example files) and is
+wired into `make check`. Run it from the repo root:
+
+```bash
+make python-test   # or: make check  (lint + TS tests + claudemd + python)
+```
+
+`make python-test` auto-creates `packages/sdk-python/.venv` on first run.
 
 ## Requirements
 

--- a/packages/sdk-python/engram/__init__.py
+++ b/packages/sdk-python/engram/__init__.py
@@ -12,12 +12,14 @@ logging.getLogger("engram").addHandler(logging.NullHandler())
 from engram.client import (
     AsyncEngramClient,
     EngramClient,
+    MIN_SERVER_VERSION,
     create_async_engram_client,
     create_engram_client,
 )
 
 # Error hierarchy
 from engram.errors import (
+    CrystalVersionConflictError,
     EngramError,
     EngramTimeoutError,
     InternalError,
@@ -76,6 +78,17 @@ from engram.resources import (
     EventSubscription,
     ExtractionResource,
     SyncExtractionResource,
+    MaintenanceResource,
+    SyncMaintenanceResource,
+)
+
+# Maintenance types
+from engram.types.maintenance import (
+    ChangelogCompactResult,
+    MaintenanceParams,
+    TombstoneCleanupResult,
+    VacuumParams,
+    VacuumResult,
 )
 
 # Types (re-exported from types subpackage — explicit imports)
@@ -298,9 +311,11 @@ __all__ = [
     # Client
     "AsyncEngramClient",
     "EngramClient",
+    "MIN_SERVER_VERSION",
     "create_async_engram_client",
     "create_engram_client",
     # Errors
+    "CrystalVersionConflictError",
     "EngramError",
     "EngramTimeoutError",
     "InternalError",
@@ -357,6 +372,14 @@ __all__ = [
     "EventSubscription",
     "ExtractionResource",
     "SyncExtractionResource",
+    "MaintenanceResource",
+    "SyncMaintenanceResource",
+    # Maintenance types
+    "MaintenanceParams",
+    "VacuumParams",
+    "TombstoneCleanupResult",
+    "ChangelogCompactResult",
+    "VacuumResult",
     # Common types
     "PaginatedResult",
     "PaginationMeta",

--- a/packages/sdk-python/engram/client.py
+++ b/packages/sdk-python/engram/client.py
@@ -29,6 +29,7 @@ from engram.resources.events import EventsResource, SyncEventsResource
 from engram.resources.export_import import ExportImportResource, SyncExportImportResource
 from engram.resources.entities import EntitiesResource, SyncEntitiesResource
 from engram.resources.extraction import ExtractionResource, SyncExtractionResource
+from engram.resources.maintenance import MaintenanceResource, SyncMaintenanceResource
 from engram.types.embeddings import (
     EmbeddingInfoResponse,
     EmbeddingResponse,
@@ -47,6 +48,55 @@ DEFAULT_BASE_URL = "http://localhost:3100"
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_RETRIES = 3
 DEFAULT_RETRY_DELAY = 1.0
+
+# Minimum engram-server version required by this SDK. Use
+# ``client.check_server_compatibility()`` to verify at runtime. Mirrors
+# ``MIN_SERVER_VERSION`` in packages/sdk/src/client.ts:204.
+#
+# - 0.30.0 landed ``expectedVersion`` CAS support on ``PATCH /crystals/:id``.
+# - 0.31.0 landed ``skipEmbedding`` support on ``PATCH /crystals/:id``.
+#
+# Older servers silently ignore both fields: correctness is preserved, but CAS
+# is not enforced and the embedding-skip optimization is a no-op.
+#
+# Newer feature floors (the SDK still works against 0.31.x for everything else,
+# so the gate stays at 0.31.0 — check these per-feature when used):
+# - 0.34.0 added ``skipEmbedding`` on ``POST /crystals`` (engram-server#763),
+#   ``POST /v1/maintenance/vacuum`` (engram-server#766), and migrated the
+#   ``/v1/sync`` routes to the standard ``{success, data}`` envelopes. Against
+#   older servers, ``skipEmbedding``-on-create is ignored, ``vacuum()`` 404s,
+#   and the sync wire shapes differ.
+MIN_SERVER_VERSION = "0.31.0"
+
+
+def _is_version_gte(actual: str, required: str) -> bool:
+    """Return ``True`` when ``actual`` >= ``required`` (semver major.minor.patch).
+
+    Unknown / unparseable versions return ``False`` so the compatibility gate
+    fails closed. Mirrors ``EngramClient.isVersionGte`` in
+    packages/sdk/src/client.ts.
+    """
+
+    def parse(v: str) -> list[int]:
+        parts: list[int] = []
+        for segment in v.split("."):
+            try:
+                parts.append(int(segment))
+            except ValueError:
+                return []
+        return parts
+
+    a = parse(actual)
+    r = parse(required)
+    if not a:
+        return False
+    a_major, a_minor, a_patch = (a + [0, 0, 0])[:3]
+    r_major, r_minor, r_patch = (r + [0, 0, 0])[:3]
+    if a_major != r_major:
+        return a_major > r_major
+    if a_minor != r_minor:
+        return a_minor > r_minor
+    return a_patch >= r_patch
 
 
 class AsyncEngramClient:
@@ -123,6 +173,7 @@ class AsyncEngramClient:
         self.export_import = ExportImportResource(self)
         self.entities = EntitiesResource(self)
         self.extraction = ExtractionResource(self)
+        self.maintenance = MaintenanceResource(self)
 
     async def __aenter__(self) -> AsyncEngramClient:
         return self
@@ -604,6 +655,29 @@ class AsyncEngramClient:
         """Get detailed health information including dependency status."""
         return await self._request("GET", "/health/detailed")
 
+    async def check_server_compatibility(self) -> dict[str, Any]:
+        """Check whether the connected server meets the minimum version floor.
+
+        Calls ``/health`` and compares the returned ``version`` against
+        :data:`MIN_SERVER_VERSION`. Mirrors ``EngramClient.checkCompatibility``
+        in packages/sdk/src/client.ts.
+
+        Returns:
+            ``{"compatible": bool, "server_version": str, "min_required": str}``.
+            ``compatible`` is ``False`` when the server omits its version or
+            reports one below the floor (fails closed).
+        """
+        health = await self._request("GET", "/health")
+        server_version = (health or {}).get("version") or "unknown"
+        compatible = server_version != "unknown" and _is_version_gte(
+            server_version, MIN_SERVER_VERSION
+        )
+        return {
+            "compatible": compatible,
+            "server_version": server_version,
+            "min_required": MIN_SERVER_VERSION,
+        }
+
     async def embed(self, text: str, module: Optional[str] = None) -> EmbeddingResponse:
         """Generate a single embedding for text."""
         body: dict[str, Any] = {"text": text}
@@ -703,6 +777,7 @@ class EngramClient:
         self.export_import = SyncExportImportResource(self)
         self.entities = SyncEntitiesResource(self)
         self.extraction = SyncExtractionResource(self)
+        self.maintenance = SyncMaintenanceResource(self)
 
     def __enter__(self) -> EngramClient:
         return self
@@ -1174,6 +1249,29 @@ class EngramClient:
     def health_detailed(self) -> dict[str, Any]:
         """Get detailed health information including dependency status."""
         return self._request("GET", "/health/detailed")
+
+    def check_server_compatibility(self) -> dict[str, Any]:
+        """Check whether the connected server meets the minimum version floor.
+
+        Calls ``/health`` and compares the returned ``version`` against
+        :data:`MIN_SERVER_VERSION`. Mirrors ``EngramClient.checkCompatibility``
+        in packages/sdk/src/client.ts.
+
+        Returns:
+            ``{"compatible": bool, "server_version": str, "min_required": str}``.
+            ``compatible`` is ``False`` when the server omits its version or
+            reports one below the floor (fails closed).
+        """
+        health = self._request("GET", "/health")
+        server_version = (health or {}).get("version") or "unknown"
+        compatible = server_version != "unknown" and _is_version_gte(
+            server_version, MIN_SERVER_VERSION
+        )
+        return {
+            "compatible": compatible,
+            "server_version": server_version,
+            "min_required": MIN_SERVER_VERSION,
+        }
 
     def embed(self, text: str, module: Optional[str] = None) -> EmbeddingResponse:
         """Generate a single embedding for text."""

--- a/packages/sdk-python/engram/client.py
+++ b/packages/sdk-python/engram/client.py
@@ -83,6 +83,16 @@ def _is_version_gte(actual: str, required: str) -> bool:
             try:
                 parts.append(int(segment))
             except ValueError:
+                # A non-numeric segment (e.g. a pre-release/build suffix like
+                # ``0.31.0-alpha`` or a stray ``0.31.x``) is unparseable here.
+                # We deliberately fail closed (return []), but emit a warning so
+                # the format issue is diagnosable rather than silently swallowed.
+                logger.warning(
+                    "unparseable version segment %r in %r; treating version as "
+                    "incompatible (fail-closed)",
+                    segment,
+                    v,
+                )
                 return []
         return parts
 

--- a/packages/sdk-python/engram/errors.py
+++ b/packages/sdk-python/engram/errors.py
@@ -33,6 +33,46 @@ class SessionExistsError(EngramError):
         super().__init__(message, code="SESSION_EXISTS", status_code=409)
 
 
+class CrystalVersionConflictError(EngramError):
+    """Optimistic-concurrency (CAS) update conflict on a crystal (409).
+
+    Raised when a ``crystals.update(...)`` call passes ``expected_version`` and
+    the crystal's current server-side ``version`` does not match. The server
+    responds with HTTP 409 + error code ``OPERATION_VERSION_CONFLICT`` and
+    includes the current version in the error details (engram-server#60).
+
+    The server-reported :attr:`current_version` is exposed so callers can
+    re-fetch, merge, and retry without a second round trip::
+
+        from engram.errors import CrystalVersionConflictError
+
+        try:
+            client.crystals.update(
+                crystal_id,
+                UpdateKnowledgeCrystalParams(title="...", expected_version=local.version),
+            )
+        except CrystalVersionConflictError as err:
+            fresh = client.crystals.get(crystal_id)
+            # merge local edits onto ``fresh``, then retry with
+            # expected_version=err.current_version
+
+    Mirrors the TypeScript SDK's ``CrystalVersionConflictError``
+    (``packages/sdk/src/errors.ts``).
+    """
+
+    def __init__(
+        self,
+        message: str = "Crystal version conflict",
+        current_version: Optional[int] = None,
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            message, code="OPERATION_VERSION_CONFLICT", status_code=409
+        )
+        self.current_version = current_version
+        self.details = details
+
+
 class ValidationError(EngramError):
     """Request validation failed (400)."""
 
@@ -90,6 +130,31 @@ class InternalError(EngramError):
         super().__init__(message, code="INTERNAL_ERROR", status_code=500)
 
 
+def _extract_current_version(body: Any, error_obj: Any) -> Optional[int]:
+    """Pull the server-reported ``currentVersion`` from a CAS-conflict body.
+
+    The 409 conflict body (engram-server#60) carries the current version. It may
+    live at the top level (``{ currentVersion }``) or nested under the error
+    object's ``details`` (``{ error: { details: { currentVersion } } }``).
+    Returns ``None`` if absent so the error still surfaces, just without the hint.
+    """
+    candidates: list[Any] = []
+    if isinstance(error_obj, dict):
+        candidates.append(error_obj.get("currentVersion"))
+        details = error_obj.get("details")
+        if isinstance(details, dict):
+            candidates.append(details.get("currentVersion"))
+    if isinstance(body, dict):
+        candidates.append(body.get("currentVersion"))
+        details = body.get("details")
+        if isinstance(details, dict):
+            candidates.append(details.get("currentVersion"))
+    for value in candidates:
+        if isinstance(value, int):
+            return value
+    return None
+
+
 def parse_api_error(status_code: int, body: Any) -> NoReturn:
     """Parse an API error response and raise the appropriate error."""
     # Shape 1 - Zod validation failure: { success: false, error: { name: "ZodError", issues: [...] } }
@@ -110,6 +175,15 @@ def parse_api_error(status_code: int, body: Any) -> NoReturn:
         error_obj = body["error"]
         if isinstance(error_obj, dict) and "code" in error_obj and "message" in error_obj:
             message = error_obj["message"]
+            # Route CAS mismatch to the typed error before the generic 409
+            # handling, so callers can catch CrystalVersionConflictError
+            # specifically (mirrors packages/sdk/src/errors.ts:201).
+            if status_code == 409 and error_obj["code"] == "OPERATION_VERSION_CONFLICT":
+                raise CrystalVersionConflictError(
+                    message,
+                    current_version=_extract_current_version(body, error_obj),
+                    details=body,
+                )
             details = error_obj.get("details")
             if isinstance(details, dict) and "issues" in details:
                 issues = details["issues"]
@@ -129,6 +203,14 @@ def parse_api_error(status_code: int, body: Any) -> NoReturn:
         if status_code == 404:
             raise NotFoundError(message)
         if status_code == 409:
+            # CAS mismatch is also a 409 — route it to the typed error before
+            # the SessionExistsError fallback so the two 409 cases stay distinct.
+            if body["code"] == "OPERATION_VERSION_CONFLICT":
+                raise CrystalVersionConflictError(
+                    message,
+                    current_version=_extract_current_version(body, None),
+                    details=body,
+                )
             raise SessionExistsError(message)
         if status_code == 500:
             raise InternalError(message)

--- a/packages/sdk-python/engram/errors.py
+++ b/packages/sdk-python/engram/errors.py
@@ -137,6 +137,10 @@ def _extract_current_version(body: Any, error_obj: Any) -> Optional[int]:
     live at the top level (``{ currentVersion }``) or nested under the error
     object's ``details`` (``{ error: { details: { currentVersion } } }``).
     Returns ``None`` if absent so the error still surfaces, just without the hint.
+
+    Crystal versions are monotonic non-negative integers, so a negative value
+    is a malformed server response — treat it as absent (return ``None``) rather
+    than handing back a nonsensical "current version" a retry would build on.
     """
     candidates: list[Any] = []
     if isinstance(error_obj, dict):
@@ -150,7 +154,9 @@ def _extract_current_version(body: Any, error_obj: Any) -> Optional[int]:
         if isinstance(details, dict):
             candidates.append(details.get("currentVersion"))
     for value in candidates:
-        if isinstance(value, int):
+        # ``bool`` is an ``int`` subclass — exclude it so ``True``/``False`` from
+        # a malformed body never masquerade as version 1/0.
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
             return value
     return None
 

--- a/packages/sdk-python/engram/resources/__init__.py
+++ b/packages/sdk-python/engram/resources/__init__.py
@@ -27,6 +27,7 @@ from engram.resources.events import EventsResource, SyncEventsResource, EventSub
 from engram.resources.export_import import ExportImportResource, SyncExportImportResource
 from engram.resources.entities import EntitiesResource, SyncEntitiesResource
 from engram.resources.extraction import ExtractionResource, SyncExtractionResource
+from engram.resources.maintenance import MaintenanceResource, SyncMaintenanceResource
 
 __all__ = [
     "SessionsResource", "SyncSessionsResource",
@@ -51,4 +52,5 @@ __all__ = [
     "ExportImportResource", "SyncExportImportResource",
     "EntitiesResource", "SyncEntitiesResource",
     "ExtractionResource", "SyncExtractionResource",
+    "MaintenanceResource", "SyncMaintenanceResource",
 ]

--- a/packages/sdk-python/engram/resources/maintenance.py
+++ b/packages/sdk-python/engram/resources/maintenance.py
@@ -17,7 +17,6 @@ fields.
 from __future__ import annotations
 
 from typing import Any, Optional, TYPE_CHECKING
-from urllib.parse import urlencode
 
 from engram._base import BaseResource, SyncBaseResource
 from engram.errors import EngramError
@@ -33,6 +32,38 @@ if TYPE_CHECKING:
     from engram.client import AsyncEngramClient, EngramClient
 
 
+# Cap the body excerpt embedded in a contract-drift error so we never dump an
+# unbounded (or sensitive-payload-sized) response into a log line or traceback.
+_BODY_EXCERPT_MAX = 200
+
+
+def _truncate_body(body: Any) -> str:
+    """Render a short, repr-safe excerpt of an unexpected response body.
+
+    Keeps just enough of the actual body to diagnose a contract drift (e.g. a
+    ``{ data }`` wrap, an HTML error page, a ``null``) without dumping an
+    unbounded payload. Uses ``repr`` so control characters can't corrupt the
+    surrounding message, and hard-caps the length.
+    """
+    text = repr(body)
+    if len(text) > _BODY_EXCERPT_MAX:
+        return text[:_BODY_EXCERPT_MAX] + "...(truncated)"
+    return text
+
+
+def _vacuum_query_params(params: Optional[VacuumParams]) -> Optional[dict[str, str]]:
+    """Build the vacuum query params, dropping ``None``/falsey values.
+
+    Returns a mapping httpx serializes itself (so encoding stays consistent and
+    new params can be added here without hand-rolling more string concat), or
+    ``None`` when there is nothing to send. Mirrors the TS SDK's
+    ``URLSearchParams`` shaping in packages/sdk/src/resources/maintenance.ts.
+    """
+    if params and params.full:
+        return {"full": "true"}
+    return None
+
+
 def _require_bare_object(path: str, body: Any, expected: str) -> dict:
     """Assert a bare (non-enveloped) maintenance body and return it.
 
@@ -40,11 +71,13 @@ def _require_bare_object(path: str, body: Any, expected: str) -> dict:
     standard ``{ data }`` envelope (an older server / contract drift). The
     explicit ``data``-wrap check is what catches a server that has NOT migrated
     to the bare-body contract — otherwise ``model_validate`` would raise a less
-    actionable pydantic error.
+    actionable pydantic error. The raised error embeds a truncated excerpt of
+    the actual body so the drift is diagnosable without a packet capture.
     """
     if not isinstance(body, dict) or "data" in body:
         raise EngramError(
-            f"Unexpected POST {path} response shape (expected a bare {expected})",
+            f"Unexpected POST {path} response shape (expected a bare {expected}); "
+            f"got: {_truncate_body(body)}",
             code="INTERNAL_ERROR",
         )
     return body
@@ -111,10 +144,11 @@ class MaintenanceResource(BaseResource):
         Requires engram-server >= 0.34.0 (engram-server#766). Against older
         servers the route does not exist and the call fails with a 404.
         """
-        query = ""
-        if params and params.full:
-            query = "?" + urlencode({"full": "true"})
-        response = await self._request("POST", f"/v1/maintenance/vacuum{query}")
+        response = await self._request(
+            "POST",
+            "/v1/maintenance/vacuum",
+            params=_vacuum_query_params(params),
+        )
         bare = _require_bare_object(
             "/v1/maintenance/vacuum",
             response,
@@ -157,10 +191,11 @@ class SyncMaintenanceResource(SyncBaseResource):
 
         See :meth:`MaintenanceResource.vacuum`. Requires engram-server >= 0.34.0.
         """
-        query = ""
-        if params and params.full:
-            query = "?" + urlencode({"full": "true"})
-        response = self._request("POST", f"/v1/maintenance/vacuum{query}")
+        response = self._request(
+            "POST",
+            "/v1/maintenance/vacuum",
+            params=_vacuum_query_params(params),
+        )
         bare = _require_bare_object(
             "/v1/maintenance/vacuum",
             response,

--- a/packages/sdk-python/engram/resources/maintenance.py
+++ b/packages/sdk-python/engram/resources/maintenance.py
@@ -1,0 +1,169 @@
+"""Maintenance resource for the Engram SDK.
+
+Resource-based interface for server maintenance operations: tombstone cleanup,
+changelog compaction, and tombstone-table vacuum, all with dry-run support
+where applicable.
+
+Mirrors the TypeScript SDK's ``MaintenanceResource``
+(``packages/sdk/src/resources/maintenance.ts``).
+
+These endpoints return **bare** response bodies (not the standard ``{ data }``
+envelope) as of engram-server 0.34 / ADR-022. Each method validates the bare
+shape and raises :class:`~engram.errors.EngramError` (code ``INTERNAL_ERROR``)
+on a contract drift, so a regression — or an older server still wrapping in
+``{ data }`` — fails loudly instead of returning a model with ``undefined``
+fields.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional, TYPE_CHECKING
+from urllib.parse import urlencode
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.errors import EngramError
+from engram.types.maintenance import (
+    ChangelogCompactResult,
+    MaintenanceParams,
+    TombstoneCleanupResult,
+    VacuumParams,
+    VacuumResult,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _require_bare_object(path: str, body: Any, expected: str) -> dict:
+    """Assert a bare (non-enveloped) maintenance body and return it.
+
+    Raises if the body is missing, not a dict, or has been wrapped in the
+    standard ``{ data }`` envelope (an older server / contract drift). The
+    explicit ``data``-wrap check is what catches a server that has NOT migrated
+    to the bare-body contract — otherwise ``model_validate`` would raise a less
+    actionable pydantic error.
+    """
+    if not isinstance(body, dict) or "data" in body:
+        raise EngramError(
+            f"Unexpected POST {path} response shape (expected a bare {expected})",
+            code="INTERNAL_ERROR",
+        )
+    return body
+
+
+class MaintenanceResource(BaseResource):
+    """Async resource for server maintenance and cleanup operations.
+
+    Example::
+
+        # Dry-run tombstone cleanup
+        preview = await client.maintenance.tombstone_cleanup(
+            MaintenanceParams(days=30, dry_run=True)
+        )
+
+        # Run changelog compaction
+        result = await client.maintenance.changelog_compact(
+            MaintenanceParams(days=90)
+        )
+
+        # Reclaim dead-tuple space (requires engram-server >= 0.34.0)
+        vac = await client.maintenance.vacuum()
+    """
+
+    async def tombstone_cleanup(
+        self, params: Optional[MaintenanceParams] = None
+    ) -> TombstoneCleanupResult:
+        """Clean up soft-deleted (tombstoned) records older than ``days``."""
+        body = params.model_dump(by_alias=True, exclude_none=True) if params else None
+        response = await self._request(
+            "POST", "/v1/maintenance/tombstone-cleanup", body
+        )
+        bare = _require_bare_object(
+            "/v1/maintenance/tombstone-cleanup",
+            response,
+            "{ deleted, warnings, dryRun }",
+        )
+        return TombstoneCleanupResult.model_validate(bare)
+
+    async def changelog_compact(
+        self, params: Optional[MaintenanceParams] = None
+    ) -> ChangelogCompactResult:
+        """Compact the changelog, removing entries older than ``days``."""
+        body = params.model_dump(by_alias=True, exclude_none=True) if params else None
+        response = await self._request(
+            "POST", "/v1/maintenance/changelog-compact", body
+        )
+        bare = _require_bare_object(
+            "/v1/maintenance/changelog-compact",
+            response,
+            "{ deleted, belowSeq, dryRun }",
+        )
+        return ChangelogCompactResult.model_validate(bare)
+
+    async def vacuum(self, params: Optional[VacuumParams] = None) -> VacuumResult:
+        """Reclaim physical space on the tombstone tables after bulk hard-deletes.
+
+        Pair with :meth:`tombstone_cleanup`: that hard-deletes rows, this returns
+        the dead-tuple space. Pass ``VacuumParams(full=True)`` to run
+        ``VACUUM FULL`` — shrinks the database on disk but takes an ``ACCESS
+        EXCLUSIVE`` lock and **requires an admin API key** (403 otherwise). A
+        ``VACUUM FULL`` already in progress surfaces as a 409.
+
+        Requires engram-server >= 0.34.0 (engram-server#766). Against older
+        servers the route does not exist and the call fails with a 404.
+        """
+        query = ""
+        if params and params.full:
+            query = "?" + urlencode({"full": "true"})
+        response = await self._request("POST", f"/v1/maintenance/vacuum{query}")
+        bare = _require_bare_object(
+            "/v1/maintenance/vacuum",
+            response,
+            "{ vacuumed: string[], full: boolean }",
+        )
+        return VacuumResult.model_validate(bare)
+
+
+class SyncMaintenanceResource(SyncBaseResource):
+    """Sync resource for server maintenance and cleanup operations."""
+
+    def tombstone_cleanup(
+        self, params: Optional[MaintenanceParams] = None
+    ) -> TombstoneCleanupResult:
+        """Clean up soft-deleted (tombstoned) records older than ``days``."""
+        body = params.model_dump(by_alias=True, exclude_none=True) if params else None
+        response = self._request("POST", "/v1/maintenance/tombstone-cleanup", body)
+        bare = _require_bare_object(
+            "/v1/maintenance/tombstone-cleanup",
+            response,
+            "{ deleted, warnings, dryRun }",
+        )
+        return TombstoneCleanupResult.model_validate(bare)
+
+    def changelog_compact(
+        self, params: Optional[MaintenanceParams] = None
+    ) -> ChangelogCompactResult:
+        """Compact the changelog, removing entries older than ``days``."""
+        body = params.model_dump(by_alias=True, exclude_none=True) if params else None
+        response = self._request("POST", "/v1/maintenance/changelog-compact", body)
+        bare = _require_bare_object(
+            "/v1/maintenance/changelog-compact",
+            response,
+            "{ deleted, belowSeq, dryRun }",
+        )
+        return ChangelogCompactResult.model_validate(bare)
+
+    def vacuum(self, params: Optional[VacuumParams] = None) -> VacuumResult:
+        """Reclaim physical space on the tombstone tables after bulk hard-deletes.
+
+        See :meth:`MaintenanceResource.vacuum`. Requires engram-server >= 0.34.0.
+        """
+        query = ""
+        if params and params.full:
+            query = "?" + urlencode({"full": "true"})
+        response = self._request("POST", f"/v1/maintenance/vacuum{query}")
+        bare = _require_bare_object(
+            "/v1/maintenance/vacuum",
+            response,
+            "{ vacuumed: string[], full: boolean }",
+        )
+        return VacuumResult.model_validate(bare)

--- a/packages/sdk-python/engram/types/knowledge_crystal.py
+++ b/packages/sdk-python/engram/types/knowledge_crystal.py
@@ -273,6 +273,19 @@ class CreateKnowledgeCrystalParams(BaseModel):
     source_session_id: Optional[str] = None
     source_project: Optional[str] = None
     path: Optional[str] = None
+    skip_embedding: Optional[bool] = None
+    """When ``True``, the server creates the crystal without generating its
+    embedding inline; a background worker drains the pending-embedding backlog
+    afterwards. Until then the crystal's ``embedding_status`` stays ``pending``
+    and it will not surface in vector search.
+
+    Serializes to the wire field ``skipEmbedding``. Requires engram-server
+    >= 0.34.0 (engram-server#763). Older servers silently ignore the field and
+    generate the embedding inline — the optimization is a no-op, correctness is
+    unaffected. Call ``client.check_server_compatibility()`` to verify at
+    runtime. To keep the normal inline-embedding behavior, **omit this field**
+    (leave it ``None``).
+    """
 
 
 class UpdateKnowledgeCrystalParams(BaseModel):
@@ -296,6 +309,36 @@ class UpdateKnowledgeCrystalParams(BaseModel):
     source_project: Optional[str] = None
     version: Optional[int] = None
     path: Optional[str] = None
+    expected_version: Optional[int] = None
+    """Optimistic-concurrency check. When set, the update succeeds only if the
+    crystal's current ``version`` equals this value. On mismatch the server
+    responds with HTTP 409 + error code ``OPERATION_VERSION_CONFLICT``, surfaced
+    by the SDK as :class:`~engram.errors.CrystalVersionConflictError` carrying
+    the current server-reported version. When absent, the update proceeds
+    unconditionally (backward compatible).
+
+    Serializes to the wire field ``expectedVersion``. Requires an engram-server
+    with CAS support on ``PATCH /crystals/:id`` (>= 0.30.0). Older servers
+    silently ignore the field.
+    """
+    skip_embedding: Optional[bool] = None
+    """When ``True``, the server commits this update without regenerating the
+    crystal's embedding. The persisted embedding stays at its previous value, so
+    subsequent semantic search returns the (now-stale) prior content. Use only
+    for fields where the embedding is **meaningless** for search (heartbeats,
+    counters, status flags); misuse on content-bearing fields silently degrades
+    search quality without an error.
+
+    Composes with ``expected_version``: a single update may set both. CAS
+    remains enforced; embedding is still skipped on success.
+
+    Serializes to the wire field ``skipEmbedding``. Requires engram-server
+    >= 0.31.0 (engram-server#65). Older servers silently ignore the field and
+    regenerate the embedding — a no-op against older servers, correctness
+    unaffected. An explicit ``False`` is sent on the wire (an explicit caller
+    signal); omitting the field (leaving it ``None``) is the documented idiom
+    for keeping the normal regenerate-embedding behavior.
+    """
 
 
 class ListKnowledgeCrystalsParams(BaseModel):

--- a/packages/sdk-python/engram/types/maintenance.py
+++ b/packages/sdk-python/engram/types/maintenance.py
@@ -1,0 +1,82 @@
+"""Maintenance operation types for the Engram SDK.
+
+Mirrors the TypeScript SDK's maintenance types
+(``packages/sdk/src/resources/maintenance.ts``).
+
+The maintenance endpoints return **bare** response bodies (not wrapped in the
+standard ``{ data }`` envelope) as of engram-server 0.34 / ADR-022. The
+resource parses these bodies directly rather than unwrapping ``data``.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "MaintenanceParams",
+    "VacuumParams",
+    "TombstoneCleanupResult",
+    "ChangelogCompactResult",
+    "VacuumResult",
+]
+
+
+class MaintenanceParams(BaseModel):
+    """Parameters for tombstone-cleanup and changelog-compact operations."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    days: Optional[int] = None
+    dry_run: Optional[bool] = None
+
+
+class VacuumParams(BaseModel):
+    """Parameters for the vacuum operation.
+
+    When ``full`` is ``True``, runs ``VACUUM (FULL, ANALYZE)`` — rewrites each
+    tombstone table and shrinks the database on disk, but takes an ``ACCESS
+    EXCLUSIVE`` lock (blocks all access to that table for the duration). Run it
+    in a maintenance window. Requires an **admin** API key (a plain write key is
+    rejected with 403). When omitted/``False``, runs the non-blocking
+    ``VACUUM (ANALYZE)``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    full: Optional[bool] = None
+
+
+class TombstoneCleanupResult(BaseModel):
+    """Result of a tombstone-cleanup operation (bare, non-enveloped body)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    deleted: int
+    warnings: List[str]
+    dry_run: bool
+
+
+class ChangelogCompactResult(BaseModel):
+    """Result of a changelog-compact operation (bare, non-enveloped body)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    deleted: int
+    below_seq: Optional[str] = None
+    dry_run: bool
+    reason: Optional[str] = None
+
+
+class VacuumResult(BaseModel):
+    """Result of a vacuum operation (bare, non-enveloped body).
+
+    Requires engram-server >= 0.34.0 (engram-server#766). Against older servers
+    the route does not exist and the call fails with a 404.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    vacuumed: List[str]
+    full: bool

--- a/packages/sdk-python/tests/test_compatibility.py
+++ b/packages/sdk-python/tests/test_compatibility.py
@@ -32,6 +32,26 @@ class TestIsVersionGte:
         assert _is_version_gte("unknown", "0.31.0") is False
         assert _is_version_gte("", "0.31.0") is False
 
+    def test_prerelease_and_build_metadata_fail_closed(self):
+        # Pre-release / build-metadata suffixes (common in dev builds) are not
+        # plain ``major.minor.patch`` integers, so the parser cannot order them.
+        # We fail closed (treat as incompatible) rather than guess — matching the
+        # TS SDK, which only parses the numeric triple.
+        assert _is_version_gte("0.31.0-alpha", "0.31.0") is False
+        assert _is_version_gte("0.34.0-rc.1", "0.31.0") is False
+        assert _is_version_gte("0.31.0+build123", "0.31.0") is False
+        assert _is_version_gte("0.31.x", "0.31.0") is False
+
+    def test_unparseable_segment_logs_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="engram"):
+            assert _is_version_gte("0.31.0-alpha", "0.31.0") is False
+        # The format issue must surface in logs, not be silently swallowed.
+        assert any(
+            "unparseable version segment" in rec.message for rec in caplog.records
+        )
+
 
 class TestSyncCheckServerCompatibility:
     def setup_method(self):

--- a/packages/sdk-python/tests/test_compatibility.py
+++ b/packages/sdk-python/tests/test_compatibility.py
@@ -1,0 +1,108 @@
+"""Tests for server-version compatibility checking.
+
+Mirrors ``EngramClient.checkCompatibility`` in packages/sdk/src/client.ts: the
+method calls ``/health``, reads ``version``, and reports compatibility against
+``MIN_SERVER_VERSION`` (0.31.0). Like the TS SDK it returns a result object
+rather than raising — a below-floor server reports ``compatible=False`` so the
+caller decides how to react (P11: surface the uncertainty, do not hide it).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import MIN_SERVER_VERSION, AsyncEngramClient, EngramClient, _is_version_gte
+
+
+class TestIsVersionGte:
+    def test_equal_versions(self):
+        assert _is_version_gte("0.31.0", "0.31.0") is True
+
+    def test_above_floor(self):
+        assert _is_version_gte("0.34.0", "0.31.0") is True
+        assert _is_version_gte("1.0.0", "0.31.0") is True
+
+    def test_below_floor(self):
+        assert _is_version_gte("0.30.9", "0.31.0") is False
+        assert _is_version_gte("0.30.0", "0.31.0") is False
+
+    def test_unparseable_fails_closed(self):
+        assert _is_version_gte("unknown", "0.31.0") is False
+        assert _is_version_gte("", "0.31.0") is False
+
+
+class TestSyncCheckServerCompatibility:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_compatible_server(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"version": "0.34.0", "status": "ok"},
+            request=httpx.Request("GET", "http://test:3100/health"),
+        )
+
+        result = self.client.check_server_compatibility()
+
+        assert result["compatible"] is True
+        assert result["server_version"] == "0.34.0"
+        assert result["min_required"] == MIN_SERVER_VERSION
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/health"
+
+    @patch.object(httpx.Client, "request")
+    def test_below_floor_server_is_incompatible(self, mock_request):
+        # The acceptance bar: a /health below 0.31.0 must report incompatible.
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"version": "0.30.0", "status": "ok"},
+            request=httpx.Request("GET", "http://test:3100/health"),
+        )
+
+        result = self.client.check_server_compatibility()
+
+        assert result["compatible"] is False
+        assert result["server_version"] == "0.30.0"
+
+    @patch.object(httpx.Client, "request")
+    def test_missing_version_is_incompatible(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"status": "ok"},
+            request=httpx.Request("GET", "http://test:3100/health"),
+        )
+
+        result = self.client.check_server_compatibility()
+
+        assert result["compatible"] is False
+        assert result["server_version"] == "unknown"
+
+
+class TestAsyncCheckServerCompatibility:
+    @pytest.mark.asyncio
+    async def test_async_below_floor_incompatible(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json={"version": "0.30.0"},
+                        request=httpx.Request("GET", "http://test:3100/health"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await client.check_server_compatibility()
+                assert result["compatible"] is False
+                assert result["server_version"] == "0.30.0"
+                call_args = mock_request.call_args
+                assert call_args[0][1] == "/health"
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_crystal_cas.py
+++ b/packages/sdk-python/tests/test_crystal_cas.py
@@ -71,6 +71,31 @@ class TestParseCasConflict:
         err = CrystalVersionConflictError("x", current_version=2)
         assert isinstance(err, EngramError)
 
+    def test_negative_current_version_is_dropped(self):
+        # Crystal versions are monotonic non-negative ints. A malformed body
+        # reporting a negative version must surface as ``None`` (absent hint),
+        # not a nonsensical value a retry would build on.
+        body = {
+            "code": "OPERATION_VERSION_CONFLICT",
+            "message": "mismatch",
+            "currentVersion": -1,
+        }
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            parse_api_error(409, body)
+        assert exc_info.value.current_version is None
+
+    def test_boolean_current_version_is_dropped(self):
+        # ``bool`` is an ``int`` subclass; a stray ``true`` must not masquerade
+        # as version 1.
+        body = {
+            "code": "OPERATION_VERSION_CONFLICT",
+            "message": "mismatch",
+            "currentVersion": True,
+        }
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            parse_api_error(409, body)
+        assert exc_info.value.current_version is None
+
 
 class TestCrystalUpdateCasWire:
     def setup_method(self):
@@ -140,6 +165,69 @@ class TestCrystalUpdateCasWire:
         )
         sent = mock_request.call_args[1]["json"]
         assert sent["skipEmbedding"] is False
+
+    @patch.object(httpx.Client, "request")
+    def test_transient_5xx_during_cas_update_is_retried(self, mock_request):
+        # Counterpart to the 409 (non-retried) case: a transient 5xx during a
+        # CAS update IS retried per the client's retry policy, and the
+        # expectedVersion is preserved across the retry so the second attempt
+        # carries the same CAS guard.
+        client = EngramClient(base_url="http://test:3100", retry_delay=0, retries=3)
+        try:
+            updated = {**SAMPLE_CRYSTAL, "title": "New"}
+            mock_request.side_effect = [
+                httpx.Response(
+                    503,
+                    json={"code": "INTERNAL_ERROR", "message": "temporarily down"},
+                    request=httpx.Request(
+                        "PATCH", "http://test:3100/v1/crystals/crystal-201"
+                    ),
+                ),
+                httpx.Response(
+                    200,
+                    json=make_api_response(updated),
+                    request=httpx.Request(
+                        "PATCH", "http://test:3100/v1/crystals/crystal-201"
+                    ),
+                ),
+            ]
+
+            result = client.crystals.update(
+                "crystal-201",
+                UpdateKnowledgeCrystalParams(title="New", expected_version=3),
+            )
+
+            assert result.title == "New"
+            # Retried exactly once (two total attempts).
+            assert mock_request.call_count == 2
+            # expectedVersion survives the retry.
+            assert mock_request.call_args[1]["json"]["expectedVersion"] == 3
+        finally:
+            client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_transient_5xx_exhausts_retries_then_raises(self, mock_request):
+        # If the 5xx persists, the client raises after exhausting retries (it
+        # does not silently return a partial result).
+        client = EngramClient(base_url="http://test:3100", retry_delay=0, retries=3)
+        try:
+            mock_request.return_value = httpx.Response(
+                503,
+                json={"code": "INTERNAL_ERROR", "message": "still down"},
+                request=httpx.Request(
+                    "PATCH", "http://test:3100/v1/crystals/crystal-201"
+                ),
+            )
+
+            with pytest.raises(EngramError) as exc_info:
+                client.crystals.update(
+                    "crystal-201",
+                    UpdateKnowledgeCrystalParams(title="New", expected_version=3),
+                )
+            assert exc_info.value.status_code == 503
+            assert mock_request.call_count == 3
+        finally:
+            client.close()
 
     @patch.object(httpx.Client, "request")
     def test_create_serializes_skip_embedding(self, mock_request):

--- a/packages/sdk-python/tests/test_crystal_cas.py
+++ b/packages/sdk-python/tests/test_crystal_cas.py
@@ -1,0 +1,159 @@
+"""Tests for crystal optimistic-concurrency (CAS) — expected_version / 409.
+
+Mirrors the TS SDK semantics (packages/sdk/src/errors.ts:197): a 409 carrying
+error code ``OPERATION_VERSION_CONFLICT`` is routed to the typed
+``CrystalVersionConflictError`` (carrying the server-reported current version),
+distinct from the generic 409 ``SessionExistsError``. Also pins that
+``expected_version`` and ``skip_embedding`` serialize to the wire fields the
+server expects (``expectedVersion`` / ``skipEmbedding``).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import EngramClient
+from engram.errors import (
+    CrystalVersionConflictError,
+    EngramError,
+    SessionExistsError,
+    parse_api_error,
+)
+from engram.types.knowledge_crystal import (
+    CreateKnowledgeCrystalParams,
+    UpdateKnowledgeCrystalParams,
+)
+from tests.conftest import SAMPLE_CRYSTAL, make_api_response
+
+
+class TestParseCasConflict:
+    def test_flat_409_conflict_raises_typed_error(self):
+        body = {
+            "code": "OPERATION_VERSION_CONFLICT",
+            "message": "version mismatch",
+            "currentVersion": 7,
+        }
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            parse_api_error(409, body)
+        err = exc_info.value
+        assert err.current_version == 7
+        assert err.code == "OPERATION_VERSION_CONFLICT"
+        assert err.status_code == 409
+
+    def test_nested_409_conflict_raises_typed_error(self):
+        body = {
+            "error": {
+                "code": "OPERATION_VERSION_CONFLICT",
+                "message": "version mismatch",
+                "details": {"currentVersion": 9},
+            }
+        }
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            parse_api_error(409, body)
+        assert exc_info.value.current_version == 9
+
+    def test_conflict_without_current_version_still_typed(self):
+        body = {"code": "OPERATION_VERSION_CONFLICT", "message": "mismatch"}
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            parse_api_error(409, body)
+        assert exc_info.value.current_version is None
+
+    def test_generic_409_still_session_exists(self):
+        # A non-CAS 409 must remain the generic SessionExistsError so the two
+        # 409 cases stay distinguishable.
+        body = {"code": "SESSION_EXISTS", "message": "already exists"}
+        with pytest.raises(SessionExistsError):
+            parse_api_error(409, body)
+
+    def test_conflict_is_subclass_of_engram_error(self):
+        err = CrystalVersionConflictError("x", current_version=2)
+        assert isinstance(err, EngramError)
+
+
+class TestCrystalUpdateCasWire:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_update_serializes_expected_version_and_skip_embedding(self, mock_request):
+        updated = {**SAMPLE_CRYSTAL, "title": "New"}
+        mock_request.return_value = httpx.Response(
+            200,
+            json=make_api_response(updated),
+            request=httpx.Request("PATCH", "http://test:3100/v1/crystals/crystal-201"),
+        )
+
+        self.client.crystals.update(
+            "crystal-201",
+            UpdateKnowledgeCrystalParams(
+                title="New", expected_version=3, skip_embedding=True
+            ),
+        )
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "PATCH"
+        assert call_args[0][1] == "/v1/crystals/crystal-201"
+        sent = call_args[1]["json"]
+        assert sent["expectedVersion"] == 3
+        assert sent["skipEmbedding"] is True
+        assert sent["title"] == "New"
+
+    @patch.object(httpx.Client, "request")
+    def test_update_with_conflict_raises_typed_error(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            409,
+            json={
+                "code": "OPERATION_VERSION_CONFLICT",
+                "message": "version mismatch",
+                "currentVersion": 5,
+            },
+            request=httpx.Request("PATCH", "http://test:3100/v1/crystals/crystal-201"),
+        )
+
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            self.client.crystals.update(
+                "crystal-201",
+                UpdateKnowledgeCrystalParams(title="New", expected_version=3),
+            )
+        assert exc_info.value.current_version == 5
+        # A 4xx must NOT be retried — exactly one fetch attempt.
+        mock_request.assert_called_once()
+
+    @patch.object(httpx.Client, "request")
+    def test_explicit_skip_embedding_false_is_sent(self, mock_request):
+        # Mirrors TS: an explicit `false` is forwarded on the wire (an explicit
+        # caller signal), while omitting the field (None) drops it.
+        mock_request.return_value = httpx.Response(
+            200,
+            json=make_api_response(SAMPLE_CRYSTAL),
+            request=httpx.Request("PATCH", "http://test:3100/v1/crystals/crystal-201"),
+        )
+
+        self.client.crystals.update(
+            "crystal-201",
+            UpdateKnowledgeCrystalParams(title="New", skip_embedding=False),
+        )
+        sent = mock_request.call_args[1]["json"]
+        assert sent["skipEmbedding"] is False
+
+    @patch.object(httpx.Client, "request")
+    def test_create_serializes_skip_embedding(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=make_api_response(SAMPLE_CRYSTAL),
+            request=httpx.Request("POST", "http://test:3100/v1/crystals"),
+        )
+
+        self.client.crystals.create(
+            CreateKnowledgeCrystalParams(
+                node_type="note", title="t", skip_embedding=True
+            )
+        )
+        sent = mock_request.call_args[1]["json"]
+        assert sent["skipEmbedding"] is True
+        assert sent["nodeType"] == "note"

--- a/packages/sdk-python/tests/test_maintenance.py
+++ b/packages/sdk-python/tests/test_maintenance.py
@@ -106,7 +106,29 @@ class TestSyncMaintenanceResource:
 
         assert result.full is True
         call_args = mock_request.call_args
-        assert call_args[0][1] == "/v1/maintenance/vacuum?full=true"
+        # The path stays bare; ``full=true`` is passed via httpx's params so the
+        # encoding is handled centrally (not hand-concatenated into the path).
+        assert call_args[0][1] == "/v1/maintenance/vacuum"
+        assert call_args[1]["params"] == {"full": "true"}
+
+    @patch.object(httpx.Client, "request")
+    def test_vacuum_default_sends_no_query_params(self, mock_request):
+        # No VacuumParams (or full=False) must not send a ``full`` query param —
+        # the helper drops falsey/None values rather than emitting ``full=false``.
+        mock_request.return_value = httpx.Response(
+            200,
+            json=BARE_VACUUM,
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum"),
+        )
+
+        self.client.maintenance.vacuum()
+
+        # When there's nothing to send, no ``params`` reaches httpx at all.
+        assert "params" not in mock_request.call_args[1]
+
+        self.client.maintenance.vacuum(VacuumParams(full=False))
+
+        assert "params" not in mock_request.call_args[1]
 
     @patch.object(httpx.Client, "request")
     def test_vacuum_rejects_enveloped_body(self, mock_request):
@@ -122,6 +144,26 @@ class TestSyncMaintenanceResource:
         with pytest.raises(EngramError) as exc_info:
             self.client.maintenance.vacuum()
         assert exc_info.value.code == "INTERNAL_ERROR"
+        # The drift error embeds a (truncated) excerpt of the actual body so the
+        # mismatch is diagnosable without a packet capture.
+        assert "data" in str(exc_info.value)
+
+    @patch.object(httpx.Client, "request")
+    def test_contract_drift_error_truncates_oversized_body(self, mock_request):
+        # A huge unexpected body must not be dumped verbatim into the error.
+        oversized = {"data": {"junk": "x" * 5000}}
+        mock_request.return_value = httpx.Response(
+            200,
+            json=oversized,
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum"),
+        )
+
+        with pytest.raises(EngramError) as exc_info:
+            self.client.maintenance.vacuum()
+        message = str(exc_info.value)
+        assert "(truncated)" in message
+        # The full 5000-char payload must not leak into the message.
+        assert "x" * 5000 not in message
 
     @patch.object(httpx.Client, "request")
     def test_tombstone_cleanup_rejects_enveloped_body(self, mock_request):

--- a/packages/sdk-python/tests/test_maintenance.py
+++ b/packages/sdk-python/tests/test_maintenance.py
@@ -1,0 +1,179 @@
+"""Tests for the maintenance resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body and
+response parsing for the BARE (non-enveloped) maintenance response bodies. The
+maintenance endpoints return bare objects as of engram-server 0.34 / ADR-022,
+so the resource must NOT unwrap a ``data`` envelope — these tests pin that.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.errors import EngramError
+from engram.types.maintenance import (
+    ChangelogCompactResult,
+    MaintenanceParams,
+    TombstoneCleanupResult,
+    VacuumParams,
+    VacuumResult,
+)
+
+
+# Bare (non-enveloped) response bodies — the server does NOT wrap these in
+# { data: ... } as of engram-server 0.34 (ADR-022).
+BARE_TOMBSTONE = {"deleted": 5, "warnings": ["partial"], "dryRun": False}
+BARE_CHANGELOG = {"deleted": 12, "belowSeq": "abc123", "dryRun": True, "reason": "old"}
+BARE_VACUUM = {"vacuumed": ["tombstones_a", "tombstones_b"], "full": False}
+
+
+class TestSyncMaintenanceResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_tombstone_cleanup_parses_bare_body(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=BARE_TOMBSTONE,
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/tombstone-cleanup"),
+        )
+
+        result = self.client.maintenance.tombstone_cleanup(
+            MaintenanceParams(days=30, dry_run=False)
+        )
+
+        assert isinstance(result, TombstoneCleanupResult)
+        assert result.deleted == 5
+        assert result.warnings == ["partial"]
+        assert result.dry_run is False
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/maintenance/tombstone-cleanup"
+        assert call_args[1]["json"] == {"days": 30, "dryRun": False}
+
+    @patch.object(httpx.Client, "request")
+    def test_changelog_compact_parses_bare_body(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=BARE_CHANGELOG,
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/changelog-compact"),
+        )
+
+        result = self.client.maintenance.changelog_compact(MaintenanceParams(days=90))
+
+        assert isinstance(result, ChangelogCompactResult)
+        assert result.deleted == 12
+        assert result.below_seq == "abc123"
+        assert result.dry_run is True
+        assert result.reason == "old"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/maintenance/changelog-compact"
+
+    @patch.object(httpx.Client, "request")
+    def test_vacuum_parses_bare_body(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=BARE_VACUUM,
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum"),
+        )
+
+        result = self.client.maintenance.vacuum()
+
+        assert isinstance(result, VacuumResult)
+        assert result.vacuumed == ["tombstones_a", "tombstones_b"]
+        assert result.full is False
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/maintenance/vacuum"
+
+    @patch.object(httpx.Client, "request")
+    def test_vacuum_full_sets_query_param(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"vacuumed": ["t"], "full": True},
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum?full=true"),
+        )
+
+        result = self.client.maintenance.vacuum(VacuumParams(full=True))
+
+        assert result.full is True
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/maintenance/vacuum?full=true"
+
+    @patch.object(httpx.Client, "request")
+    def test_vacuum_rejects_enveloped_body(self, mock_request):
+        # An older server (or a contract regression) that wraps the result in
+        # the standard { data } envelope must fail loudly, not silently return
+        # a model with missing fields.
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": BARE_VACUUM},
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum"),
+        )
+
+        with pytest.raises(EngramError) as exc_info:
+            self.client.maintenance.vacuum()
+        assert exc_info.value.code == "INTERNAL_ERROR"
+
+    @patch.object(httpx.Client, "request")
+    def test_tombstone_cleanup_rejects_enveloped_body(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": BARE_TOMBSTONE},
+            request=httpx.Request("POST", "http://test:3100/v1/maintenance/tombstone-cleanup"),
+        )
+
+        with pytest.raises(EngramError) as exc_info:
+            self.client.maintenance.tombstone_cleanup()
+        assert exc_info.value.code == "INTERNAL_ERROR"
+
+
+class TestAsyncMaintenanceResource:
+    @pytest.mark.asyncio
+    async def test_async_vacuum_parses_bare_body(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=BARE_VACUUM,
+                        request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await client.maintenance.vacuum()
+                assert isinstance(result, VacuumResult)
+                assert result.vacuumed == ["tombstones_a", "tombstones_b"]
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "POST"
+                assert call_args[0][1] == "/v1/maintenance/vacuum"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_vacuum_rejects_enveloped_body(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json={"data": BARE_VACUUM},
+                        request=httpx.Request("POST", "http://test:3100/v1/maintenance/vacuum"),
+                    )
+
+                mock_request.side_effect = _resp
+                with pytest.raises(EngramError) as exc_info:
+                    await client.maintenance.vacuum()
+                assert exc_info.value.code == "INTERNAL_ERROR"
+        finally:
+            await client.close()

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Run the sdk-python core unit suite for the `make python-test` gate.
+#
+# Self-contained: creates packages/sdk-python/.venv on first run (gitignored)
+# and installs the package in editable mode with its dev extras. Runs only the
+# core unit suite — mocked transport, no live server — excluding:
+#   * integration-marked tests (require a live engram server)
+#   * the framework-example adapter tests (langchain/crewai/autogen), which
+#     exercise optional examples/ code, are not part of the SDK contract, and
+#     are red on a clean checkout regardless of this gate.
+#
+# Mirrors the TS resource-test discipline: the suite asserts request
+# path/method/body and response parsing for enveloped AND bare shapes.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_DIR="$REPO_ROOT/packages/sdk-python"
+VENV="$PKG_DIR/.venv"
+PY="$VENV/bin/python"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if [ ! -x "$PY" ]; then
+  echo "→ creating sdk-python venv at $VENV"
+  "$PYTHON_BIN" -m venv "$VENV"
+  "$PY" -m pip install --quiet --upgrade pip
+fi
+
+# Install (idempotent — pip is a no-op when already satisfied).
+"$PY" -m pip install --quiet -e "$PKG_DIR[dev]"
+
+cd "$PKG_DIR"
+exec "$PY" -m pytest \
+  -m "not integration" \
+  --ignore=tests/test_integration_crewai.py \
+  --ignore=tests/test_integration_langchain.py \
+  --ignore=tests/test_integration_autogen.py \
+  "$@"


### PR DESCRIPTION
## Summary

Initiative 3 of `docs/plans/2026-06-12-next-stage.md` — bring `sdk-python` back toward the 0.34.0 server contract, and (most urgently, per P11) stop the package from claiming parity it lost when `@centient/sdk` went 1.7.1 → 2.0.0.

**Phase A — stop lying.** The stale `"Full API parity"` claim is replaced by an explicit **support matrix** (resource × supported?) in both README and CHANGELOG. The historical 1.0.0 CHANGELOG claim now carries a correction note. No unqualified full-api-parity claim survives a case-insensitive grep (remaining hits are the negation in the README, the two correction notes, and the historical line that the correction note directly precedes).

**Phase B — 0.34.0 core.**
- `expected_version` + `skip_embedding` on crystal create/update params, mirroring TS semantics including the server-floor caveats. An explicit `skip_embedding=False` is sent on the wire (explicit caller signal); `None` omits it — matching TS.
- `CrystalVersionConflictError` mapped from HTTP 409 `OPERATION_VERSION_CONFLICT` (both flat `{code,message}` and nested `{error:{...}}` shapes), carrying `current_version`, routed before the generic 409 `SessionExistsError`.
- `MaintenanceResource` / `SyncMaintenanceResource` (`client.maintenance`) with `vacuum()` / `tombstone_cleanup()` / `changelog_compact()` handling **bare** (non-enveloped) bodies; a wrapped `{ data }` body fails loudly with `INTERNAL_ERROR` (mirrors the loud-shape-guard in `packages/sdk/src/resources/maintenance.ts`).
- `MIN_SERVER_VERSION = "0.31.0"` + `check_server_compatibility()` mirroring `packages/sdk/src/client.ts:204` — calls `/health`, compares against the floor, fails closed on an unknown/below-floor version.

## Design notes

- **Wire serialization is automatic and verified.** The crystal params use `alias_generator=to_camel` + `exclude_none=True`, so `expected_version`/`skip_embedding` serialize to `expectedVersion`/`skipEmbedding`. Tests assert the exact sent body.
- **No `Math.random`/clock in core paths.** `_is_version_gte` is pure; compatibility reads the server's reported version.
- **Bare-body guard** rejects a `{ data }`-wrapped maintenance body explicitly, so an un-migrated/regressed server fails loudly rather than returning a model with missing fields.
- **pyproject stays `1.0.x`.** Phase C (sync resource + 6 remaining resources + 2.0.0-aligned version bump) is deferred per the spec. `sdk-python` has no `package.json`, so it is invisible to Changesets/pnpm workspaces — no JS changeset applies.

## Gate wiring (spec step 4)

- `scripts/run-python-tests.sh` auto-creates a **gitignored** `packages/sdk-python/.venv`, editable-installs the package + dev extras, and runs the **core** unit suite (`-m "not integration"`, excluding the three framework-example adapter tests which exercise optional `examples/` code and are red on a clean checkout regardless of this change).
- `make python-test` runs that script; it is wired into `make check`.
- **Merge-with-#87 caveat:** the Makefile on `origin/main` differs from the in-flight PR #87 that restructures the `publish` target. I touched **only** the `.PHONY`, the `check` dependency list, and the new `python-test` target lines — nothing in `publish` — to keep that merge trivial.

## Test evidence

`make check` green from the repo root:
- lint: **0 errors**
- vitest (TS): **1296 passed**, 14 skipped
- pytest (sdk-python): **538 passed**, 10 deselected (513 baseline + 25 new)
- claudemd-check: all package versions match, resource count 31

New tests (mocked transport, mirroring the TS resource-test discipline — assert path/method/body + parse enveloped AND bare shapes): `tests/test_maintenance.py`, `tests/test_compatibility.py`, `tests/test_crystal_cas.py`.

## Followups

- **Phase C** (next-stage spec Initiative 3, step 3): `SyncResource` (NDJSON push/pull, peers, conflicts) against the `{success,data}` envelopes, plus `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users`; then the 2.0.0-aligned version bump via the release procedure. Reference: `packages/sdk/src/resources/sync.ts`.
- The three framework-example integration tests (`langchain`/`crewai`/`autogen`) are pre-existing red on a clean checkout (Mock setup, not SDK code). Excluded from the gate; worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)