### PR TITLE
feat(sdk-python): Phase C — full @centient/sdk 2.1.0 parity + nested-envelope error fix (#117 sibling)

### DIFF
--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,34 +1,60 @@
 # Changelog
 
-## Unreleased
+## 2.1.0 (Phase B + C — full `@centient/sdk` 2.1.0 resource parity)
 
-### Parity correction — TypeScript SDK 2.0.0
+This release closes the parity gap with the TypeScript SDK: the version is now
+aligned to `@centient/sdk` 2.1.0, and every TS resource surface has a Python
+counterpart (or an explicit line in the support matrix saying why not).
 
-> **Correction.** Earlier releases of this CHANGELOG (the 1.0.0 entry below)
-> claimed *"Full API parity"* with the TypeScript SDK. That claim was true at
-> the time but went stale when `@centient/sdk` moved 1.7.1 → 2.0.0 underneath
-> this package. **There is no full-API-parity guarantee.** Parity is now tracked
-> explicitly in the support matrix below and in `README.md`. This package does
-> not claim parity it does not have.
-
-#### Support matrix (vs `@centient/sdk` 2.0.0)
+#### Support matrix (vs `@centient/sdk` 2.1.0)
 
 | TS SDK surface | Python? | Notes |
 |----------------|---------|-------|
 | Sessions, notes, scratch, coordination | yes | `client.sessions` and sub-resources |
 | Crystals (CRUD, search, ACL, share, fork, hierarchy, versions, trash, merge, clusters) | yes | `client.crystals` |
-| `expected_version` CAS on `crystals.update` | yes | **new** — mirrors TS `expectedVersion`; 409 maps to `CrystalVersionConflictError` |
-| `skip_embedding` on `crystals.create` / `crystals.update` | yes | **new** — mirrors TS `skipEmbedding`; server-floor caveats documented |
-| `MaintenanceResource` (`vacuum`, `tombstone_cleanup`, `changelog_compact`) | yes | **new** — handles bare (non-enveloped) bodies |
-| `MIN_SERVER_VERSION` + `check_server_compatibility()` | yes | **new** — mirrors `client.ts` (floor `0.31.0`) |
+| `expected_version` CAS on `crystals.update` | yes | mirrors TS `expectedVersion`; 409 maps to `CrystalVersionConflictError` |
+| `skip_embedding` on `crystals.create` / `crystals.update` | yes | mirrors TS `skipEmbedding`; server-floor caveats documented |
+| `MaintenanceResource` (`vacuum`, `tombstone_cleanup`, `changelog_compact`) | yes | handles bare (non-enveloped) bodies |
+| `MIN_SERVER_VERSION` + `check_server_compatibility()` | yes | mirrors `client.ts` (floor `0.31.0`) |
 | Edges, session links, terrafirma, entities, extraction, events | yes | |
 | Export / import | yes | |
+| `SyncResource` (NDJSON push/pull, peers, conflicts) | yes | **new (Phase C)** — `client.sync`; standard `{data}` envelopes + bare `{peer}` peer shapes + NDJSON push/pull |
+| `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users` | yes | **new (Phase C)** — `client.<name>` |
+| `shimmers` (lock / heartbeat / ipc; `ShimmerCasConflictError` / `ShimmerDisabledError`) | yes | **new (Phase C)** — `client.shimmers` |
+| Crystal dedup / deferred-merge review (`notes.dedup`, `crystals.pending_merges` / `review_merge` / `merge_history`) | yes | **new (Phase C)** — bare (non-enveloped) bodies |
 | Blobs, audit | yes | Python-only bonus surfaces (not in TS SDK) |
-| `SyncResource` (NDJSON push/pull, peers, conflicts — TS 2.0.0 `{success,data}` envelopes) | no | **not yet ported** — Phase C follow-up (next-stage spec Initiative 3) |
-| `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users` resources | no | **not yet ported** — Phase C |
 | Flat client methods (`createSession`, `search`, …) | no | out of scope by design — Python is resource-only |
 
-#### Added (0.34.0 core)
+#### Added (Phase C — sync + remaining resources, 2.1.0 parity)
+
+- `SyncResource` / `SyncSyncResource` (`client.sync`) with `push` / `pull`
+  (NDJSON wire format), `push_to` / `pull_from`, `get_status`,
+  `list_conflicts` / `resolve_conflict`, and a `.peers` sub-resource
+  (`create` / `list` / `get` / `delete` / `link` / `unlink` / `pause` /
+  `resume`). The `/v1/sync` routes use the standard `{data}` envelope; the
+  peer routes use bare `{peer}` / `{peers}` shapes; a malformed NDJSON line
+  raises `NetworkError`, a contract drift raises `EngramError`.
+- `AgentsResource`, `AmbientContextResource`, `FactsResource`, `GcResource`,
+  `MemorySpacesResource`, `UsersResource` (and their `Sync*` variants) wired
+  onto both clients.
+- `ShimmersResource` / `SyncShimmersResource` (`client.shimmers`) —
+  `heartbeat`, `acquire_lock` / `renew_lock` / `release_lock`,
+  `emit_ipc` / `consume_ipc`, `get`. New typed errors `ShimmerCasConflictError`
+  (409 `SHIMMER_CAS_CONFLICT`) and `ShimmerDisabledError` (503
+  `SHIMMER_DISABLED`); the latter is **non-retryable** via the new
+  `EngramError.retryable` property (mirrors TS — a permanent deployment gate is
+  not re-issued).
+- Crystal dedup / deferred-merge review (P11): `notes.dedup`,
+  `crystals.pending_merges`, `crystals.review_merge`, `crystals.merge_history`.
+  These return bare (non-enveloped) bodies; the resources validate the bare
+  shape and raise loudly on a `{data}`-wrapped / drifted body.
+- `EngramError.retryable` (default `True`); the client retry loop now honors it,
+  so `ShimmerDisabledError` (503) is not retried.
+- pytest mocked-transport coverage for every new resource (path/method/body/query
+  assertions, enveloped AND bare shapes, NDJSON push/pull round-trips, error
+  mapping). Run via `make python-test` / `make check`.
+
+#### Added (0.34.0 core — Phase B)
 
 - `expected_version` field on `UpdateKnowledgeCrystalParams` — optimistic-concurrency
   (CAS) check, serializes to `expectedVersion`. On version mismatch the server

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -4,12 +4,13 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/engram-py.svg)](https://pypi.org/project/engram-py/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Python SDK for Engram Memory Server (v1.0.0 Stable). Provides both async and sync clients, typed via Pydantic v2 models.
+Python SDK for Engram Memory Server (v2.1.0). Provides both async and sync clients, typed via Pydantic v2 models.
 
-> **Parity scope:** This SDK does **not** claim full API parity with the
-> TypeScript SDK (`@centient/sdk`). Coverage is tracked explicitly in the
-> [TypeScript SDK parity](#typescript-sdk-parity) matrix below. The two SDKs are
-> independent clients of the same Engram REST contract.
+> **Parity scope:** As of v2.1.0 this SDK covers every `@centient/sdk` 2.1.0
+> resource surface (see the [TypeScript SDK parity](#typescript-sdk-parity)
+> matrix below). It remains a **resource-only** client — the TS flat client
+> methods (`createSession`, `search`, …) are intentionally out of scope. The two
+> SDKs are independent clients of the same Engram REST contract.
 
 > **Unified Type Model:** Knowledge items and crystals use a single
 > `KnowledgeCrystal` type backed by the `knowledge_crystals` table. The old
@@ -22,7 +23,7 @@ Python SDK for Engram Memory Server (v1.0.0 Stable). Provides both async and syn
 This SDK is a resource-only client of the Engram REST API. It tracks the
 TypeScript SDK (`@centient/sdk`) feature-by-feature rather than promising
 blanket parity — when the two drift, this matrix is the source of truth (vs
-`@centient/sdk` 2.0.0):
+`@centient/sdk` 2.1.0):
 
 | TS SDK surface | Python? | Notes |
 |----------------|---------|-------|
@@ -34,9 +35,11 @@ blanket parity — when the two drift, this matrix is the source of truth (vs
 | `MIN_SERVER_VERSION` + `check_server_compatibility()` | yes | mirrors `client.ts`; floor `0.31.0` |
 | Edges, session links, terrafirma, entities, extraction, events | yes | |
 | Export / import | yes | |
+| Sync resource (`client.sync`: NDJSON push/pull, `.peers`, conflicts) | yes | standard `{data}` envelopes + bare `{peer}` peer shapes + NDJSON push/pull |
+| `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users` | yes | `client.<name>` |
+| Shimmers (`client.shimmers`: lock / heartbeat / ipc) | yes | typed `ShimmerCasConflictError` / `ShimmerDisabledError` (the latter non-retryable) |
+| Dedup / deferred-merge review (`notes.dedup`, `crystals.pending_merges` / `review_merge` / `merge_history`) | yes | bare (non-enveloped) response bodies |
 | Blobs, audit | yes | Python-only bonus surfaces (not in TS SDK) |
-| Sync resource (NDJSON push/pull, peers, conflicts) | **no** | not yet ported (next-stage spec Initiative 3, Phase C) |
-| `agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users` | **no** | not yet ported (Phase C) |
 | Flat client methods (`createSession`, `search`, …) | **no** | out of scope by design — Python is resource-only |
 
 ## Installation
@@ -801,6 +804,15 @@ The SDK provides resource-based access to all Engram APIs:
 | Audit | `client.audit` | Audit event ingestion, querying, stats, pruning |
 | Export/Import | `client.export_import` | Data export (streaming), import (multipart), preview |
 | Maintenance | `client.maintenance` | Tombstone cleanup, changelog compaction, tombstone-table vacuum (bare bodies) |
+| Sync | `client.sync` | Multi-node replication: NDJSON push/pull, `client.sync.peers`, conflicts |
+| Agents | `client.agents` | Agent identity CRUD |
+| Ambient Context | `client.ambient_context` | Session-relevant ambient crystals |
+| Facts | `client.facts` | Temporal key/value facts with history |
+| GC | `client.gc` | Crystal garbage-collection candidates, audit log, run |
+| Memory Spaces | `client.memory_spaces` | Shared memory spaces and membership |
+| Users | `client.users` | User and API-key management |
+| Shimmers | `client.shimmers` | Node-local TTL state: locks, heartbeats, IPC |
+| Dedup / Merge review | `client.notes.dedup` / `client.crystals.pending_merges` / `review_merge` / `merge_history` | Deferred-merge review lifecycle (bare bodies) |
 | Health | `client.health()` / `client.health_ready()` / `client.health_detailed()` | Server health checks |
 | Compatibility | `client.check_server_compatibility()` | Verify the server meets `MIN_SERVER_VERSION` (0.31.0) |
 | Embeddings | `client.embed()` / `client.embed_batch()` / `client.embedding_info()` | Text embedding generation |
@@ -848,6 +860,8 @@ except ValidationError as e:
 | `NotFoundError` | 404 | Resource not found |
 | `SessionExistsError` | 409 | Session already exists |
 | `CrystalVersionConflictError` | 409 | `expected_version` CAS mismatch (carries `current_version`) |
+| `ShimmerCasConflictError` | 409 | Shimmer lock/state CAS conflict (`SHIMMER_CAS_CONFLICT`) |
+| `ShimmerDisabledError` | 503 | Shimmer surface not enabled on the deployment (`SHIMMER_DISABLED`; non-retryable) |
 | `ValidationError` | 400 | Invalid request parameters |
 | `UnauthorizedError` | 401 | Missing or invalid API key |
 | `NetworkError` | - | Connection failure |

--- a/packages/sdk-python/engram/__init__.py
+++ b/packages/sdk-python/engram/__init__.py
@@ -1,7 +1,7 @@
 """Engram Python SDK - SDK for Engram Memory Server."""
 import logging
 
-__version__ = "1.0.0"
+__version__ = "2.1.0"
 
 # Library best practice: attach NullHandler so consumers who don't configure
 # logging never see "No handler found" warnings.  Users can still attach their
@@ -26,6 +26,8 @@ from engram.errors import (
     NetworkError,
     NotFoundError,
     SessionExistsError,
+    ShimmerCasConflictError,
+    ShimmerDisabledError,
     UnauthorizedError,
     ValidationError,
     parse_api_error,
@@ -80,6 +82,24 @@ from engram.resources import (
     SyncExtractionResource,
     MaintenanceResource,
     SyncMaintenanceResource,
+    SyncResource,
+    SyncSyncResource,
+    SyncPeersResource,
+    SyncSyncPeersResource,
+    AgentsResource,
+    SyncAgentsResource,
+    AmbientContextResource,
+    SyncAmbientContextResource,
+    FactsResource,
+    SyncFactsResource,
+    GcResource,
+    SyncGcResource,
+    MemorySpacesResource,
+    SyncMemorySpacesResource,
+    UsersResource,
+    SyncUsersResource,
+    ShimmersResource,
+    SyncShimmersResource,
 )
 
 # Maintenance types

--- a/packages/sdk-python/engram/client.py
+++ b/packages/sdk-python/engram/client.py
@@ -273,7 +273,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -387,7 +387,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -503,7 +503,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -630,7 +630,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -888,7 +888,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -1001,7 +1001,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -1115,7 +1115,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -1237,7 +1237,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
-                and exc.retryable
+                and getattr(exc, "retryable", True)
                 and _attempt < self._retries
             ):
                 logger.warning(

--- a/packages/sdk-python/engram/client.py
+++ b/packages/sdk-python/engram/client.py
@@ -271,7 +271,8 @@ class AsyncEngramClient:
         except EngramError as exc:
             # Retry on server errors
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -385,7 +386,8 @@ class AsyncEngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -501,7 +503,8 @@ class AsyncEngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -628,7 +631,8 @@ class AsyncEngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -886,7 +890,8 @@ class EngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -999,7 +1004,8 @@ class EngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -1113,7 +1119,8 @@ class EngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries
@@ -1235,7 +1242,8 @@ class EngramClient:
 
         except EngramError as exc:
             if (
-                exc.status_code is not None
+                isinstance(exc, EngramError)
+                and exc.status_code is not None
                 and exc.status_code >= 500
                 and getattr(exc, "retryable", True)
                 and _attempt < self._retries

--- a/packages/sdk-python/engram/client.py
+++ b/packages/sdk-python/engram/client.py
@@ -30,6 +30,20 @@ from engram.resources.export_import import ExportImportResource, SyncExportImpor
 from engram.resources.entities import EntitiesResource, SyncEntitiesResource
 from engram.resources.extraction import ExtractionResource, SyncExtractionResource
 from engram.resources.maintenance import MaintenanceResource, SyncMaintenanceResource
+from engram.resources.sync import SyncResource, SyncSyncResource
+from engram.resources.agents import AgentsResource, SyncAgentsResource
+from engram.resources.ambient_context import (
+    AmbientContextResource,
+    SyncAmbientContextResource,
+)
+from engram.resources.facts import FactsResource, SyncFactsResource
+from engram.resources.gc import GcResource, SyncGcResource
+from engram.resources.memory_spaces import (
+    MemorySpacesResource,
+    SyncMemorySpacesResource,
+)
+from engram.resources.users import UsersResource, SyncUsersResource
+from engram.resources.shimmers import ShimmersResource, SyncShimmersResource
 from engram.types.embeddings import (
     EmbeddingInfoResponse,
     EmbeddingResponse,
@@ -184,6 +198,14 @@ class AsyncEngramClient:
         self.entities = EntitiesResource(self)
         self.extraction = ExtractionResource(self)
         self.maintenance = MaintenanceResource(self)
+        self.sync = SyncResource(self)
+        self.agents = AgentsResource(self)
+        self.ambient_context = AmbientContextResource(self)
+        self.facts = FactsResource(self)
+        self.gc = GcResource(self)
+        self.memory_spaces = MemorySpacesResource(self)
+        self.users = UsersResource(self)
+        self.shimmers = ShimmersResource(self)
 
     async def __aenter__(self) -> AsyncEngramClient:
         return self
@@ -251,6 +273,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -364,6 +387,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -479,6 +503,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -605,6 +630,7 @@ class AsyncEngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -788,6 +814,14 @@ class EngramClient:
         self.entities = SyncEntitiesResource(self)
         self.extraction = SyncExtractionResource(self)
         self.maintenance = SyncMaintenanceResource(self)
+        self.sync = SyncSyncResource(self)
+        self.agents = SyncAgentsResource(self)
+        self.ambient_context = SyncAmbientContextResource(self)
+        self.facts = SyncFactsResource(self)
+        self.gc = SyncGcResource(self)
+        self.memory_spaces = SyncMemorySpacesResource(self)
+        self.users = SyncUsersResource(self)
+        self.shimmers = SyncShimmersResource(self)
 
     def __enter__(self) -> EngramClient:
         return self
@@ -854,6 +888,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -966,6 +1001,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -1079,6 +1115,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(
@@ -1200,6 +1237,7 @@ class EngramClient:
             if (
                 exc.status_code is not None
                 and exc.status_code >= 500
+                and exc.retryable
                 and _attempt < self._retries
             ):
                 logger.warning(

--- a/packages/sdk-python/engram/errors.py
+++ b/packages/sdk-python/engram/errors.py
@@ -18,6 +18,17 @@ class EngramError(Exception):
         self.code = code
         self.status_code = status_code
 
+    @property
+    def retryable(self) -> bool:
+        """Whether the transport may retry this error.
+
+        Defaults to ``True`` so the existing "retry 5xx" policy is unchanged.
+        Subclasses representing a permanent server state override this to
+        ``False`` (e.g. :class:`ShimmerDisabledError`), mirroring the TS SDK's
+        ``EngramError.retryable`` (``packages/sdk/src/errors.ts``).
+        """
+        return True
+
 
 class NotFoundError(EngramError):
     """Resource not found (404)."""
@@ -71,6 +82,66 @@ class CrystalVersionConflictError(EngramError):
         )
         self.current_version = current_version
         self.details = details
+
+
+class ShimmerCasConflictError(EngramError):
+    """Shimmer compare-and-swap conflict (409 ``SHIMMER_CAS_CONFLICT``).
+
+    Raised when a shimmer lock acquire/renew, or an ipc post-once, fails its
+    compare-and-swap:
+
+    - ``acquire_lock``: the key is already held by another live owner.
+    - ``renew_lock``: the supplied ``expected_revision``/``owner_token`` did not
+      match the live holder.
+    - ``emit_ipc``: a live message already occupies the key (ipc is write-once).
+
+    **Security:** the 409 body uses the REDACTED projection — the current
+    holder's ``ownerToken`` is NEVER exposed to a losing caller (engram-server
+    #933 P1). The server may include the conflicting record under
+    ``details.current`` with its ``ownerToken`` already null. Application-level
+    retryable (the contended resource may free up), but re-issuing the identical
+    request immediately will conflict again until the holder releases or fades.
+
+    Mirrors the TypeScript SDK's ``ShimmerCasConflictError``
+    (``packages/sdk/src/errors.ts``).
+    """
+
+    def __init__(
+        self,
+        message: str = "Shimmer compare-and-swap conflict",
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(message, code="SHIMMER_CAS_CONFLICT", status_code=409)
+        self.details = details
+
+
+class ShimmerDisabledError(EngramError):
+    """Shimmer surface not enabled on this deployment (503 ``SHIMMER_DISABLED``).
+
+    Shimmers are gated behind ``ENGRAM_SHIMMER_ENABLED`` (default OFF). When off,
+    every shimmer route answers a typed 503 rather than silently no-op'ing. This
+    is a deployment configuration state, not a transient outage: it will not
+    clear on retry until the operator enables the surface, so it is NOT retried
+    by the client.
+
+    Mirrors the TypeScript SDK's ``ShimmerDisabledError``
+    (``packages/sdk/src/errors.ts``).
+    """
+
+    def __init__(
+        self,
+        message: str = (
+            "Shimmers are not enabled on this deployment "
+            "(set ENGRAM_SHIMMER_ENABLED=true)"
+        ),
+    ) -> None:
+        super().__init__(message, code="SHIMMER_DISABLED", status_code=503)
+
+    @property
+    def retryable(self) -> bool:
+        # Permanent deployment gate: re-issuing returns the same 503 until the
+        # operator enables the surface. Never retried.
+        return False
 
 
 class ValidationError(EngramError):
@@ -190,6 +261,12 @@ def parse_api_error(status_code: int, body: Any) -> NoReturn:
                     current_version=_extract_current_version(body, error_obj),
                     details=body,
                 )
+            # Route typed shimmer errors before the generic throw so callers can
+            # catch them by class (mirrors packages/sdk/src/errors.ts:360).
+            if error_obj["code"] == "SHIMMER_CAS_CONFLICT":
+                raise ShimmerCasConflictError(message, details=error_obj.get("details"))
+            if error_obj["code"] == "SHIMMER_DISABLED":
+                raise ShimmerDisabledError(message)
             details = error_obj.get("details")
             if isinstance(details, dict) and "issues" in details:
                 issues = details["issues"]
@@ -204,6 +281,12 @@ def parse_api_error(status_code: int, body: Any) -> NoReturn:
     # Returned by middleware and standard API error responses (404, 401, 409, 500, etc.).
     if isinstance(body, dict) and "code" in body and "message" in body:
         message = body["message"]
+        # Typed shimmer errors (also handled in the nested-error branch above for
+        # the Hono envelope shape; this covers a bare { code, message } body).
+        if body["code"] == "SHIMMER_CAS_CONFLICT":
+            raise ShimmerCasConflictError(message, details=body)
+        if body["code"] == "SHIMMER_DISABLED":
+            raise ShimmerDisabledError(message)
         if status_code == 401:
             raise UnauthorizedError(message)
         if status_code == 404:

--- a/packages/sdk-python/engram/errors.py
+++ b/packages/sdk-python/engram/errors.py
@@ -31,10 +31,23 @@ class EngramError(Exception):
 
 
 class NotFoundError(EngramError):
-    """Resource not found (404)."""
+    """Resource not found (404).
 
-    def __init__(self, message: str = "Resource not found") -> None:
-        super().__init__(message, code="NOT_FOUND", status_code=404)
+    ``code``/``details`` are optional so the status->class mapping can preserve
+    the server's original error code (e.g. ``RES_NOT_FOUND``) and details
+    regardless of envelope shape (flat ``{code,message}`` or nested
+    ``{error:{code,message}}``) — see :func:`parse_api_error`. They default to
+    the legacy hardcoded code so ``NotFoundError("...")`` is unchanged.
+    """
+
+    def __init__(
+        self,
+        message: str = "Resource not found",
+        code: str = "NOT_FOUND",
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(message, code=code, status_code=404)
+        self.details = details
 
 
 class SessionExistsError(EngramError):
@@ -157,10 +170,21 @@ class ValidationError(EngramError):
 
 
 class UnauthorizedError(EngramError):
-    """Authentication failed (401)."""
+    """Authentication failed (401).
 
-    def __init__(self, message: str = "Unauthorized - invalid or missing API key") -> None:
-        super().__init__(message, code="UNAUTHORIZED", status_code=401)
+    ``code``/``details`` are optional (default to the legacy code) so the
+    status->class mapping preserves the server's original code/details
+    regardless of envelope shape — see :func:`parse_api_error`.
+    """
+
+    def __init__(
+        self,
+        message: str = "Unauthorized - invalid or missing API key",
+        code: str = "UNAUTHORIZED",
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(message, code=code, status_code=401)
+        self.details = details
 
 
 class NetworkError(EngramError):
@@ -195,10 +219,21 @@ def __getattr__(name: str) -> type:
 
 
 class InternalError(EngramError):
-    """Internal server error (500)."""
+    """Internal server error (500).
 
-    def __init__(self, message: str = "Internal server error") -> None:
-        super().__init__(message, code="INTERNAL_ERROR", status_code=500)
+    ``code``/``details`` are optional (default to the legacy code) so the
+    status->class mapping preserves the server's original code/details
+    regardless of envelope shape — see :func:`parse_api_error`.
+    """
+
+    def __init__(
+        self,
+        message: str = "Internal server error",
+        code: str = "INTERNAL_ERROR",
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(message, code=code, status_code=500)
+        self.details = details
 
 
 def _extract_current_version(body: Any, error_obj: Any) -> Optional[int]:
@@ -230,6 +265,42 @@ def _extract_current_version(body: Any, error_obj: Any) -> Optional[int]:
         if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
             return value
     return None
+
+
+def _status_mapped_error(
+    status_code: int,
+    code: str,
+    message: str,
+    details: Any = None,
+) -> EngramError:
+    """Map an HTTP status (+ server code/details) to the typed error class.
+
+    This is the SINGLE status->class mapping shared by BOTH the nested-envelope
+    and flat error branches of :func:`parse_api_error`. Previously the mapping
+    lived only in the flat branch, so a nested ``{ error: { code, message } }``
+    404 was thrown as a base :class:`EngramError` instead of
+    :class:`NotFoundError` (issue #117 / TS PR #118). Routing both branches
+    through this helper removes that divergence: the thrown class depends on the
+    HTTP status, not the envelope shape.
+
+    The server's original ``code``/``details`` are preserved on the typed error
+    (so e.g. a nested 404 ``RES_NOT_FOUND`` is ``isinstance NotFoundError`` AND
+    keeps ``code == "RES_NOT_FOUND"``).
+
+    The shimmer and CAS code-specific errors are handled by the caller BEFORE
+    this helper, since they are dispatched on ``code`` rather than status. A
+    generic 409 (code other than ``SESSION_EXISTS``) intentionally stays a base
+    :class:`EngramError` rather than being mangled into a ``SessionExistsError``.
+    """
+    if status_code == 401:
+        return UnauthorizedError(message, code=code, details=details)
+    if status_code == 404:
+        return NotFoundError(message, code=code, details=details)
+    if status_code == 409 and code == "SESSION_EXISTS":
+        return SessionExistsError(message)
+    if status_code == 500:
+        return InternalError(message, code=code, details=details)
+    return EngramError(message, code=code, status_code=status_code)
 
 
 def parse_api_error(status_code: int, body: Any) -> NoReturn:
@@ -275,7 +346,12 @@ def parse_api_error(status_code: int, body: Any) -> NoReturn:
                         f"{'.'.join(i.get('path', []))}: {i.get('message', '')}"
                         for i in issues
                     )
-            raise EngramError(message, code=error_obj["code"], status_code=status_code)
+            # Route through the shared status->class mapping so a nested 404 /
+            # 401 / 500 maps to its typed error (issue #117), not a base
+            # EngramError. The server's code/details are preserved.
+            raise _status_mapped_error(
+                status_code, error_obj["code"], message, details=details
+            )
 
     # Shape 3 - Flat error object: { code, message }
     # Returned by middleware and standard API error responses (404, 401, 409, 500, etc.).
@@ -287,23 +363,16 @@ def parse_api_error(status_code: int, body: Any) -> NoReturn:
             raise ShimmerCasConflictError(message, details=body)
         if body["code"] == "SHIMMER_DISABLED":
             raise ShimmerDisabledError(message)
-        if status_code == 401:
-            raise UnauthorizedError(message)
-        if status_code == 404:
-            raise NotFoundError(message)
-        if status_code == 409:
-            # CAS mismatch is also a 409 — route it to the typed error before
-            # the SessionExistsError fallback so the two 409 cases stay distinct.
-            if body["code"] == "OPERATION_VERSION_CONFLICT":
-                raise CrystalVersionConflictError(
-                    message,
-                    current_version=_extract_current_version(body, None),
-                    details=body,
-                )
-            raise SessionExistsError(message)
-        if status_code == 500:
-            raise InternalError(message)
-        raise EngramError(message, code=body["code"], status_code=status_code)
+        # CAS mismatch is also a 409 — route it to the typed error before the
+        # generic status mapping so the two 409 cases stay distinct.
+        if status_code == 409 and body["code"] == "OPERATION_VERSION_CONFLICT":
+            raise CrystalVersionConflictError(
+                message,
+                current_version=_extract_current_version(body, None),
+                details=body,
+            )
+        # Shared status->class mapping (same path the nested branch uses).
+        raise _status_mapped_error(status_code, body["code"], message, details=body)
 
     # Fallback
     raise EngramError(

--- a/packages/sdk-python/engram/resources/__init__.py
+++ b/packages/sdk-python/engram/resources/__init__.py
@@ -28,6 +28,21 @@ from engram.resources.export_import import ExportImportResource, SyncExportImpor
 from engram.resources.entities import EntitiesResource, SyncEntitiesResource
 from engram.resources.extraction import ExtractionResource, SyncExtractionResource
 from engram.resources.maintenance import MaintenanceResource, SyncMaintenanceResource
+from engram.resources.sync import (
+    SyncResource, SyncSyncResource,
+    SyncPeersResource, SyncSyncPeersResource,
+)
+from engram.resources.agents import AgentsResource, SyncAgentsResource
+from engram.resources.ambient_context import (
+    AmbientContextResource, SyncAmbientContextResource,
+)
+from engram.resources.facts import FactsResource, SyncFactsResource
+from engram.resources.gc import GcResource, SyncGcResource
+from engram.resources.memory_spaces import (
+    MemorySpacesResource, SyncMemorySpacesResource,
+)
+from engram.resources.users import UsersResource, SyncUsersResource
+from engram.resources.shimmers import ShimmersResource, SyncShimmersResource
 
 __all__ = [
     "SessionsResource", "SyncSessionsResource",
@@ -53,4 +68,13 @@ __all__ = [
     "EntitiesResource", "SyncEntitiesResource",
     "ExtractionResource", "SyncExtractionResource",
     "MaintenanceResource", "SyncMaintenanceResource",
+    "SyncResource", "SyncSyncResource",
+    "SyncPeersResource", "SyncSyncPeersResource",
+    "AgentsResource", "SyncAgentsResource",
+    "AmbientContextResource", "SyncAmbientContextResource",
+    "FactsResource", "SyncFactsResource",
+    "GcResource", "SyncGcResource",
+    "MemorySpacesResource", "SyncMemorySpacesResource",
+    "UsersResource", "SyncUsersResource",
+    "ShimmersResource", "SyncShimmersResource",
 ]

--- a/packages/sdk-python/engram/resources/agents.py
+++ b/packages/sdk-python/engram/resources/agents.py
@@ -1,0 +1,171 @@
+"""Agents resource for the Engram SDK.
+
+Resource-based interface for agent identity management: CRUD operations on
+agent records with an idempotent upsert on creation.
+
+Mirrors the TypeScript SDK's ``AgentsResource``
+(``packages/sdk/src/resources/agents.ts``).
+
+Agent responses use a **nested** envelope: a single agent arrives as
+``{ data: { agent } }`` and a list as ``{ data: { agents } }``. These helpers
+unwrap the inner ``agent``/``agents`` key and raise :class:`~engram.errors.EngramError`
+(code ``INTERNAL_ERROR``) on a contract drift, mirroring the TS resource's
+``ResponseShapeError`` — so a regression fails loudly instead of returning a
+model with missing fields.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Optional, TYPE_CHECKING
+from urllib.parse import quote
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.errors import EngramError
+from engram.types.agents import (
+    AgentIdentity,
+    CreateAgentParams,
+    DeleteAgentResult,
+    ListAgentsParams,
+    UpdateAgentParams,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _require_agent(response: Any, route: str) -> AgentIdentity:
+    """Unwrap ``{ data: { agent } }`` into an :class:`AgentIdentity`.
+
+    Raises if the response, its ``data`` envelope, or the inner ``agent`` field
+    is missing or not an object, mirroring the TS resource's ``requireAgent``.
+    """
+    data = response.get("data") if isinstance(response, dict) else None
+    agent = data.get("agent") if isinstance(data, dict) else None
+    if not isinstance(agent, dict):
+        raise EngramError(
+            f"Unexpected {route} response shape (expected {{ data: {{ agent }} }})",
+            code="INTERNAL_ERROR",
+        )
+    return AgentIdentity.model_validate(agent)
+
+
+def _require_agents(response: Any, route: str) -> List[AgentIdentity]:
+    """Unwrap ``{ data: { agents } }`` into a list of :class:`AgentIdentity`.
+
+    Raises if the response, its ``data`` envelope, or the inner ``agents`` field
+    is missing or not an array, mirroring the TS resource's ``requireArray``.
+    """
+    data = response.get("data") if isinstance(response, dict) else None
+    agents = data.get("agents") if isinstance(data, dict) else None
+    if not isinstance(agents, list):
+        raise EngramError(
+            f"Unexpected {route} response shape (expected {{ data: {{ agents }} }})",
+            code="INTERNAL_ERROR",
+        )
+    return [AgentIdentity.model_validate(item) for item in agents]
+
+
+def _list_query_params(
+    params: Optional[ListAgentsParams],
+) -> Optional[dict[str, str]]:
+    """Build the list query params, dropping ``None``/empty values."""
+    if params and params.owner_user_id:
+        return {"ownerUserId": params.owner_user_id}
+    return None
+
+
+class AgentsResource(BaseResource):
+    """Async resource for agent identity management."""
+
+    async def create(self, params: CreateAgentParams) -> AgentIdentity:
+        """Create or idempotently upsert an agent.
+
+        Returns 200 (not 201) because this is an idempotent upsert. If an agent
+        with the given ``external_id`` already exists (including soft-deleted),
+        it is updated/resurrected rather than duplicated.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request("POST", "/v1/agents", body)
+        return _require_agent(response, "POST /v1/agents")
+
+    async def list(
+        self, params: Optional[ListAgentsParams] = None
+    ) -> List[AgentIdentity]:
+        """List all non-deleted agents, optionally filtered by ``owner_user_id``."""
+        response = await self._request(
+            "GET", "/v1/agents", params=_list_query_params(params)
+        )
+        return _require_agents(response, "GET /v1/agents")
+
+    async def get(self, agent_id: str) -> AgentIdentity:
+        """Get a single agent by its internal UUID."""
+        path = f"/v1/agents/{quote(agent_id, safe='')}"
+        response = await self._request("GET", path)
+        return _require_agent(response, f"GET {path}")
+
+    async def update(
+        self, agent_id: str, params: UpdateAgentParams
+    ) -> AgentIdentity:
+        """Update an agent's display name and/or permissions."""
+        path = f"/v1/agents/{quote(agent_id, safe='')}"
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request("PUT", path, body)
+        return _require_agent(response, f"PUT {path}")
+
+    async def delete(self, agent_id: str) -> DeleteAgentResult:
+        """Soft-delete an agent and clean up associated ACL rows."""
+        path = f"/v1/agents/{quote(agent_id, safe='')}"
+        response = await self._request("DELETE", path)
+        data = response.get("data") if isinstance(response, dict) else None
+        if not isinstance(data, dict):
+            raise EngramError(
+                f"Unexpected DELETE {path} response shape (expected {{ data: {{ deleted }} }})",
+                code="INTERNAL_ERROR",
+            )
+        return DeleteAgentResult.model_validate(data)
+
+
+class SyncAgentsResource(SyncBaseResource):
+    """Sync resource for agent identity management."""
+
+    def create(self, params: CreateAgentParams) -> AgentIdentity:
+        """Create or idempotently upsert an agent.
+
+        See :meth:`AgentsResource.create`.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request("POST", "/v1/agents", body)
+        return _require_agent(response, "POST /v1/agents")
+
+    def list(
+        self, params: Optional[ListAgentsParams] = None
+    ) -> List[AgentIdentity]:
+        """List all non-deleted agents, optionally filtered by ``owner_user_id``."""
+        response = self._request(
+            "GET", "/v1/agents", params=_list_query_params(params)
+        )
+        return _require_agents(response, "GET /v1/agents")
+
+    def get(self, agent_id: str) -> AgentIdentity:
+        """Get a single agent by its internal UUID."""
+        path = f"/v1/agents/{quote(agent_id, safe='')}"
+        response = self._request("GET", path)
+        return _require_agent(response, f"GET {path}")
+
+    def update(self, agent_id: str, params: UpdateAgentParams) -> AgentIdentity:
+        """Update an agent's display name and/or permissions."""
+        path = f"/v1/agents/{quote(agent_id, safe='')}"
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request("PUT", path, body)
+        return _require_agent(response, f"PUT {path}")
+
+    def delete(self, agent_id: str) -> DeleteAgentResult:
+        """Soft-delete an agent and clean up associated ACL rows."""
+        path = f"/v1/agents/{quote(agent_id, safe='')}"
+        response = self._request("DELETE", path)
+        data = response.get("data") if isinstance(response, dict) else None
+        if not isinstance(data, dict):
+            raise EngramError(
+                f"Unexpected DELETE {path} response shape (expected {{ data: {{ deleted }} }})",
+                code="INTERNAL_ERROR",
+            )
+        return DeleteAgentResult.model_validate(data)

--- a/packages/sdk-python/engram/resources/ambient_context.py
+++ b/packages/sdk-python/engram/resources/ambient_context.py
@@ -1,0 +1,82 @@
+"""Ambient context resource for the Engram SDK.
+
+Resource-based interface for role-biased ambient knowledge context: returns
+crystals ranked by relevance to the current agent's role.
+
+Mirrors the TypeScript SDK's ``AmbientContextResource``
+(``packages/sdk/src/resources/ambient-context.ts``).
+"""
+from __future__ import annotations
+
+from typing import List, Optional, TYPE_CHECKING
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.types.ambient_context import AmbientCrystal, GetAmbientContextParams
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _ambient_query_params(params: GetAmbientContextParams) -> dict[str, str]:
+    """Build the ambient-context query params, dropping omitted optionals.
+
+    Mirrors the TS SDK's ``URLSearchParams`` shaping: ``sessionId`` is always
+    sent; ``role`` and ``limit`` only when provided.
+    """
+    qs: dict[str, str] = {"sessionId": params.session_id}
+    if params.role is not None:
+        qs["role"] = params.role
+    if params.limit is not None:
+        qs["limit"] = str(params.limit)
+    return qs
+
+
+class AmbientContextResource(BaseResource):
+    """Async resource for role-biased ambient knowledge context."""
+
+    async def get(self, params: GetAmbientContextParams) -> List[AmbientCrystal]:
+        """Fetch ambient crystals for a session, optionally biased by agent role.
+
+        When ``role`` is provided, crystals with tags matching the role string
+        are ranked higher. Results are limited to top-N (default 10 server-side).
+
+        Args:
+            params: Session id plus optional role bias and result limit.
+
+        Returns:
+            Crystals ranked by relevance to the agent's role.
+        """
+        response = await self._request(
+            "GET",
+            "/v1/ambient-context",
+            params=_ambient_query_params(params),
+        )
+        data = response["data"]
+        return [
+            AmbientCrystal.model_validate(item) for item in data["ambientCrystals"]
+        ]
+
+
+class SyncAmbientContextResource(SyncBaseResource):
+    """Sync resource for role-biased ambient knowledge context."""
+
+    def get(self, params: GetAmbientContextParams) -> List[AmbientCrystal]:
+        """Fetch ambient crystals for a session, optionally biased by agent role.
+
+        See :meth:`AmbientContextResource.get`.
+
+        Args:
+            params: Session id plus optional role bias and result limit.
+
+        Returns:
+            Crystals ranked by relevance to the agent's role.
+        """
+        response = self._request(
+            "GET",
+            "/v1/ambient-context",
+            params=_ambient_query_params(params),
+        )
+        data = response["data"]
+        return [
+            AmbientCrystal.model_validate(item) for item in data["ambientCrystals"]
+        ]

--- a/packages/sdk-python/engram/resources/crystals.py
+++ b/packages/sdk-python/engram/resources/crystals.py
@@ -55,9 +55,37 @@ from engram.types.crystals import (
     ShareLink,
     SharedCrystalResult,
 )
+from engram.errors import EngramError
+from engram.types.dedup_merge import (
+    ListPendingMergesParams,
+    MergeRecord,
+    PendingMerge,
+    ReviewMergeParams,
+    ReviewMergeResult,
+)
 
 if TYPE_CHECKING:
     from engram.client import AsyncEngramClient, EngramClient
+
+
+def _require_bare(body: Any, route: str, expected: str) -> dict:
+    """Assert a bare (non-enveloped) merge-review body and return it.
+
+    These P11 merge-review routes return ``{ success, ... }`` directly, NOT the
+    standard ``{ data }`` envelope. A drift (a ``data`` wrap, a non-dict, an
+    HTML error page) fails loudly here rather than surfacing as a KeyError /
+    pydantic error at the call site.
+    """
+    if not isinstance(body, dict) or "data" in body:
+        excerpt = repr(body)
+        if len(excerpt) > 200:
+            excerpt = excerpt[:200] + "...(truncated)"
+        raise EngramError(
+            f"Unexpected {route} response shape (expected a bare {expected}); "
+            f"got: {excerpt}",
+            code="INTERNAL_ERROR",
+        )
+    return body
 
 
 # ============================================================================
@@ -810,6 +838,97 @@ class CrystalsResource(BaseResource):
             CrystalCluster.model_validate(c) for c in response["data"]
         ]
 
+    # ------------------------------------------------------------------
+    # Deferred-merge review (P11)
+    # ------------------------------------------------------------------
+
+    async def pending_merges(
+        self, params: Optional[ListPendingMergesParams] = None
+    ) -> dict:
+        """List deferred merge candidates awaiting review.
+
+        Returns ``{ "pending": List[PendingMerge], "total": int }``. The route
+        returns a **bare** ``{ success, pending, total }`` object, NOT the
+        standard ``{ data }`` envelope.
+        """
+        qs: dict[str, str] = {}
+        if params:
+            if params.session_id:
+                qs["session_id"] = params.session_id
+            if params.limit is not None:
+                qs["limit"] = str(params.limit)
+        response = await self._request(
+            "GET", "/v1/crystals/merges/pending", params=qs if qs else None
+        )
+        obj = _require_bare(response, "GET /v1/crystals/merges/pending", "{ pending, total }")
+        if not isinstance(obj.get("pending"), list) or not isinstance(obj.get("total"), int):
+            raise EngramError(
+                "Unexpected GET /v1/crystals/merges/pending response: "
+                "missing pending[] / numeric total",
+                code="INTERNAL_ERROR",
+            )
+        return {
+            "pending": [PendingMerge.model_validate(m) for m in obj["pending"]],
+            "total": obj["total"],
+        }
+
+    async def review_merge(
+        self, merge_id: str, params: ReviewMergeParams
+    ) -> ReviewMergeResult:
+        """Review a deferred merge candidate — approve, reject, or modify it.
+
+        When ``params.decision`` is ``"modify"`` you must supply
+        ``merged_content`` (the server rejects a ``modify`` without it). The
+        route returns a **bare** ``{ success, decision, targetCrystalId? }``
+        object, NOT the standard ``{ data }`` envelope.
+        """
+        body: dict[str, Any] = {"decision": params.decision}
+        if params.merged_content is not None:
+            body["merged_content"] = params.merged_content
+        response = await self._request(
+            "POST",
+            f"/v1/crystals/merges/{quote(merge_id, safe='')}/review",
+            body,
+        )
+        obj = _require_bare(
+            response, "POST /v1/crystals/merges/{id}/review", "{ decision, targetCrystalId? }"
+        )
+        target = obj.get("targetCrystalId")
+        return ReviewMergeResult(
+            decision=obj["decision"],
+            target_crystal_id=target if isinstance(target, str) and target else None,
+        )
+
+    async def merge_history(self, item_id: str) -> dict:
+        """Get the full merge provenance chain for a note or crystal (P11).
+
+        Returns ``{ "id": str, "merge_chain": List[MergeRecord], "total": int }``,
+        newest-first. The route returns a **bare**
+        ``{ success, id, merge_chain, total }`` object, NOT the standard
+        ``{ data }`` envelope.
+        """
+        response = await self._request(
+            "GET", f"/v1/crystals/merges/history/{quote(item_id, safe='')}"
+        )
+        obj = _require_bare(
+            response, "GET /v1/crystals/merges/history/{id}", "{ id, merge_chain, total }"
+        )
+        if (
+            not isinstance(obj.get("id"), str)
+            or not isinstance(obj.get("merge_chain"), list)
+            or not isinstance(obj.get("total"), int)
+        ):
+            raise EngramError(
+                "Unexpected GET /v1/crystals/merges/history response: "
+                "missing id / merge_chain[] / numeric total",
+                code="INTERNAL_ERROR",
+            )
+        return {
+            "id": obj["id"],
+            "merge_chain": [MergeRecord.model_validate(r) for r in obj["merge_chain"]],
+            "total": obj["total"],
+        }
+
     def items(self, crystal_id: str) -> CrystalItemsResource:
         """Get an items sub-resource scoped to the given crystal."""
         return CrystalItemsResource(self._client, crystal_id)
@@ -1104,6 +1223,91 @@ class SyncCrystalsResource(SyncBaseResource):
         return [
             CrystalCluster.model_validate(c) for c in response["data"]
         ]
+
+    # ------------------------------------------------------------------
+    # Deferred-merge review (P11)
+    # ------------------------------------------------------------------
+
+    def pending_merges(
+        self, params: Optional[ListPendingMergesParams] = None
+    ) -> dict:
+        """List deferred merge candidates awaiting review.
+
+        Returns ``{ "pending": List[PendingMerge], "total": int }``. Bare
+        (non-enveloped) ``{ success, pending, total }`` body.
+        """
+        qs: dict[str, str] = {}
+        if params:
+            if params.session_id:
+                qs["session_id"] = params.session_id
+            if params.limit is not None:
+                qs["limit"] = str(params.limit)
+        response = self._request(
+            "GET", "/v1/crystals/merges/pending", params=qs if qs else None
+        )
+        obj = _require_bare(response, "GET /v1/crystals/merges/pending", "{ pending, total }")
+        if not isinstance(obj.get("pending"), list) or not isinstance(obj.get("total"), int):
+            raise EngramError(
+                "Unexpected GET /v1/crystals/merges/pending response: "
+                "missing pending[] / numeric total",
+                code="INTERNAL_ERROR",
+            )
+        return {
+            "pending": [PendingMerge.model_validate(m) for m in obj["pending"]],
+            "total": obj["total"],
+        }
+
+    def review_merge(
+        self, merge_id: str, params: ReviewMergeParams
+    ) -> ReviewMergeResult:
+        """Review a deferred merge candidate — approve, reject, or modify it.
+
+        Bare (non-enveloped) ``{ success, decision, targetCrystalId? }`` body.
+        """
+        body: dict[str, Any] = {"decision": params.decision}
+        if params.merged_content is not None:
+            body["merged_content"] = params.merged_content
+        response = self._request(
+            "POST",
+            f"/v1/crystals/merges/{quote(merge_id, safe='')}/review",
+            body,
+        )
+        obj = _require_bare(
+            response, "POST /v1/crystals/merges/{id}/review", "{ decision, targetCrystalId? }"
+        )
+        target = obj.get("targetCrystalId")
+        return ReviewMergeResult(
+            decision=obj["decision"],
+            target_crystal_id=target if isinstance(target, str) and target else None,
+        )
+
+    def merge_history(self, item_id: str) -> dict:
+        """Get the full merge provenance chain for a note or crystal (P11).
+
+        Returns ``{ "id": str, "merge_chain": List[MergeRecord], "total": int }``.
+        Bare (non-enveloped) ``{ success, id, merge_chain, total }`` body.
+        """
+        response = self._request(
+            "GET", f"/v1/crystals/merges/history/{quote(item_id, safe='')}"
+        )
+        obj = _require_bare(
+            response, "GET /v1/crystals/merges/history/{id}", "{ id, merge_chain, total }"
+        )
+        if (
+            not isinstance(obj.get("id"), str)
+            or not isinstance(obj.get("merge_chain"), list)
+            or not isinstance(obj.get("total"), int)
+        ):
+            raise EngramError(
+                "Unexpected GET /v1/crystals/merges/history response: "
+                "missing id / merge_chain[] / numeric total",
+                code="INTERNAL_ERROR",
+            )
+        return {
+            "id": obj["id"],
+            "merge_chain": [MergeRecord.model_validate(r) for r in obj["merge_chain"]],
+            "total": obj["total"],
+        }
 
     def items(self, crystal_id: str) -> SyncCrystalItemsResource:
         """Get an items sub-resource scoped to the given crystal."""

--- a/packages/sdk-python/engram/resources/facts.py
+++ b/packages/sdk-python/engram/resources/facts.py
@@ -1,0 +1,182 @@
+"""Facts resource for the Engram SDK.
+
+Resource-based interface for bi-temporal fact management: versioned facts with
+point-in-time queries and full version history.
+
+Mirrors the TypeScript SDK's ``FactsResource``
+(``packages/sdk/src/resources/facts.ts``). Single-object responses are
+unwrapped from the standard ``{ data }`` envelope; history is parsed as a
+paginated list.
+"""
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+from urllib.parse import quote
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.types.common import PaginatedResult
+from engram.types.facts import (
+    CreateFactParams,
+    Fact,
+    FactHistoryParams,
+    UpdateFactParams,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _history_query(params: Optional[FactHistoryParams]) -> Optional[dict[str, str]]:
+    """Build the history query params, dropping ``None`` values.
+
+    Mirrors the TS SDK's ``URLSearchParams`` shaping in
+    ``packages/sdk/src/resources/facts.ts``.
+    """
+    if params is None:
+        return None
+    qs: dict[str, str] = {}
+    if params.valid_from is not None:
+        qs["validFrom"] = params.valid_from
+    if params.valid_to is not None:
+        qs["validTo"] = params.valid_to
+    if params.limit is not None:
+        qs["limit"] = str(params.limit)
+    if params.offset is not None:
+        qs["offset"] = str(params.offset)
+    return qs if qs else None
+
+
+class FactsResource(BaseResource):
+    """Async resource for bi-temporal facts.
+
+    Example::
+
+        # Create a new fact
+        fact = await client.facts.create(
+            CreateFactParams(key="user.preferences.theme", value={"mode": "dark"})
+        )
+
+        # Get a fact by key
+        current = await client.facts.get_by_key("user.preferences.theme")
+
+        # Get a fact as it was at a specific point in time
+        historical = await client.facts.get(fact.id, as_of="2025-01-15T00:00:00Z")
+
+        # Update a fact
+        updated = await client.facts.update(
+            fact.id, UpdateFactParams(value={"mode": "light"})
+        )
+
+        # Browse version history
+        history = await client.facts.get_history(fact.id, FactHistoryParams(limit=10))
+    """
+
+    async def create(self, params: CreateFactParams) -> Fact:
+        """Create a new fact."""
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request("POST", "/v1/facts", body)
+        return Fact.model_validate(response["data"])
+
+    async def get(self, fact_id: str, as_of: Optional[str] = None) -> Fact:
+        """Get a fact by ID, optionally as of a specific point in time.
+
+        Args:
+            fact_id: The fact ID.
+            as_of: Point-in-time timestamp to resolve the fact at.
+
+        Returns:
+            The fact version.
+        """
+        qs: dict[str, str] = {}
+        if as_of is not None:
+            qs["asOf"] = as_of
+        response = await self._request(
+            "GET", f"/v1/facts/{quote(fact_id, safe='')}", params=qs if qs else None
+        )
+        return Fact.model_validate(response["data"])
+
+    async def get_by_key(self, key: str) -> Fact:
+        """Get a fact by its key."""
+        response = await self._request("GET", "/v1/facts", params={"key": key})
+        return Fact.model_validate(response["data"])
+
+    async def update(self, fact_id: str, params: UpdateFactParams) -> Fact:
+        """Update an existing fact."""
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request(
+            "PATCH", f"/v1/facts/{quote(fact_id, safe='')}", body
+        )
+        return Fact.model_validate(response["data"])
+
+    async def get_history(
+        self, fact_id: str, params: Optional[FactHistoryParams] = None
+    ) -> PaginatedResult[Fact]:
+        """Get the version history of a fact.
+
+        Returns:
+            Paginated list of fact versions (``items``), with ``total`` and
+            ``has_more`` from the response pagination meta.
+        """
+        response = await self._request(
+            "GET",
+            f"/v1/facts/{quote(fact_id, safe='')}/history",
+            params=_history_query(params),
+        )
+        return self._parse_list(response, Fact)
+
+
+class SyncFactsResource(SyncBaseResource):
+    """Sync resource for bi-temporal facts."""
+
+    def create(self, params: CreateFactParams) -> Fact:
+        """Create a new fact."""
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request("POST", "/v1/facts", body)
+        return Fact.model_validate(response["data"])
+
+    def get(self, fact_id: str, as_of: Optional[str] = None) -> Fact:
+        """Get a fact by ID, optionally as of a specific point in time.
+
+        Args:
+            fact_id: The fact ID.
+            as_of: Point-in-time timestamp to resolve the fact at.
+
+        Returns:
+            The fact version.
+        """
+        qs: dict[str, str] = {}
+        if as_of is not None:
+            qs["asOf"] = as_of
+        response = self._request(
+            "GET", f"/v1/facts/{quote(fact_id, safe='')}", params=qs if qs else None
+        )
+        return Fact.model_validate(response["data"])
+
+    def get_by_key(self, key: str) -> Fact:
+        """Get a fact by its key."""
+        response = self._request("GET", "/v1/facts", params={"key": key})
+        return Fact.model_validate(response["data"])
+
+    def update(self, fact_id: str, params: UpdateFactParams) -> Fact:
+        """Update an existing fact."""
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request(
+            "PATCH", f"/v1/facts/{quote(fact_id, safe='')}", body
+        )
+        return Fact.model_validate(response["data"])
+
+    def get_history(
+        self, fact_id: str, params: Optional[FactHistoryParams] = None
+    ) -> PaginatedResult[Fact]:
+        """Get the version history of a fact.
+
+        Returns:
+            Paginated list of fact versions (``items``), with ``total`` and
+            ``has_more`` from the response pagination meta.
+        """
+        response = self._request(
+            "GET",
+            f"/v1/facts/{quote(fact_id, safe='')}/history",
+            params=_history_query(params),
+        )
+        return self._parse_list(response, Fact)

--- a/packages/sdk-python/engram/resources/gc.py
+++ b/packages/sdk-python/engram/resources/gc.py
@@ -1,0 +1,143 @@
+"""GC (garbage collection) resources for the Engram SDK.
+
+Resource-based interface for knowledge garbage-collection operations:
+listing candidates, reading the audit log, and triggering a (optionally
+dry-run) GC pass.
+
+Mirrors the TypeScript SDK's ``GcResource``
+(``packages/sdk/src/resources/gc.ts``).
+
+The candidate-list and audit-log endpoints return the standard ``{ data, meta }``
+envelope where ``data`` carries the list payload plus sibling scalars; the
+``hasMore`` flag is sourced from ``meta.pagination.hasMore`` (defaulting to
+``False``) and folded into the returned result model, exactly as the TS SDK does.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional, TYPE_CHECKING
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.types.gc import (
+    GcAuditResult,
+    GcCandidatesResult,
+    GcRunOptions,
+    GcRunResult,
+    ListGcAuditParams,
+    ListGcCandidatesParams,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _has_more(response: Any) -> bool:
+    """Extract ``meta.pagination.hasMore`` from an envelope, defaulting to False."""
+    pagination = ((response or {}).get("meta") or {}).get("pagination") or {}
+    return bool(pagination.get("hasMore", False))
+
+
+def _candidate_query(params: Optional[ListGcCandidatesParams]) -> Optional[dict[str, str]]:
+    """Build the candidate-list query params, dropping ``None`` values."""
+    if params is None:
+        return None
+    qs: dict[str, str] = {}
+    if params.threshold is not None:
+        qs["threshold"] = str(params.threshold)
+    if params.limit is not None:
+        qs["limit"] = str(params.limit)
+    if params.offset is not None:
+        qs["offset"] = str(params.offset)
+    return qs or None
+
+
+def _audit_query(params: Optional[ListGcAuditParams]) -> Optional[dict[str, str]]:
+    """Build the audit-log query params, dropping ``None`` values."""
+    if params is None:
+        return None
+    qs: dict[str, str] = {}
+    if params.limit is not None:
+        qs["limit"] = str(params.limit)
+    if params.offset is not None:
+        qs["offset"] = str(params.offset)
+    return qs or None
+
+
+def _build_candidates_result(response: Any) -> GcCandidatesResult:
+    data = dict(response["data"])
+    data["hasMore"] = _has_more(response)
+    return GcCandidatesResult.model_validate(data)
+
+
+def _build_audit_result(response: Any) -> GcAuditResult:
+    data = dict(response["data"])
+    data["hasMore"] = _has_more(response)
+    return GcAuditResult.model_validate(data)
+
+
+class GcResource(BaseResource):
+    """Async resource for knowledge garbage-collection operations.
+
+    Example::
+
+        candidates = await client.gc.get_candidates(
+            ListGcCandidatesParams(threshold=0.2, limit=50)
+        )
+        audit = await client.gc.get_audit_log()
+        result = await client.gc.run(GcRunOptions(dry_run=True))
+    """
+
+    async def get_candidates(
+        self, params: Optional[ListGcCandidatesParams] = None
+    ) -> GcCandidatesResult:
+        """List garbage-collection candidates ranked by relevance score."""
+        response = await self._request(
+            "GET", "/v1/gc/candidates", params=_candidate_query(params)
+        )
+        return _build_candidates_result(response)
+
+    async def get_audit_log(
+        self, params: Optional[ListGcAuditParams] = None
+    ) -> GcAuditResult:
+        """Get the GC audit log of previous runs."""
+        response = await self._request(
+            "GET", "/v1/gc/audit", params=_audit_query(params)
+        )
+        return _build_audit_result(response)
+
+    async def run(self, options: Optional[GcRunOptions] = None) -> GcRunResult:
+        """Run garbage collection, optionally as a dry run."""
+        body = (
+            options.model_dump(by_alias=True, exclude_none=True) if options else None
+        )
+        response = await self._request("POST", "/v1/gc/run", body)
+        return GcRunResult.model_validate(response["data"])
+
+
+class SyncGcResource(SyncBaseResource):
+    """Sync resource for knowledge garbage-collection operations."""
+
+    def get_candidates(
+        self, params: Optional[ListGcCandidatesParams] = None
+    ) -> GcCandidatesResult:
+        """List garbage-collection candidates ranked by relevance score."""
+        response = self._request(
+            "GET", "/v1/gc/candidates", params=_candidate_query(params)
+        )
+        return _build_candidates_result(response)
+
+    def get_audit_log(
+        self, params: Optional[ListGcAuditParams] = None
+    ) -> GcAuditResult:
+        """Get the GC audit log of previous runs."""
+        response = self._request(
+            "GET", "/v1/gc/audit", params=_audit_query(params)
+        )
+        return _build_audit_result(response)
+
+    def run(self, options: Optional[GcRunOptions] = None) -> GcRunResult:
+        """Run garbage collection, optionally as a dry run."""
+        body = (
+            options.model_dump(by_alias=True, exclude_none=True) if options else None
+        )
+        response = self._request("POST", "/v1/gc/run", body)
+        return GcRunResult.model_validate(response["data"])

--- a/packages/sdk-python/engram/resources/memory_spaces.py
+++ b/packages/sdk-python/engram/resources/memory_spaces.py
@@ -1,0 +1,206 @@
+"""Memory space resources for the Engram SDK.
+
+Resource-based interface for shared memory space management. Memory spaces
+allow agents to collaborate within shared knowledge containers.
+
+Mirrors the TypeScript SDK's ``MemorySpacesResource``
+(``packages/sdk/src/resources/memory-spaces.ts``).
+
+These endpoints use the standard ``{ data }`` envelope, but the inner payload
+is keyed by member name (``{ data: { space } }``, ``{ data: { spaces } }``,
+``{ data: { member } }``). Each method unwraps ``data`` and then the named
+member, matching the TS contract exactly.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Optional, TYPE_CHECKING
+from urllib.parse import quote
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.types.memory_spaces import (
+    CreateMemorySpaceParams,
+    JoinMemorySpaceParams,
+    MemorySpace,
+    MemorySpaceMember,
+    MemorySpaceWithMembers,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _unwrap_member(response: Any, key: str) -> Any:
+    """Unwrap ``response["data"][key]`` from a memory-spaces envelope.
+
+    The memory-spaces routes wrap their payload as ``{ data: { <key> } }``
+    (e.g. ``{ data: { space } }``). This mirrors the TS ``unwrapDataObject``
+    followed by the named-member read.
+    """
+    data = response["data"]
+    return data[key]
+
+
+class MemorySpacesResource(BaseResource):
+    """Async resource for shared memory spaces."""
+
+    async def list(self, agent_id: Optional[str] = None) -> List[MemorySpace]:
+        """List memory spaces, optionally filtered by agent membership.
+
+        Args:
+            agent_id: Filter to spaces the given agent is a member of.
+
+        Returns:
+            List of memory spaces.
+        """
+        qs: dict[str, str] = {}
+        if agent_id is not None:
+            qs["agentId"] = agent_id
+        response = await self._request(
+            "GET", "/v1/memory-spaces", params=qs if qs else None
+        )
+        spaces = _unwrap_member(response, "spaces")
+        return [MemorySpace.model_validate(item) for item in spaces]
+
+    async def create(self, params: CreateMemorySpaceParams) -> MemorySpace:
+        """Create a new memory space.
+
+        Args:
+            params: Title, optional description/visibility, and initial members.
+
+        Returns:
+            The created memory space.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request("POST", "/v1/memory-spaces", body)
+        return MemorySpace.model_validate(_unwrap_member(response, "space"))
+
+    async def get(self, space_id: str) -> MemorySpaceWithMembers:
+        """Get a memory space by ID, including its members.
+
+        Args:
+            space_id: The memory space ID.
+
+        Returns:
+            The memory space with its members.
+        """
+        response = await self._request(
+            "GET", f"/v1/memory-spaces/{quote(space_id, safe='')}"
+        )
+        return MemorySpaceWithMembers.model_validate(_unwrap_member(response, "space"))
+
+    async def join(
+        self, space_id: str, params: JoinMemorySpaceParams
+    ) -> MemorySpaceMember:
+        """Join a memory space as an agent with a given permission level.
+
+        Args:
+            space_id: The memory space ID.
+            params: The agent ID and permission level.
+
+        Returns:
+            The created membership record.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request(
+            "POST", f"/v1/memory-spaces/{quote(space_id, safe='')}/join", body
+        )
+        return MemorySpaceMember.model_validate(_unwrap_member(response, "member"))
+
+    async def leave(self, space_id: str, agent_id: str) -> dict[str, Any]:
+        """Leave a memory space (remove an agent from the space).
+
+        Args:
+            space_id: The memory space ID.
+            agent_id: The agent to remove.
+
+        Returns:
+            ``{"removed": True}`` on success.
+        """
+        response = await self._request(
+            "DELETE",
+            f"/v1/memory-spaces/{quote(space_id, safe='')}/leave",
+            params={"agentId": agent_id},
+        )
+        return response["data"]
+
+
+class SyncMemorySpacesResource(SyncBaseResource):
+    """Sync resource for shared memory spaces."""
+
+    def list(self, agent_id: Optional[str] = None) -> List[MemorySpace]:
+        """List memory spaces, optionally filtered by agent membership.
+
+        Args:
+            agent_id: Filter to spaces the given agent is a member of.
+
+        Returns:
+            List of memory spaces.
+        """
+        qs: dict[str, str] = {}
+        if agent_id is not None:
+            qs["agentId"] = agent_id
+        response = self._request(
+            "GET", "/v1/memory-spaces", params=qs if qs else None
+        )
+        spaces = _unwrap_member(response, "spaces")
+        return [MemorySpace.model_validate(item) for item in spaces]
+
+    def create(self, params: CreateMemorySpaceParams) -> MemorySpace:
+        """Create a new memory space.
+
+        Args:
+            params: Title, optional description/visibility, and initial members.
+
+        Returns:
+            The created memory space.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request("POST", "/v1/memory-spaces", body)
+        return MemorySpace.model_validate(_unwrap_member(response, "space"))
+
+    def get(self, space_id: str) -> MemorySpaceWithMembers:
+        """Get a memory space by ID, including its members.
+
+        Args:
+            space_id: The memory space ID.
+
+        Returns:
+            The memory space with its members.
+        """
+        response = self._request(
+            "GET", f"/v1/memory-spaces/{quote(space_id, safe='')}"
+        )
+        return MemorySpaceWithMembers.model_validate(_unwrap_member(response, "space"))
+
+    def join(self, space_id: str, params: JoinMemorySpaceParams) -> MemorySpaceMember:
+        """Join a memory space as an agent with a given permission level.
+
+        Args:
+            space_id: The memory space ID.
+            params: The agent ID and permission level.
+
+        Returns:
+            The created membership record.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request(
+            "POST", f"/v1/memory-spaces/{quote(space_id, safe='')}/join", body
+        )
+        return MemorySpaceMember.model_validate(_unwrap_member(response, "member"))
+
+    def leave(self, space_id: str, agent_id: str) -> dict[str, Any]:
+        """Leave a memory space (remove an agent from the space).
+
+        Args:
+            space_id: The memory space ID.
+            agent_id: The agent to remove.
+
+        Returns:
+            ``{"removed": True}`` on success.
+        """
+        response = self._request(
+            "DELETE",
+            f"/v1/memory-spaces/{quote(space_id, safe='')}/leave",
+            params={"agentId": agent_id},
+        )
+        return response["data"]

--- a/packages/sdk-python/engram/resources/notes.py
+++ b/packages/sdk-python/engram/resources/notes.py
@@ -5,6 +5,8 @@ from typing import Any, Optional, TYPE_CHECKING
 from urllib.parse import quote
 
 from engram._base import BaseResource, SyncBaseResource
+from engram.errors import EngramError
+from engram.types.dedup_merge import DedupNoteParams, DedupNoteResult
 from engram.types.sessions import (
     LifecycleStatus,
     LocalSearchResult,
@@ -16,6 +18,35 @@ from engram.types.sessions import (
 
 if TYPE_CHECKING:
     from engram.client import AsyncEngramClient, EngramClient
+
+
+def _dedup_body(params: Optional[DedupNoteParams]) -> dict:
+    """Build the snake_case dedup request body, omitting absent fields.
+
+    The server's ``DedupRequestSchema`` is strict and snake_case; only the two
+    known fields are copied so any extra attribute never reaches the wire.
+    """
+    body: dict[str, Any] = {}
+    if params is not None:
+        if params.merge_method is not None:
+            body["merge_method"] = params.merge_method
+        if params.threshold is not None:
+            body["threshold"] = params.threshold
+    return body
+
+
+def _require_bare_dedup(body: Any, route: str) -> DedupNoteResult:
+    """Validate the bare (non-enveloped) dedup body and return the result."""
+    if not isinstance(body, dict) or "data" in body or "action" not in body:
+        excerpt = repr(body)
+        if len(excerpt) > 200:
+            excerpt = excerpt[:200] + "...(truncated)"
+        raise EngramError(
+            f"Unexpected {route} response shape (expected a bare "
+            f"{{ action, merge_id, confidence, canonical_id }}); got: {excerpt}",
+            code="INTERNAL_ERROR",
+        )
+    return DedupNoteResult.model_validate(body)
 
 
 class NotesResource(BaseResource):
@@ -69,6 +100,24 @@ class NotesResource(BaseResource):
         return LocalSessionNote.model_validate(response["data"])
 
 
+    async def dedup(
+        self, id: str, params: Optional[DedupNoteParams] = None
+    ) -> DedupNoteResult:
+        """Trigger an explicit dedup check for a session note (P11 Tier 1).
+
+        Returns one of ``merged`` / ``deferred`` / ``no_match`` plus the
+        matched-item id and similarity confidence. When the embedding service
+        is not ready the result is ``{ action: "no_match", ...None }``. The
+        server returns a **bare** object — NOT the standard ``{ data }``
+        envelope. The body fields are accepted on the wire but currently ignored
+        server-side.
+        """
+        response = await self._request(
+            "POST", f"/v1/notes/{quote(id, safe='')}/dedup", _dedup_body(params)
+        )
+        return _require_bare_dedup(response, f"POST /v1/notes/{id}/dedup")
+
+
 class SyncNotesResource(SyncBaseResource):
     """Sync resource for global note operations."""
 
@@ -118,3 +167,16 @@ class SyncNotesResource(SyncBaseResource):
             "PATCH", f"/v1/notes/{quote(id, safe='')}/lifecycle", body
         )
         return LocalSessionNote.model_validate(response["data"])
+
+    def dedup(
+        self, id: str, params: Optional[DedupNoteParams] = None
+    ) -> DedupNoteResult:
+        """Trigger an explicit dedup check for a session note (P11 Tier 1).
+
+        See :meth:`NotesResource.dedup`. The server returns a **bare** object —
+        NOT the standard ``{ data }`` envelope.
+        """
+        response = self._request(
+            "POST", f"/v1/notes/{quote(id, safe='')}/dedup", _dedup_body(params)
+        )
+        return _require_bare_dedup(response, f"POST /v1/notes/{id}/dedup")

--- a/packages/sdk-python/engram/resources/shimmers.py
+++ b/packages/sdk-python/engram/resources/shimmers.py
@@ -1,0 +1,292 @@
+"""Shimmers resource for the Engram SDK (engram ``/v1/shimmers``).
+
+Ergonomic, use-case-named wrappers over the per-type shimmer write semantics. A
+shimmer is node-local, TTL-backed operational state: locks (CAS), heartbeats
+(overwrite), and ipc (write-once + exactly-once consume).
+
+Mirrors the TypeScript SDK's ``ShimmersResource``
+(``packages/sdk/src/resources/shimmers.ts``, ADR-027 / engram-server #931, #933).
+
+Endpoint mapping::
+
+    heartbeat(key, ...)     -> POST   /v1/shimmers              (recordType: heartbeat)
+    acquire_lock(key, ...)  -> POST   /v1/shimmers              (recordType: lock)
+    renew_lock(key, ...)    -> PUT    /v1/shimmers/:key         (recordType: lock, CAS)
+    release_lock(key, ...)  -> DELETE /v1/shimmers/:key?recordType=lock&ownerToken=...
+    emit_ipc(key, ...)      -> POST   /v1/shimmers              (recordType: ipc)
+    consume_ipc(key)        -> DELETE /v1/shimmers/:key?recordType=ipc
+    get(key, record_type)   -> GET    /v1/shimmers/:key?recordType=...
+
+Single-object responses are unwrapped from the standard ``{ data }`` envelope.
+The entire surface requires a WRITE-scoped key and answers 503
+(:class:`~engram.errors.ShimmerDisabledError`) when ``ENGRAM_SHIMMER_ENABLED``
+is off. Lock acquire/renew CAS failures and ipc write-once collisions surface as
+:class:`~engram.errors.ShimmerCasConflictError` (409). Both are raised centrally
+by ``parse_api_error`` from the server error codes.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional, TYPE_CHECKING
+from urllib.parse import quote
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.types.shimmers import (
+    AcquireLockParams,
+    ReleaseLockParams,
+    RenewLockParams,
+    Shimmer,
+    ShimmerDeleteResult,
+    ShimmerRead,
+    ShimmerRecordType,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+def _heartbeat_body(key: str, value: Any, ttl_seconds: int) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "recordType": "heartbeat",
+        "key": key,
+        "ttlSeconds": ttl_seconds,
+    }
+    if value is not None:
+        body["value"] = value
+    return body
+
+
+def _acquire_body(key: str, params: AcquireLockParams) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "recordType": "lock",
+        "key": key,
+        "ownerToken": params.owner_token,
+        "ttlSeconds": params.ttl_seconds,
+    }
+    if params.value is not None:
+        body["value"] = params.value
+    return body
+
+
+def _renew_body(params: RenewLockParams) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "recordType": "lock",
+        "ownerToken": params.owner_token,
+        "expectedRevision": params.expected_revision,
+        "ttlSeconds": params.ttl_seconds,
+    }
+    if params.value is not None:
+        body["value"] = params.value
+    return body
+
+
+def _ipc_body(key: str, value: Any, ttl_seconds: int) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "recordType": "ipc",
+        "key": key,
+        "ttlSeconds": ttl_seconds,
+    }
+    if value is not None:
+        body["value"] = value
+    return body
+
+
+class ShimmersResource(BaseResource):
+    """Async resource for node-local TTL-backed operational state.
+
+    Attached as ``client.shimmers``. Locks, heartbeats, and ipc.
+
+    Example::
+
+        # Emit a heartbeat (never conflicts)
+        await client.shimmers.heartbeat("worker-1", {"phase": "build"}, ttl_seconds=30)
+
+        # Acquire a lock (raises ShimmerCasConflictError if held)
+        lock = await client.shimmers.acquire_lock(
+            "deploy", AcquireLockParams(owner_token="me", ttl_seconds=60)
+        )
+    """
+
+    async def heartbeat(
+        self, key: str, value: Any, ttl_seconds: int
+    ) -> Shimmer:
+        """Emit/refresh a heartbeat: unconditional overwrite + TTL window.
+
+        Last-writer-wins — a heartbeat NEVER conflicts.
+        """
+        response = await self._request(
+            "POST", "/v1/shimmers", _heartbeat_body(key, value, ttl_seconds)
+        )
+        return Shimmer.model_validate(response["data"])
+
+    async def acquire_lock(self, key: str, params: AcquireLockParams) -> Shimmer:
+        """Acquire a lock if it is free (CAS acquire-if-absent).
+
+        The returned record echoes back the ``owner_token`` you supplied — keep
+        it; it is the capability required to renew or release.
+
+        Raises:
+            ShimmerCasConflictError: 409 — the lock is already held by another
+                live owner (the holder's token is NOT exposed).
+        """
+        response = await self._request(
+            "POST", "/v1/shimmers", _acquire_body(key, params)
+        )
+        return Shimmer.model_validate(response["data"])
+
+    async def renew_lock(self, key: str, params: RenewLockParams) -> Shimmer:
+        """Renew a held lock (CAS).
+
+        The supplied ``expected_revision`` and ``owner_token`` must match the
+        live holder. On success the lease is extended and the revision advances.
+
+        Raises:
+            ShimmerCasConflictError: 409 — the revision/owner did not match the
+                live holder.
+        """
+        response = await self._request(
+            "PUT",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            _renew_body(params),
+        )
+        return Shimmer.model_validate(response["data"])
+
+    async def release_lock(
+        self, key: str, params: ReleaseLockParams
+    ) -> ShimmerDeleteResult:
+        """Release a lock (owner-guarded).
+
+        ``released`` is true iff a live lock held by the supplied owner was
+        deleted; a non-holder gets ``released=False`` (not an error).
+        ``consumed`` is always ``None`` for a lock release.
+        """
+        response = await self._request(
+            "DELETE",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            params={"recordType": "lock", "ownerToken": params.owner_token},
+        )
+        return ShimmerDeleteResult.model_validate(response["data"])
+
+    async def emit_ipc(self, key: str, value: Any, ttl_seconds: int) -> Shimmer:
+        """Post an ipc message (write-once).
+
+        The key holds at most one live message until it is consumed or fades.
+
+        Raises:
+            ShimmerCasConflictError: 409 — a live message already occupies the
+                key.
+        """
+        response = await self._request(
+            "POST", "/v1/shimmers", _ipc_body(key, value, ttl_seconds)
+        )
+        return Shimmer.model_validate(response["data"])
+
+    async def consume_ipc(self, key: str) -> Optional[ShimmerRead]:
+        """Consume an ipc message (atomic exactly-once ``DELETE ... RETURNING``).
+
+        Exactly one concurrent caller receives the record; every other receives
+        ``None``. Returns the consumed record (with its ``owner_token`` redacted
+        to ``None``), or ``None`` when no live message existed.
+        """
+        response = await self._request(
+            "DELETE",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            params={"recordType": "ipc"},
+        )
+        result = ShimmerDeleteResult.model_validate(response["data"])
+        return result.consumed
+
+    async def get(self, key: str, record_type: ShimmerRecordType) -> ShimmerRead:
+        """Read a live shimmer (TTL-filtered).
+
+        Returns the record for (``record_type``, ``key``) when LIVE
+        (fades_at > now). A faded-but-unreaped row reads as absent. The result
+        NEVER carries an ``owner_token`` (always ``None`` on a read).
+
+        Raises:
+            NotFoundError: 404 — no live shimmer for (record_type, key).
+        """
+        response = await self._request(
+            "GET",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            params={"recordType": record_type},
+        )
+        return ShimmerRead.model_validate(response["data"])
+
+
+class SyncShimmersResource(SyncBaseResource):
+    """Sync resource for node-local TTL-backed operational state."""
+
+    def heartbeat(self, key: str, value: Any, ttl_seconds: int) -> Shimmer:
+        """Emit/refresh a heartbeat: unconditional overwrite + TTL window."""
+        response = self._request(
+            "POST", "/v1/shimmers", _heartbeat_body(key, value, ttl_seconds)
+        )
+        return Shimmer.model_validate(response["data"])
+
+    def acquire_lock(self, key: str, params: AcquireLockParams) -> Shimmer:
+        """Acquire a lock if it is free (CAS acquire-if-absent).
+
+        Raises:
+            ShimmerCasConflictError: 409 — the lock is already held.
+        """
+        response = self._request("POST", "/v1/shimmers", _acquire_body(key, params))
+        return Shimmer.model_validate(response["data"])
+
+    def renew_lock(self, key: str, params: RenewLockParams) -> Shimmer:
+        """Renew a held lock (CAS).
+
+        Raises:
+            ShimmerCasConflictError: 409 — the revision/owner did not match.
+        """
+        response = self._request(
+            "PUT",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            _renew_body(params),
+        )
+        return Shimmer.model_validate(response["data"])
+
+    def release_lock(
+        self, key: str, params: ReleaseLockParams
+    ) -> ShimmerDeleteResult:
+        """Release a lock (owner-guarded)."""
+        response = self._request(
+            "DELETE",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            params={"recordType": "lock", "ownerToken": params.owner_token},
+        )
+        return ShimmerDeleteResult.model_validate(response["data"])
+
+    def emit_ipc(self, key: str, value: Any, ttl_seconds: int) -> Shimmer:
+        """Post an ipc message (write-once).
+
+        Raises:
+            ShimmerCasConflictError: 409 — a live message already occupies the
+                key.
+        """
+        response = self._request(
+            "POST", "/v1/shimmers", _ipc_body(key, value, ttl_seconds)
+        )
+        return Shimmer.model_validate(response["data"])
+
+    def consume_ipc(self, key: str) -> Optional[ShimmerRead]:
+        """Consume an ipc message (atomic exactly-once)."""
+        response = self._request(
+            "DELETE",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            params={"recordType": "ipc"},
+        )
+        result = ShimmerDeleteResult.model_validate(response["data"])
+        return result.consumed
+
+    def get(self, key: str, record_type: ShimmerRecordType) -> ShimmerRead:
+        """Read a live shimmer (TTL-filtered).
+
+        Raises:
+            NotFoundError: 404 — no live shimmer for (record_type, key).
+        """
+        response = self._request(
+            "GET",
+            f"/v1/shimmers/{quote(key, safe='')}",
+            params={"recordType": record_type},
+        )
+        return ShimmerRead.model_validate(response["data"])

--- a/packages/sdk-python/engram/resources/sync.py
+++ b/packages/sdk-python/engram/resources/sync.py
@@ -22,6 +22,8 @@ import json
 from typing import Any, List, Optional, TYPE_CHECKING
 from urllib.parse import quote
 
+from pydantic import ValidationError as PydanticValidationError
+
 from engram._base import BaseResource, SyncBaseResource
 from engram.errors import EngramError, NetworkError
 from engram.types.sync import (
@@ -123,7 +125,16 @@ def _parse_pull_ndjson(text: str, route: str) -> List[SyncChange]:
                 f'Unexpected entityType "{raw.get("entityType")}" at NDJSON '
                 f"line {i} from {route}"
             )
-        changes.append(SyncChange.model_validate(raw))
+        # A field with the wrong type (e.g. seq as a number, changedFields as a
+        # list) surfaces as a structured NetworkError carrying the line index —
+        # consistent with the other parse-boundary failures above — rather than
+        # leaking a raw pydantic ValidationError to the caller.
+        try:
+            changes.append(SyncChange.model_validate(raw))
+        except PydanticValidationError as exc:
+            raise NetworkError(
+                f"Malformed SyncChange at NDJSON line {i} from {route}: {exc}"
+            )
     return changes
 
 

--- a/packages/sdk-python/engram/resources/sync.py
+++ b/packages/sdk-python/engram/resources/sync.py
@@ -1,0 +1,445 @@
+"""Sync resource for the Engram SDK — multi-node replication.
+
+Resource-based interface for push/pull replication, conflict resolution, and
+peer management. Mirrors the TypeScript SDK's ``SyncResource``
+(``packages/sdk/src/resources/sync.ts``).
+
+Envelope rules (matching the server contract):
+
+- Most ``/v1/sync`` routes use the standard ``{ success, data }`` envelope.
+- The peer routes (``/v1/sync/peers/*``) use BARE shapes: ``{ peer }``,
+  ``{ peers }``, ``{ removed, name }`` — they are NOT enveloped.
+- ``push`` sends NDJSON (``application/x-ndjson``) and ``pull`` parses an NDJSON
+  response stream (one serialized changelog entry per line).
+
+Contract drift surfaces as :class:`~engram.errors.EngramError`
+(code ``INTERNAL_ERROR``); a malformed NDJSON line surfaces as
+:class:`~engram.errors.NetworkError`, mirroring the TS SDK.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, List, Optional, TYPE_CHECKING
+from urllib.parse import quote
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.errors import EngramError, NetworkError
+from engram.types.sync import (
+    CreatePeerParams,
+    ListConflictsParams,
+    ResolveConflictParams,
+    SyncChange,
+    SyncConflict,
+    SyncPeer,
+    SyncPullParams,
+    SyncPullResult,
+    SyncPushResult,
+    SyncStatus,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+_BODY_EXCERPT_MAX = 200
+
+# The four entity types the server always reports counts for.
+_SYNC_ENTITY_TYPES = (
+    "knowledge_crystals",
+    "knowledge_crystal_edges",
+    "sessions",
+    "session_notes",
+)
+
+
+def _truncate_body(body: Any) -> str:
+    """Render a short, repr-safe excerpt of an unexpected response body."""
+    text = repr(body)
+    if len(text) > _BODY_EXCERPT_MAX:
+        return text[:_BODY_EXCERPT_MAX] + "...(truncated)"
+    return text
+
+
+def _unwrap_data(body: Any, route: str) -> Any:
+    """Unwrap the standard ``{ data }`` envelope, failing loudly on drift."""
+    if not isinstance(body, dict) or "data" not in body:
+        raise EngramError(
+            f"Unexpected {route} response shape (expected {{ data }}); "
+            f"got: {_truncate_body(body)}",
+            code="INTERNAL_ERROR",
+        )
+    return body["data"]
+
+
+def _require_peer(body: Any, route: str) -> dict:
+    """Narrow a bare ``{ peer }`` peers response."""
+    if not isinstance(body, dict) or not isinstance(body.get("peer"), dict):
+        raise EngramError(
+            f"Unexpected {route} response shape (expected {{ peer }}); "
+            f"got: {_truncate_body(body)}",
+            code="INTERNAL_ERROR",
+        )
+    return body["peer"]
+
+
+def _require_peers(body: Any, route: str) -> list:
+    """Narrow a bare ``{ peers: [...] }`` peers-list response."""
+    if not isinstance(body, dict) or not isinstance(body.get("peers"), list):
+        raise EngramError(
+            f"Unexpected {route} response shape (expected {{ peers }}); "
+            f"got: {_truncate_body(body)}",
+            code="INTERNAL_ERROR",
+        )
+    return body["peers"]
+
+
+def _parse_pull_ndjson(text: str, route: str) -> List[SyncChange]:
+    """Parse an NDJSON pull response into a list of SyncChange.
+
+    Mirrors the TS validation: a malformed/truncated line, a missing required
+    field, or an unknown ``entityType`` raises :class:`NetworkError` with the
+    offending line index — a contract drift fails here, not as an AttributeError
+    at the call site.
+    """
+    changes: List[SyncChange] = []
+    lines = [line for line in text.split("\n") if line.strip()]
+    for i, line in enumerate(lines):
+        try:
+            raw = json.loads(line)
+        except (ValueError, TypeError):
+            raise NetworkError(
+                f"Failed to parse NDJSON line {i} from {route}: {line[:200]}"
+            )
+        if not isinstance(raw, dict) or not all(
+            raw.get(k)
+            for k in ("seq", "entityType", "entityId", "operation", "createdAt")
+        ):
+            raise NetworkError(
+                f"Malformed SyncChange at NDJSON line {i} from {route}: "
+                "missing required field(s)"
+            )
+        if raw.get("entityType") not in _SYNC_ENTITY_TYPES:
+            raise NetworkError(
+                f'Unexpected entityType "{raw.get("entityType")}" at NDJSON '
+                f"line {i} from {route}"
+            )
+        changes.append(SyncChange.model_validate(raw))
+    return changes
+
+
+def _build_push_ndjson(changes: List[SyncChange]) -> bytes:
+    """Serialize changes to NDJSON bytes (one entry per line, trailing newline).
+
+    Empty payload → empty body, matching the TS SDK and the server contract.
+    """
+    if not changes:
+        return b""
+    body = (
+        "\n".join(
+            json.dumps(c.model_dump(by_alias=True, exclude_none=False)) for c in changes
+        )
+        + "\n"
+    )
+    return body.encode("utf-8")
+
+
+# ============================================================================
+# Async resources
+# ============================================================================
+
+
+class SyncPeersResource(BaseResource):
+    """Async sub-resource for managing sync peers.
+
+    The peers routes (``/v1/sync/peers/*``) use BARE response shapes
+    (``{ peer }``, ``{ peers }``, ``{ removed, name }``) — they are NOT wrapped
+    in the standard ``{ success, data }`` envelope.
+    """
+
+    async def create(self, params: CreatePeerParams) -> SyncPeer:
+        """Register a new sync peer."""
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request("POST", "/v1/sync/peers", body)
+        return SyncPeer.model_validate(_require_peer(response, "POST /v1/sync/peers"))
+
+    async def list(self) -> List[SyncPeer]:
+        """List all registered sync peers."""
+        response = await self._request("GET", "/v1/sync/peers")
+        peers = _require_peers(response, "GET /v1/sync/peers")
+        return [SyncPeer.model_validate(p) for p in peers]
+
+    async def get(self, name: str) -> SyncPeer:
+        """Get a sync peer by name."""
+        response = await self._request(
+            "GET", f"/v1/sync/peers/{quote(name, safe='')}"
+        )
+        return SyncPeer.model_validate(
+            _require_peer(response, "GET /v1/sync/peers/{name}")
+        )
+
+    async def delete(self, name: str) -> dict:
+        """Delete a sync peer by name. Returns ``{ removed, name }``."""
+        return await self._request(
+            "DELETE", f"/v1/sync/peers/{quote(name, safe='')}"
+        )
+
+    async def link(self, name: str) -> None:
+        """Enable automatic sync link for a peer."""
+        await self._request("POST", f"/v1/sync/peers/{quote(name, safe='')}/link")
+
+    async def unlink(self, name: str) -> None:
+        """Disable automatic sync link for a peer."""
+        await self._request("DELETE", f"/v1/sync/peers/{quote(name, safe='')}/link")
+
+    async def pause(self, name: str) -> None:
+        """Pause an active sync link for a peer."""
+        await self._request(
+            "POST", f"/v1/sync/peers/{quote(name, safe='')}/link/pause"
+        )
+
+    async def resume(self, name: str) -> None:
+        """Resume a paused sync link for a peer."""
+        await self._request(
+            "POST", f"/v1/sync/peers/{quote(name, safe='')}/link/resume"
+        )
+
+
+class SyncResource(BaseResource):
+    """Async resource for multi-node data synchronization.
+
+    Provides push/pull replication, conflict detection and resolution, and
+    peer-to-peer sync orchestration. ``push``/``pull`` exchange the raw NDJSON
+    changelog wire format directly with a peer and are intended for tooling and
+    tests — routine background replication is driven by the server-side link
+    daemon.
+    """
+
+    def __init__(self, client: AsyncEngramClient) -> None:
+        super().__init__(client)
+        self._peers = SyncPeersResource(client)
+
+    @property
+    def peers(self) -> SyncPeersResource:
+        """Access the peers sub-resource for managing sync peers."""
+        return self._peers
+
+    async def push(self, changes: Optional[List[SyncChange]] = None) -> SyncPushResult:
+        """Push local changes to the server as NDJSON."""
+        response = await self._client._request_raw(
+            "POST",
+            "/v1/sync/push",
+            content=_build_push_ndjson(changes or []),
+            content_type="application/x-ndjson",
+        )
+        data = _unwrap_data(response.json(), "POST /v1/sync/push")
+        return SyncPushResult.model_validate(data)
+
+    async def pull(self, params: SyncPullParams) -> List[SyncChange]:
+        """Pull remote changes from the server (NDJSON response).
+
+        ``params.since_seq`` is required — pass ``None`` to pull from the
+        beginning of the changelog.
+        """
+        body = json.dumps(
+            params.model_dump(by_alias=True, exclude_none=True)
+            | {"sinceSeq": params.since_seq}
+        ).encode("utf-8")
+        response = await self._client._request_raw(
+            "POST", "/v1/sync/pull", content=body, content_type="application/json"
+        )
+        return _parse_pull_ndjson(response.text, "POST /v1/sync/pull")
+
+    async def get_status(self) -> SyncStatus:
+        """Get the current sync status."""
+        response = await self._request("GET", "/v1/sync/status")
+        return SyncStatus.model_validate(_unwrap_data(response, "GET /v1/sync/status"))
+
+    async def push_to(self, peer: str) -> SyncPushResult:
+        """Push local changes to a specific peer."""
+        response = await self._request(
+            "POST", "/v1/sync/push-to", params={"peer": peer}
+        )
+        return SyncPushResult.model_validate(
+            _unwrap_data(response, "POST /v1/sync/push-to")
+        )
+
+    async def pull_from(self, peer: str) -> SyncPullResult:
+        """Trigger a daemon-side pull from a specific peer."""
+        response = await self._request(
+            "POST", "/v1/sync/pull-from", params={"peer": peer}
+        )
+        return SyncPullResult.model_validate(
+            _unwrap_data(response, "POST /v1/sync/pull-from")
+        )
+
+    async def list_conflicts(
+        self, params: Optional[ListConflictsParams] = None
+    ) -> dict:
+        """List sync conflicts. Returns ``{ "conflicts": [...], "total": int }``."""
+        qs: Optional[dict] = None
+        if params is not None and params.unresolved is not None:
+            qs = {"unresolved": str(params.unresolved).lower()}
+        response = await self._request("GET", "/v1/sync/conflicts", params=qs)
+        data = _unwrap_data(response, "GET /v1/sync/conflicts")
+        if not isinstance(data, dict) or not isinstance(data.get("conflicts"), list):
+            raise EngramError(
+                "Unexpected GET /v1/sync/conflicts response shape "
+                f"(expected {{ conflicts, total }}); got: {_truncate_body(data)}",
+                code="INTERNAL_ERROR",
+            )
+        return {
+            "conflicts": [SyncConflict.model_validate(c) for c in data["conflicts"]],
+            "total": data.get("total", len(data["conflicts"])),
+        }
+
+    async def resolve_conflict(
+        self, conflict_id: str, params: Optional[ResolveConflictParams] = None
+    ) -> SyncConflict:
+        """Resolve a sync conflict by ID."""
+        body = (
+            params.model_dump(by_alias=True, exclude_none=True) if params else None
+        )
+        response = await self._request(
+            "POST",
+            f"/v1/sync/conflicts/{quote(conflict_id, safe='')}/resolve",
+            body,
+        )
+        return SyncConflict.model_validate(
+            _unwrap_data(response, "POST /v1/sync/conflicts/{id}/resolve")
+        )
+
+
+# ============================================================================
+# Sync (synchronous-client) resources
+# ============================================================================
+
+
+class SyncSyncPeersResource(SyncBaseResource):
+    """Synchronous-client sub-resource for managing sync peers."""
+
+    def create(self, params: CreatePeerParams) -> SyncPeer:
+        """Register a new sync peer."""
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request("POST", "/v1/sync/peers", body)
+        return SyncPeer.model_validate(_require_peer(response, "POST /v1/sync/peers"))
+
+    def list(self) -> List[SyncPeer]:
+        """List all registered sync peers."""
+        response = self._request("GET", "/v1/sync/peers")
+        peers = _require_peers(response, "GET /v1/sync/peers")
+        return [SyncPeer.model_validate(p) for p in peers]
+
+    def get(self, name: str) -> SyncPeer:
+        """Get a sync peer by name."""
+        response = self._request("GET", f"/v1/sync/peers/{quote(name, safe='')}")
+        return SyncPeer.model_validate(
+            _require_peer(response, "GET /v1/sync/peers/{name}")
+        )
+
+    def delete(self, name: str) -> dict:
+        """Delete a sync peer by name. Returns ``{ removed, name }``."""
+        return self._request("DELETE", f"/v1/sync/peers/{quote(name, safe='')}")
+
+    def link(self, name: str) -> None:
+        """Enable automatic sync link for a peer."""
+        self._request("POST", f"/v1/sync/peers/{quote(name, safe='')}/link")
+
+    def unlink(self, name: str) -> None:
+        """Disable automatic sync link for a peer."""
+        self._request("DELETE", f"/v1/sync/peers/{quote(name, safe='')}/link")
+
+    def pause(self, name: str) -> None:
+        """Pause an active sync link for a peer."""
+        self._request("POST", f"/v1/sync/peers/{quote(name, safe='')}/link/pause")
+
+    def resume(self, name: str) -> None:
+        """Resume a paused sync link for a peer."""
+        self._request("POST", f"/v1/sync/peers/{quote(name, safe='')}/link/resume")
+
+
+class SyncSyncResource(SyncBaseResource):
+    """Synchronous-client resource for multi-node data synchronization."""
+
+    def __init__(self, client: EngramClient) -> None:
+        super().__init__(client)
+        self._peers = SyncSyncPeersResource(client)
+
+    @property
+    def peers(self) -> SyncSyncPeersResource:
+        """Access the peers sub-resource for managing sync peers."""
+        return self._peers
+
+    def push(self, changes: Optional[List[SyncChange]] = None) -> SyncPushResult:
+        """Push local changes to the server as NDJSON."""
+        response = self._client._request_raw(
+            "POST",
+            "/v1/sync/push",
+            content=_build_push_ndjson(changes or []),
+            content_type="application/x-ndjson",
+        )
+        data = _unwrap_data(response.json(), "POST /v1/sync/push")
+        return SyncPushResult.model_validate(data)
+
+    def pull(self, params: SyncPullParams) -> List[SyncChange]:
+        """Pull remote changes from the server (NDJSON response)."""
+        body = json.dumps(
+            params.model_dump(by_alias=True, exclude_none=True)
+            | {"sinceSeq": params.since_seq}
+        ).encode("utf-8")
+        response = self._client._request_raw(
+            "POST", "/v1/sync/pull", content=body, content_type="application/json"
+        )
+        return _parse_pull_ndjson(response.text, "POST /v1/sync/pull")
+
+    def get_status(self) -> SyncStatus:
+        """Get the current sync status."""
+        response = self._request("GET", "/v1/sync/status")
+        return SyncStatus.model_validate(_unwrap_data(response, "GET /v1/sync/status"))
+
+    def push_to(self, peer: str) -> SyncPushResult:
+        """Push local changes to a specific peer."""
+        response = self._request("POST", "/v1/sync/push-to", params={"peer": peer})
+        return SyncPushResult.model_validate(
+            _unwrap_data(response, "POST /v1/sync/push-to")
+        )
+
+    def pull_from(self, peer: str) -> SyncPullResult:
+        """Trigger a daemon-side pull from a specific peer."""
+        response = self._request("POST", "/v1/sync/pull-from", params={"peer": peer})
+        return SyncPullResult.model_validate(
+            _unwrap_data(response, "POST /v1/sync/pull-from")
+        )
+
+    def list_conflicts(self, params: Optional[ListConflictsParams] = None) -> dict:
+        """List sync conflicts. Returns ``{ "conflicts": [...], "total": int }``."""
+        qs: Optional[dict] = None
+        if params is not None and params.unresolved is not None:
+            qs = {"unresolved": str(params.unresolved).lower()}
+        response = self._request("GET", "/v1/sync/conflicts", params=qs)
+        data = _unwrap_data(response, "GET /v1/sync/conflicts")
+        if not isinstance(data, dict) or not isinstance(data.get("conflicts"), list):
+            raise EngramError(
+                "Unexpected GET /v1/sync/conflicts response shape "
+                f"(expected {{ conflicts, total }}); got: {_truncate_body(data)}",
+                code="INTERNAL_ERROR",
+            )
+        return {
+            "conflicts": [SyncConflict.model_validate(c) for c in data["conflicts"]],
+            "total": data.get("total", len(data["conflicts"])),
+        }
+
+    def resolve_conflict(
+        self, conflict_id: str, params: Optional[ResolveConflictParams] = None
+    ) -> SyncConflict:
+        """Resolve a sync conflict by ID."""
+        body = (
+            params.model_dump(by_alias=True, exclude_none=True) if params else None
+        )
+        response = self._request(
+            "POST",
+            f"/v1/sync/conflicts/{quote(conflict_id, safe='')}/resolve",
+            body,
+        )
+        return SyncConflict.model_validate(
+            _unwrap_data(response, "POST /v1/sync/conflicts/{id}/resolve")
+        )

--- a/packages/sdk-python/engram/resources/users.py
+++ b/packages/sdk-python/engram/resources/users.py
@@ -1,0 +1,192 @@
+"""User resources for the Engram SDK.
+
+Resource-based interface for user management: user creation (with an initial
+API key), listing, lookup, and deletion (optionally revoking API keys).
+
+Mirrors the TypeScript SDK's ``UsersResource``
+(``packages/sdk/src/resources/users.ts``).
+
+The user endpoints use the standard ``{ data }`` envelope. The single-object
+routes nest their payload one level deeper:
+
+* ``POST /v1/users`` -> ``{ data: { user, key } }``
+* ``GET /v1/users`` -> ``{ data: { users: [...] } }``
+* ``GET /v1/users/:idOrName`` -> ``{ data: { user } }``
+* ``DELETE /v1/users/:idOrName`` -> ``{ data: { deleted, revokedKeys } }``
+"""
+from __future__ import annotations
+
+from typing import List, Optional, TYPE_CHECKING
+from urllib.parse import quote
+
+from engram._base import BaseResource, SyncBaseResource
+from engram.types.users import (
+    CreateUserParams,
+    CreateUserResult,
+    DeleteUserResult,
+    User,
+)
+
+if TYPE_CHECKING:
+    from engram.client import AsyncEngramClient, EngramClient
+
+
+class UsersResource(BaseResource):
+    """Async resource for user accounts and API key provisioning.
+
+    Example::
+
+        # Create a new user (returns user + initial API key)
+        result = await client.users.create(CreateUserParams(name="alice"))
+
+        # List all users
+        users = await client.users.list()
+
+        # Get a user by ID or name
+        user = await client.users.get("alice")
+
+        # Delete a user and revoke their keys
+        result = await client.users.delete("alice", revoke_keys=True)
+    """
+
+    async def create(self, params: CreateUserParams) -> CreateUserResult:
+        """Create a new user. Returns the user and an initial API key.
+
+        Args:
+            params: The user creation parameters (``name`` and optional
+                ``display_name``).
+
+        Returns:
+            The created user and its initial API key.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = await self._request("POST", "/v1/users", body)
+        return CreateUserResult.model_validate(response["data"])
+
+    async def list(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[User]:
+        """List all users.
+
+        Args:
+            limit: Maximum number of results to return.
+            offset: Number of results to skip.
+
+        Returns:
+            A list of users.
+        """
+        qs: dict[str, str] = {}
+        if limit is not None:
+            qs["limit"] = str(limit)
+        if offset is not None:
+            qs["offset"] = str(offset)
+        response = await self._request(
+            "GET", "/v1/users", params=qs if qs else None
+        )
+        return [User.model_validate(u) for u in response["data"]["users"]]
+
+    async def get(self, id_or_name: str) -> User:
+        """Get a user by ID or name.
+
+        Args:
+            id_or_name: The user ID or name.
+
+        Returns:
+            The user.
+        """
+        response = await self._request(
+            "GET", f"/v1/users/{quote(id_or_name, safe='')}"
+        )
+        return User.model_validate(response["data"]["user"])
+
+    async def delete(
+        self, id_or_name: str, revoke_keys: bool = False
+    ) -> DeleteUserResult:
+        """Delete a user by ID or name, optionally revoking all their API keys.
+
+        Args:
+            id_or_name: The user ID or name.
+            revoke_keys: When ``True``, revoke all of the user's API keys.
+
+        Returns:
+            Deletion result, including the count of revoked keys.
+        """
+        params = {"revokeKeys": "true"} if revoke_keys else None
+        response = await self._request(
+            "DELETE", f"/v1/users/{quote(id_or_name, safe='')}", params=params
+        )
+        return DeleteUserResult.model_validate(response["data"])
+
+
+class SyncUsersResource(SyncBaseResource):
+    """Sync resource for user accounts and API key provisioning."""
+
+    def create(self, params: CreateUserParams) -> CreateUserResult:
+        """Create a new user. Returns the user and an initial API key.
+
+        Args:
+            params: The user creation parameters (``name`` and optional
+                ``display_name``).
+
+        Returns:
+            The created user and its initial API key.
+        """
+        body = params.model_dump(by_alias=True, exclude_none=True)
+        response = self._request("POST", "/v1/users", body)
+        return CreateUserResult.model_validate(response["data"])
+
+    def list(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[User]:
+        """List all users.
+
+        Args:
+            limit: Maximum number of results to return.
+            offset: Number of results to skip.
+
+        Returns:
+            A list of users.
+        """
+        qs: dict[str, str] = {}
+        if limit is not None:
+            qs["limit"] = str(limit)
+        if offset is not None:
+            qs["offset"] = str(offset)
+        response = self._request("GET", "/v1/users", params=qs if qs else None)
+        return [User.model_validate(u) for u in response["data"]["users"]]
+
+    def get(self, id_or_name: str) -> User:
+        """Get a user by ID or name.
+
+        Args:
+            id_or_name: The user ID or name.
+
+        Returns:
+            The user.
+        """
+        response = self._request(
+            "GET", f"/v1/users/{quote(id_or_name, safe='')}"
+        )
+        return User.model_validate(response["data"]["user"])
+
+    def delete(
+        self, id_or_name: str, revoke_keys: bool = False
+    ) -> DeleteUserResult:
+        """Delete a user by ID or name, optionally revoking all their API keys.
+
+        Args:
+            id_or_name: The user ID or name.
+            revoke_keys: When ``True``, revoke all of the user's API keys.
+
+        Returns:
+            Deletion result, including the count of revoked keys.
+        """
+        params = {"revokeKeys": "true"} if revoke_keys else None
+        response = self._request(
+            "DELETE", f"/v1/users/{quote(id_or_name, safe='')}", params=params
+        )
+        return DeleteUserResult.model_validate(response["data"])

--- a/packages/sdk-python/engram/types/__init__.py
+++ b/packages/sdk-python/engram/types/__init__.py
@@ -1,5 +1,10 @@
 """Engram SDK type definitions."""
 from engram.types.common import *  # noqa: F401, F403
+# NOTE: the replication sync module is imported BEFORE terrafirma so that
+# terrafirma's `SyncStatus` (its long-standing public flat-namespace export)
+# wins the name. The replication `SyncStatus` stays reachable as
+# `engram.types.sync.SyncStatus`.
+from engram.types.sync import *  # noqa: F401, F403
 from engram.types.sessions import *  # noqa: F401, F403
 from engram.types.knowledge_crystal import *  # noqa: F401, F403
 from engram.types.crystals import *  # noqa: F401, F403
@@ -12,3 +17,12 @@ from engram.types.events import *  # noqa: F401, F403
 from engram.types.export_import import *  # noqa: F401, F403
 from engram.types.reranking import *  # noqa: F401, F403
 from engram.types.entities import *  # noqa: F401, F403
+from engram.types.maintenance import *  # noqa: F401, F403
+from engram.types.dedup_merge import *  # noqa: F401, F403
+from engram.types.agents import *  # noqa: F401, F403
+from engram.types.ambient_context import *  # noqa: F401, F403
+from engram.types.facts import *  # noqa: F401, F403
+from engram.types.gc import *  # noqa: F401, F403
+from engram.types.memory_spaces import *  # noqa: F401, F403
+from engram.types.users import *  # noqa: F401, F403
+from engram.types.shimmers import *  # noqa: F401, F403

--- a/packages/sdk-python/engram/types/__init__.py
+++ b/packages/sdk-python/engram/types/__init__.py
@@ -1,9 +1,5 @@
 """Engram SDK type definitions."""
 from engram.types.common import *  # noqa: F401, F403
-# NOTE: the replication sync module is imported BEFORE terrafirma so that
-# terrafirma's `SyncStatus` (its long-standing public flat-namespace export)
-# wins the name. The replication `SyncStatus` stays reachable as
-# `engram.types.sync.SyncStatus`.
 from engram.types.sync import *  # noqa: F401, F403
 from engram.types.sessions import *  # noqa: F401, F403
 from engram.types.knowledge_crystal import *  # noqa: F401, F403
@@ -26,3 +22,10 @@ from engram.types.gc import *  # noqa: F401, F403
 from engram.types.memory_spaces import *  # noqa: F401, F403
 from engram.types.users import *  # noqa: F401, F403
 from engram.types.shimmers import *  # noqa: F401, F403
+
+# `SyncStatus` is defined in BOTH terrafirma (filesystem sync) and sync
+# (multi-node replication). Bind the flat-namespace `engram.types.SyncStatus`
+# to terrafirma's — its long-standing public export — EXPLICITLY here so the
+# resolution does not depend on star-import order. The replication status type
+# stays reachable as `engram.types.sync.SyncStatus` (and via `client.sync`).
+from engram.types.terrafirma import SyncStatus as SyncStatus  # noqa: F401

--- a/packages/sdk-python/engram/types/agents.py
+++ b/packages/sdk-python/engram/types/agents.py
@@ -1,0 +1,79 @@
+"""Agent identity types for the Engram SDK.
+
+Mirrors the TypeScript SDK's agents types
+(``packages/sdk/src/resources/agents.ts``).
+
+Agent records are returned wrapped in a nested envelope: a single agent as
+``{ data: { agent } }`` and a list as ``{ data: { agents } }``. The resource
+unwraps these inner keys rather than treating ``data`` itself as the payload.
+
+Request params use ``populate_by_name=True`` + ``alias_generator=to_camel`` so
+snake_case Python fields serialize to the camelCase wire fields the server
+expects (e.g. ``external_id`` -> ``externalId``).
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "AgentIdentity",
+    "CreateAgentParams",
+    "UpdateAgentParams",
+    "ListAgentsParams",
+    "DeleteAgentResult",
+]
+
+
+class AgentIdentity(BaseModel):
+    """An agent identity record."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(alias="agentId")
+    external_id: str = Field(alias="externalId")
+    display_name: str = Field(alias="displayName")
+    role: str
+    permissions: List[str]
+    owner_user_id: Optional[str] = Field(None, alias="ownerUserId")
+    created_at: str = Field(alias="createdAt")
+    last_active_at: Optional[str] = Field(None, alias="lastActiveAt")
+
+
+class CreateAgentParams(BaseModel):
+    """Parameters for creating (idempotently upserting) an agent."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    external_id: str
+    display_name: str
+    role: Optional[str] = None
+    permissions: Optional[List[str]] = None
+    owner_user_id: Optional[str] = None
+
+
+class UpdateAgentParams(BaseModel):
+    """Parameters for updating an agent's display name and/or permissions."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    display_name: Optional[str] = None
+    permissions: Optional[List[str]] = None
+
+
+class ListAgentsParams(BaseModel):
+    """Parameters for filtering the agent list."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    owner_user_id: Optional[str] = None
+
+
+class DeleteAgentResult(BaseModel):
+    """Result of a soft-delete agent operation."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    deleted: bool

--- a/packages/sdk-python/engram/types/ambient_context.py
+++ b/packages/sdk-python/engram/types/ambient_context.py
@@ -1,0 +1,42 @@
+"""Ambient context types for the Engram SDK.
+
+Mirrors the TypeScript SDK's ambient-context types
+(``packages/sdk/src/resources/ambient-context.ts``).
+
+Role-biased ambient knowledge context: crystals ranked by relevance to the
+current agent's role.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "AmbientCrystal",
+    "GetAmbientContextParams",
+]
+
+
+class AmbientCrystal(BaseModel):
+    """A crystal returned in an ambient-context query, with a relevance score."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    title: str
+    description: Optional[str] = None
+    node_type: str
+    tags: List[str]
+    relevance_score: float
+
+
+class GetAmbientContextParams(BaseModel):
+    """Parameters for fetching ambient context for a session."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    session_id: str
+    role: Optional[str] = None
+    limit: Optional[int] = None

--- a/packages/sdk-python/engram/types/dedup_merge.py
+++ b/packages/sdk-python/engram/types/dedup_merge.py
@@ -1,0 +1,136 @@
+"""Dedup / deferred-merge review types (P11 lifecycle) for the Engram SDK.
+
+Mirrors the TypeScript SDK's dedup-merge types
+(``packages/sdk/src/resources/crystals.ts`` and
+``packages/sdk/src/resources/sessions.ts``).
+
+Several of these routes return **bare** (non-enveloped) bodies — see the
+resource methods (``crystals.pending_merges`` / ``review_merge`` /
+``merge_history`` and ``notes.dedup``) for the unwrapping rules.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "DedupMergeMethod",
+    "DedupMergeOutcomeStrategy",
+    "MergeReviewDecision",
+    "NoteDedupAction",
+    "PendingMerge",
+    "ListPendingMergesParams",
+    "MergeRecord",
+    "ReviewMergeParams",
+    "ReviewMergeResult",
+    "DedupNoteParams",
+    "DedupNoteResult",
+]
+
+
+# How a duplicate was detected/merged.
+DedupMergeMethod = Literal["semantic", "exact", "manual"]
+
+# Which side survives a merge.
+DedupMergeOutcomeStrategy = Literal["oldest_wins", "user_selected"]
+
+# Decision passed to ``crystals.review_merge``.
+MergeReviewDecision = Literal["approve", "reject", "modify"]
+
+# Outcome of a note dedup check.
+NoteDedupAction = Literal["merged", "deferred", "no_match"]
+
+
+class PendingMerge(BaseModel):
+    """A deferred merge candidate awaiting review (camelCase wire shape)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    merge_id: str
+    source_id: str
+    target_id: str
+    source_type: Literal["session_note", "knowledge_crystal"]
+    target_type: Literal["knowledge_crystal"]
+    confidence: float
+    merge_method: DedupMergeMethod
+    merge_outcome_strategy: DedupMergeOutcomeStrategy
+    created_at: str
+
+
+class ListPendingMergesParams(BaseModel):
+    """Filters for ``crystals.pending_merges``."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    session_id: Optional[str] = None
+    limit: Optional[int] = None
+
+
+class MergeRecord(BaseModel):
+    """A single record in a merge provenance chain (camelCase wire shape)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    source_note_id: Optional[str] = None
+    source_crystal_id: Optional[str] = None
+    target_crystal_id: str
+    merge_method: DedupMergeMethod
+    merge_outcome_strategy: DedupMergeOutcomeStrategy
+    similarity_score: Optional[float] = None
+    merge_reason: str
+    merged_content_snapshot: Dict[str, Any]
+    merged_by: str
+    merged_at: str
+    reversible: bool
+    reverse_record_id: Optional[str] = None
+    created_at: str
+
+
+class ReviewMergeParams(BaseModel):
+    """Params for ``crystals.review_merge``.
+
+    ``merged_content`` is required when ``decision`` is ``"modify"`` (the server
+    rejects a ``modify`` without it with a 400 ``VALIDATION_ERROR``).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    decision: MergeReviewDecision
+    merged_content: Optional[str] = None
+
+
+class ReviewMergeResult(BaseModel):
+    """Result of ``crystals.review_merge``."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    decision: MergeReviewDecision
+    # The surviving crystal id (present on approve/modify, absent on reject).
+    target_crystal_id: Optional[str] = None
+
+
+class DedupNoteParams(BaseModel):
+    """Request body for ``notes.dedup``.
+
+    Both fields are accepted on the wire for forward-compatibility but are not
+    currently read by the server.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    merge_method: Optional[Literal["semantic", "exact"]] = None
+    threshold: Optional[float] = None
+
+
+class DedupNoteResult(BaseModel):
+    """Result of ``notes.dedup`` (bare, non-enveloped, snake_case wire body)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: NoteDedupAction
+    merge_id: Optional[str] = None
+    confidence: Optional[float] = None
+    canonical_id: Optional[str] = None

--- a/packages/sdk-python/engram/types/facts.py
+++ b/packages/sdk-python/engram/types/facts.py
@@ -1,0 +1,66 @@
+"""Fact types for the Engram SDK.
+
+Bi-temporal fact types mirroring the TypeScript SDK's facts types
+(``packages/sdk/src/resources/facts.ts``).
+
+Facts are versioned with point-in-time (``validAt`` / ``asOf``) queries and a
+full version history. Single-object responses are wrapped in the standard
+``{ data }`` envelope; history is a paginated list.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "Fact",
+    "CreateFactParams",
+    "UpdateFactParams",
+    "FactHistoryParams",
+]
+
+
+class Fact(BaseModel):
+    """A bi-temporal fact version."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    key: str
+    value: Dict[str, Any]
+    valid_from: str
+    valid_to: Optional[str] = None
+    created_at: str
+    updated_at: str
+
+
+class CreateFactParams(BaseModel):
+    """Parameters for creating a new fact."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    key: str
+    value: Dict[str, Any]
+    valid_at: Optional[str] = None
+
+
+class UpdateFactParams(BaseModel):
+    """Parameters for updating an existing fact."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    value: Dict[str, Any]
+    valid_at: Optional[str] = None
+
+
+class FactHistoryParams(BaseModel):
+    """Parameters for querying the version history of a fact."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    valid_from: Optional[str] = None
+    valid_to: Optional[str] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None

--- a/packages/sdk-python/engram/types/gc.py
+++ b/packages/sdk-python/engram/types/gc.py
@@ -1,0 +1,127 @@
+"""Garbage-collection (GC) operation types for the Engram SDK.
+
+Mirrors the TypeScript SDK's GC types
+(``packages/sdk/src/resources/gc.ts``).
+
+GC endpoints return the standard ``{ data, meta }`` envelope. ``getCandidates``
+and ``getAuditLog`` carry their list payload nested under ``data`` together with
+a sibling ``threshold``/``total`` scalar, and ``hasMore`` is sourced from
+``meta.pagination.hasMore``; the resource folds that into the result models
+below.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "GcCandidate",
+    "GcAuditEntry",
+    "GcRunResult",
+    "GcCandidatesResult",
+    "GcAuditResult",
+    "ListGcCandidatesParams",
+    "ListGcAuditParams",
+    "GcRunOptions",
+]
+
+
+class GcCandidate(BaseModel):
+    """A garbage-collection candidate ranked by relevance score."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    title: str
+    node_type: str
+    relevance_score: float
+    access_count: int
+    last_accessed_at: Optional[str] = None
+    created_at: str
+    verified: bool
+    lifecycle_status: str
+
+
+class GcAuditEntry(BaseModel):
+    """An entry in the GC audit log describing a previous run."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    run_at: str
+    decay_curve: str
+    threshold: float
+    scanned_crystals: int
+    archived_crystals: int
+    scanned_notes: int
+    archived_notes: int
+    dry_run: bool
+    details: Dict[str, Any]
+
+
+class GcRunResult(BaseModel):
+    """Result of a garbage-collection run."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    scanned_crystals: int
+    archived_crystals: int
+    scanned_notes: int
+    archived_notes: int
+    dry_run: bool
+
+
+class GcCandidatesResult(BaseModel):
+    """Aggregate result of listing GC candidates.
+
+    ``has_more`` is folded in by the resource from ``meta.pagination.hasMore``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    candidates: List[GcCandidate]
+    threshold: float
+    total: int
+    has_more: bool = False
+
+
+class GcAuditResult(BaseModel):
+    """Aggregate result of reading the GC audit log.
+
+    ``has_more`` is folded in by the resource from ``meta.pagination.hasMore``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    entries: List[GcAuditEntry]
+    total: int
+    has_more: bool = False
+
+
+class ListGcCandidatesParams(BaseModel):
+    """Query parameters for listing GC candidates."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    threshold: Optional[float] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+
+
+class ListGcAuditParams(BaseModel):
+    """Query parameters for reading the GC audit log."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+
+
+class GcRunOptions(BaseModel):
+    """Options for triggering a GC run."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    dry_run: Optional[bool] = None

--- a/packages/sdk-python/engram/types/memory_spaces.py
+++ b/packages/sdk-python/engram/types/memory_spaces.py
@@ -1,0 +1,88 @@
+"""Memory space types for the Engram SDK.
+
+Mirrors the TypeScript SDK's memory-spaces types
+(``packages/sdk/src/resources/memory-spaces.ts``).
+
+Memory spaces are shared knowledge containers that let multiple agents
+collaborate within a single space. These endpoints use the standard
+``{ data }`` envelope, with the inner payload keyed by member name
+(``{ data: { space } }``, ``{ data: { spaces } }``, ``{ data: { member } }``).
+"""
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "MemorySpacePermission",
+    "MemorySpace",
+    "MemorySpaceMember",
+    "MemorySpaceWithMembers",
+    "MemorySpaceInitialMember",
+    "CreateMemorySpaceParams",
+    "JoinMemorySpaceParams",
+]
+
+
+MemorySpacePermission = Literal["read", "write", "admin"]
+
+
+class MemorySpace(BaseModel):
+    """A shared memory space."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    title: str
+    description: Optional[str] = None
+    visibility: Literal["private", "shared"]
+    node_type: Literal["memory_space"]
+    created_at: str
+    updated_at: str
+
+
+class MemorySpaceMember(BaseModel):
+    """A member of a memory space."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    agent_id: str
+    permission: MemorySpacePermission
+    joined_at: str
+
+
+class MemorySpaceWithMembers(MemorySpace):
+    """A memory space including its members."""
+
+    members: List[MemorySpaceMember] = []
+
+
+class MemorySpaceInitialMember(BaseModel):
+    """An initial member specification used when creating a memory space."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    agent_id: str
+    permission: MemorySpacePermission
+
+
+class CreateMemorySpaceParams(BaseModel):
+    """Parameters for creating a memory space."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    title: str
+    description: Optional[str] = None
+    visibility: Optional[Literal["private", "shared"]] = None
+    initial_members: Optional[List[MemorySpaceInitialMember]] = None
+
+
+class JoinMemorySpaceParams(BaseModel):
+    """Parameters for joining a memory space."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    agent_id: str
+    permission: MemorySpacePermission

--- a/packages/sdk-python/engram/types/shimmers.py
+++ b/packages/sdk-python/engram/types/shimmers.py
@@ -1,0 +1,132 @@
+"""Shimmer types for the Engram SDK.
+
+Mirrors the TypeScript SDK's shimmer types
+(``packages/sdk/src/types/shimmer.ts``, ADR-027 / engram-server #931, #933).
+
+A *shimmer* is node-local, TTL-backed operational state — what engram is *doing
+right now* (in contrast to a crystal, what it *remembers*). Three record types,
+each with its own write semantic:
+
+- **lock** — CAS acquire / hold / renew + TTL lease; the ``owner_token`` is the
+  holder's release/renew capability.
+- **heartbeat** — last-writer-wins overwrite + TTL liveness window; NEVER CAS.
+- **ipc** — write-once + atomic exactly-once delete-on-consume + TTL backstop.
+
+**Security (engram-server #933 P1):** a lock's ``owner_token`` is REDACTED to
+``None`` on every response a non-owner can observe — reads (:meth:`get`) and 409
+CAS-conflict bodies. The token is echoed back ONLY on a successful
+acquire/renew, and only the value the caller itself supplied.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "ShimmerRecordType",
+    "Shimmer",
+    "ShimmerRead",
+    "ShimmerDeleteResult",
+    "AcquireLockParams",
+    "RenewLockParams",
+    "ReleaseLockParams",
+]
+
+
+ShimmerRecordType = Literal["lock", "heartbeat", "ipc"]
+"""The three shimmer record types.
+
+- ``lock``: CAS acquire/hold/renew/release + TTL lease.
+- ``heartbeat``: overwrite / last-writer-wins + TTL liveness window (never CAS).
+- ``ipc``: write-once + atomic exactly-once delete-on-consume + TTL backstop.
+"""
+
+
+class Shimmer(BaseModel):
+    """A shimmer record as returned by an acquire/renew success.
+
+    The only response that may carry an ``owner_token`` (the caller's own,
+    echoed back). For lock acquire/renew the token is non-null; for
+    heartbeat/ipc it is always null.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    record_type: ShimmerRecordType
+    record_key: str
+    value: Any = None
+    owner_token: Optional[str] = None
+    revision: int
+    created_at: str
+    updated_at: str
+    fades_at: str
+
+
+class ShimmerRead(BaseModel):
+    """A shimmer as returned by a TTL-filtered read (:meth:`get`).
+
+    Identical to :class:`Shimmer` except the ``owner_token`` is ALWAYS ``None``
+    — a reader never learns another client's lock token (engram-server #933 P1).
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    record_type: ShimmerRecordType
+    record_key: str
+    value: Any = None
+    owner_token: None = None
+    revision: int
+    created_at: str
+    updated_at: str
+    fades_at: str
+
+
+class ShimmerDeleteResult(BaseModel):
+    """Result of a DELETE — lock release or ipc consume.
+
+    - lock release: ``released`` is true iff an owner-matched live lock was
+      deleted; ``consumed`` is always ``None``.
+    - ipc consume: ``consumed`` is the exactly-once consumed record (with its
+      ``owner_token`` redacted to ``None``), or ``None`` when no live message
+      existed; ``released`` mirrors ``consumed is not None``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    released: bool
+    consumed: Optional[ShimmerRead] = None
+
+
+class AcquireLockParams(BaseModel):
+    """Options for acquiring a lock."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    owner_token: str
+    ttl_seconds: int
+    value: Any = None
+
+
+class RenewLockParams(BaseModel):
+    """Options for renewing a held lock (CAS)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    owner_token: str
+    expected_revision: int
+    ttl_seconds: int
+    value: Any = None
+
+
+class ReleaseLockParams(BaseModel):
+    """Options for releasing a lock (owner-guarded).
+
+    Must match the live holder; a non-holder gets ``released=False``, not an
+    error.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    owner_token: str

--- a/packages/sdk-python/engram/types/sync.py
+++ b/packages/sdk-python/engram/types/sync.py
@@ -1,0 +1,195 @@
+"""Sync (multi-node replication) types for the Engram SDK.
+
+Mirrors the TypeScript SDK's sync types
+(``packages/sdk/src/resources/sync.ts``).
+
+The ``/v1/sync`` routes use the standard ``{ success, data }`` envelope, EXCEPT
+the peer routes (``/v1/sync/peers/*``) which return BARE shapes (``{ peer }``,
+``{ peers }``, ``{ removed, name }``). Push/pull exchange the raw NDJSON
+changelog wire format. See the resource module for the unwrapping rules.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "SyncEntityType",
+    "SyncPeer",
+    "SyncConflict",
+    "SyncStatus",
+    "SyncChange",
+    "SyncCountEntry",
+    "SyncCounts",
+    "SyncPushResult",
+    "SyncPullResult",
+    "CreatePeerParams",
+    "SyncPullParams",
+    "ListConflictsParams",
+    "ResolveConflictParams",
+]
+
+
+# The four entity types the server tracks in the sync changelog. Matches the
+# server's ``SyncEntityType`` enum.
+SyncEntityType = Literal[
+    "knowledge_crystals",
+    "knowledge_crystal_edges",
+    "sessions",
+    "session_notes",
+]
+
+
+class SyncPeer(BaseModel):
+    """A registered sync peer."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    name: str
+    url: str
+    last_push_at: Optional[str] = None
+    last_pull_at: Optional[str] = None
+    last_push_seq: Optional[str] = None
+    last_pull_seq: Optional[str] = None
+    link_enabled: bool
+    link_interval_seconds: int
+    link_last_sync_at: Optional[str] = None
+    link_last_error: Optional[str] = None
+    link_paused: bool
+    created_at: str
+    updated_at: str
+
+
+class SyncConflict(BaseModel):
+    """A single sync conflict record."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    entity_type: str
+    entity_id: str
+    field_name: str
+    local_value: Any = None
+    remote_value: Any = None
+    local_updated_at: Optional[str] = None
+    remote_updated_at: Optional[str] = None
+    winner: str
+    resolution: str
+    resolved_at: Optional[str] = None
+    created_at: str
+
+
+class SyncStatus(BaseModel):
+    """The current sync status of this instance."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    instance_id: str
+    schema_version: str
+    peers_count: int
+    active_links_count: int
+    changelog_size: int
+
+
+class SyncChange(BaseModel):
+    """A single change record in the sync changelog.
+
+    One NDJSON line in the ``push`` body and the ``pull`` response stream.
+    Matches the server's serialized ``SyncChangelogEntry`` wire shape.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    seq: str
+    entity_type: SyncEntityType
+    entity_id: str
+    operation: Literal["insert", "update", "delete"]
+    changed_fields: Optional[Dict[str, Any]] = None
+    previous_values: Optional[Dict[str, Any]] = None
+    created_at: str
+
+
+class SyncCountEntry(BaseModel):
+    """Apply counts for a single entity type."""
+
+    inserted: int
+    updated: int
+    skipped: int
+
+
+class SyncCounts(BaseModel):
+    """Per-entity-type apply counts returned by push operations.
+
+    The server always populates all four entity-type keys. The wire keys are
+    the snake_case entity-type identifiers (NOT camelCase), so this model does
+    NOT use the camel alias generator.
+    """
+
+    knowledge_crystals: SyncCountEntry
+    knowledge_crystal_edges: SyncCountEntry
+    sessions: SyncCountEntry
+    session_notes: SyncCountEntry
+
+
+class SyncPushResult(BaseModel):
+    """Result of applying a batch of changes (``push`` / ``push_to``)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    counts: SyncCounts
+    conflicts: int
+    duration: float
+
+
+class SyncPullResult(BaseModel):
+    """Result of triggering a daemon-side pull from a named peer (``pull_from``)."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    entries_streamed: int
+    max_seq: Optional[str] = None
+    duration: float
+
+
+class CreatePeerParams(BaseModel):
+    """Parameters for registering a sync peer."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    name: str
+    url: str
+    api_key: Optional[str] = None
+
+
+class SyncPullParams(BaseModel):
+    """Parameters for pulling changelog entries.
+
+    ``since_seq`` is required by the server (``POST /v1/sync/pull`` rejects a
+    missing ``sinceSeq`` with a 400). Pass ``None`` to pull from the beginning
+    of the changelog.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    since_seq: Optional[str] = None
+    entity_types: Optional[List[SyncEntityType]] = None
+
+
+class ListConflictsParams(BaseModel):
+    """Parameters for listing sync conflicts."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    unresolved: Optional[bool] = None
+
+
+class ResolveConflictParams(BaseModel):
+    """Parameters for resolving a sync conflict."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    resolution: Optional[Literal["local", "remote"]] = None
+    rationale: Optional[str] = None

--- a/packages/sdk-python/engram/types/users.py
+++ b/packages/sdk-python/engram/types/users.py
@@ -1,0 +1,76 @@
+"""User management types for the Engram SDK.
+
+Mirrors the TypeScript SDK's user types
+(``packages/sdk/src/resources/users.ts``).
+
+The user endpoints use the standard ``{ data }`` envelope. The single-object
+routes nest their payload one level deeper (e.g. ``{ data: { user } }`` /
+``{ data: { user, key } }``); the resource unwraps that member before
+validation, so these models describe the inner payload shapes only.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = [
+    "User",
+    "ApiKey",
+    "CreateUserParams",
+    "CreateUserResult",
+    "DeleteUserResult",
+]
+
+
+class User(BaseModel):
+    """A user account."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    name: str
+    display_name: Optional[str] = None
+    created_at: str
+
+
+class ApiKey(BaseModel):
+    """An API key provisioned for a user.
+
+    The plaintext ``value`` is returned only at creation time.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str
+    name: str
+    prefix: str
+    value: str
+
+
+class CreateUserParams(BaseModel):
+    """Parameters for creating a user."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    name: str
+    display_name: Optional[str] = None
+
+
+class CreateUserResult(BaseModel):
+    """Result of creating a user: the user plus its initial API key."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    user: User
+    key: ApiKey
+
+
+class DeleteUserResult(BaseModel):
+    """Result of deleting a user."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    deleted: bool
+    revoked_keys: int

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "engram-py"
-version = "1.0.0"
+version = "2.1.0"
 description = "Python SDK for Engram Memory Server"
 readme = "README.md"
 license = "MIT"

--- a/packages/sdk-python/tests/test_agents.py
+++ b/packages/sdk-python/tests/test_agents.py
@@ -1,0 +1,277 @@
+"""Tests for the agents resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body/query and
+response parsing. Agent responses use a NESTED envelope — ``{ data: { agent } }``
+for a single agent and ``{ data: { agents } }`` for a list — so the resource
+must unwrap the inner ``agent``/``agents`` key, not treat ``data`` as the payload.
+
+The resource is instantiated directly against the client (rather than via a
+``client.agents`` attribute) so these tests do not depend on central client
+wiring done by the coordinator.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.errors import EngramError
+from engram.resources.agents import AgentsResource, SyncAgentsResource
+from engram.types.agents import (
+    AgentIdentity,
+    CreateAgentParams,
+    ListAgentsParams,
+    UpdateAgentParams,
+)
+
+
+SAMPLE_AGENT = {
+    "agentId": "agent-123",
+    "externalId": "ext-abc",
+    "displayName": "Test Agent",
+    "role": "assistant",
+    "permissions": ["read", "write"],
+    "ownerUserId": "user-1",
+    "createdAt": "2026-01-01T00:00:00Z",
+    "lastActiveAt": None,
+}
+
+
+def _resp(json_data, method="GET", path="/v1/agents") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json=json_data,
+        request=httpx.Request(method, f"http://test:3100{path}"),
+    )
+
+
+class TestSyncAgentsResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.agents = SyncAgentsResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_create_posts_and_unwraps_agent(self, mock_request):
+        mock_request.return_value = _resp({"data": {"agent": SAMPLE_AGENT}}, "POST")
+
+        result = self.agents.create(
+            CreateAgentParams(
+                external_id="ext-abc",
+                display_name="Test Agent",
+                role="assistant",
+                permissions=["read", "write"],
+                owner_user_id="user-1",
+            )
+        )
+
+        assert isinstance(result, AgentIdentity)
+        assert result.agent_id == "agent-123"
+        assert result.external_id == "ext-abc"
+        assert result.permissions == ["read", "write"]
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/agents"
+        # snake_case params serialize to camelCase wire fields; None dropped.
+        assert call_args[1]["json"] == {
+            "externalId": "ext-abc",
+            "displayName": "Test Agent",
+            "role": "assistant",
+            "permissions": ["read", "write"],
+            "ownerUserId": "user-1",
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_create_drops_unset_optionals(self, mock_request):
+        mock_request.return_value = _resp({"data": {"agent": SAMPLE_AGENT}}, "POST")
+
+        self.agents.create(
+            CreateAgentParams(external_id="ext-abc", display_name="Test Agent")
+        )
+
+        assert mock_request.call_args[1]["json"] == {
+            "externalId": "ext-abc",
+            "displayName": "Test Agent",
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_list_unwraps_agents_array(self, mock_request):
+        mock_request.return_value = _resp({"data": {"agents": [SAMPLE_AGENT]}})
+
+        result = self.agents.list()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].agent_id == "agent-123"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/agents"
+        # No filter -> no query params reach httpx.
+        assert "params" not in call_args[1] or call_args[1]["params"] is None
+
+    @patch.object(httpx.Client, "request")
+    def test_list_passes_owner_filter_as_query(self, mock_request):
+        mock_request.return_value = _resp({"data": {"agents": []}})
+
+        result = self.agents.list(ListAgentsParams(owner_user_id="user-9"))
+
+        assert result == []
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/agents"
+        assert call_args[1]["params"] == {"ownerUserId": "user-9"}
+
+    @patch.object(httpx.Client, "request")
+    def test_get_unwraps_agent(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"agent": SAMPLE_AGENT}}, path="/v1/agents/agent-123"
+        )
+
+        result = self.agents.get("agent-123")
+
+        assert result.agent_id == "agent-123"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/agents/agent-123"
+
+    @patch.object(httpx.Client, "request")
+    def test_get_url_encodes_id(self, mock_request):
+        mock_request.return_value = _resp({"data": {"agent": SAMPLE_AGENT}})
+
+        self.agents.get("a/b c")
+
+        assert mock_request.call_args[0][1] == "/v1/agents/a%2Fb%20c"
+
+    @patch.object(httpx.Client, "request")
+    def test_update_puts_and_unwraps_agent(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"agent": SAMPLE_AGENT}}, "PUT", "/v1/agents/agent-123"
+        )
+
+        result = self.agents.update(
+            "agent-123",
+            UpdateAgentParams(display_name="Renamed", permissions=["read"]),
+        )
+
+        assert result.agent_id == "agent-123"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "PUT"
+        assert call_args[0][1] == "/v1/agents/agent-123"
+        assert call_args[1]["json"] == {
+            "displayName": "Renamed",
+            "permissions": ["read"],
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_delete_unwraps_deleted(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"deleted": True}}, "DELETE", "/v1/agents/agent-123"
+        )
+
+        result = self.agents.delete("agent-123")
+
+        assert result.deleted is True
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert call_args[0][1] == "/v1/agents/agent-123"
+
+    @patch.object(httpx.Client, "request")
+    def test_get_rejects_missing_agent_key(self, mock_request):
+        # A response missing the inner `agent` key must fail loudly (mirrors the
+        # TS resource's ResponseShapeError), not return a model with empty fields.
+        mock_request.return_value = _resp({"data": {}})
+
+        with pytest.raises(EngramError) as exc_info:
+            self.agents.get("agent-123")
+        assert exc_info.value.code == "INTERNAL_ERROR"
+
+    @patch.object(httpx.Client, "request")
+    def test_list_rejects_non_array_agents(self, mock_request):
+        mock_request.return_value = _resp({"data": {"agents": "nope"}})
+
+        with pytest.raises(EngramError) as exc_info:
+            self.agents.list()
+        assert exc_info.value.code == "INTERNAL_ERROR"
+
+
+class TestAsyncAgentsResource:
+    @pytest.mark.asyncio
+    async def test_async_create_unwraps_agent(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        agents = AgentsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*args, **kwargs):
+                    return _resp({"data": {"agent": SAMPLE_AGENT}}, "POST")
+
+                mock_request.side_effect = _r
+                result = await agents.create(
+                    CreateAgentParams(external_id="ext-abc", display_name="Test Agent")
+                )
+                assert isinstance(result, AgentIdentity)
+                assert result.agent_id == "agent-123"
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "POST"
+                assert call_args[0][1] == "/v1/agents"
+                assert call_args[1]["json"] == {
+                    "externalId": "ext-abc",
+                    "displayName": "Test Agent",
+                }
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_list_with_filter(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        agents = AgentsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*args, **kwargs):
+                    return _resp({"data": {"agents": [SAMPLE_AGENT]}})
+
+                mock_request.side_effect = _r
+                result = await agents.list(ListAgentsParams(owner_user_id="user-9"))
+                assert len(result) == 1
+                call_args = mock_request.call_args
+                assert call_args[0][1] == "/v1/agents"
+                assert call_args[1]["params"] == {"ownerUserId": "user-9"}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_delete(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        agents = AgentsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*args, **kwargs):
+                    return _resp(
+                        {"data": {"deleted": True}}, "DELETE", "/v1/agents/agent-123"
+                    )
+
+                mock_request.side_effect = _r
+                result = await agents.delete("agent-123")
+                assert result.deleted is True
+                assert mock_request.call_args[0][0] == "DELETE"
+                assert mock_request.call_args[0][1] == "/v1/agents/agent-123"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get_rejects_missing_agent_key(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        agents = AgentsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*args, **kwargs):
+                    return _resp({"data": {}})
+
+                mock_request.side_effect = _r
+                with pytest.raises(EngramError) as exc_info:
+                    await agents.get("agent-123")
+                assert exc_info.value.code == "INTERNAL_ERROR"
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_ambient_context.py
+++ b/packages/sdk-python/tests/test_ambient_context.py
@@ -1,0 +1,148 @@
+"""Tests for the ambient-context resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/query params
+and response parsing. The route returns the standard enveloped body shape
+``{ data: { ambientCrystals: [...] } }`` and the resource unwraps to a plain
+list of crystals.
+
+The client does not (yet) expose an ``ambient_context`` attribute, so these
+tests instantiate the resource directly with the client — matching the wire
+contract is what's under test.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.resources.ambient_context import (
+    AmbientContextResource,
+    SyncAmbientContextResource,
+)
+from engram.types.ambient_context import AmbientCrystal, GetAmbientContextParams
+
+
+SAMPLE_AMBIENT_CRYSTAL = {
+    "id": "kc-1",
+    "title": "Auth Pattern",
+    "description": "JWT-based auth",
+    "nodeType": "pattern",
+    "tags": ["auth", "security"],
+    "relevanceScore": 0.87,
+}
+
+SAMPLE_AMBIENT_CRYSTAL_NULL_DESC = {
+    "id": "kc-2",
+    "title": "Untitled",
+    "description": None,
+    "nodeType": "collection",
+    "tags": [],
+    "relevanceScore": 0.42,
+}
+
+ENVELOPE = {"data": {"ambientCrystals": [SAMPLE_AMBIENT_CRYSTAL, SAMPLE_AMBIENT_CRYSTAL_NULL_DESC]}}
+
+
+class TestSyncAmbientContextResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.resource = SyncAmbientContextResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_parses_enveloped_list(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=ENVELOPE,
+            request=httpx.Request("GET", "http://test:3100/v1/ambient-context"),
+        )
+
+        result = self.resource.get(GetAmbientContextParams(session_id="sess-123"))
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(c, AmbientCrystal) for c in result)
+        first = result[0]
+        assert first.id == "kc-1"
+        assert first.title == "Auth Pattern"
+        assert first.description == "JWT-based auth"
+        assert first.node_type == "pattern"
+        assert first.tags == ["auth", "security"]
+        assert first.relevance_score == 0.87
+        assert result[1].description is None
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/ambient-context"
+        assert call_args[1]["params"] == {"sessionId": "sess-123"}
+
+    @patch.object(httpx.Client, "request")
+    def test_get_sends_role_and_limit_query_params(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"ambientCrystals": []}},
+            request=httpx.Request("GET", "http://test:3100/v1/ambient-context"),
+        )
+
+        self.resource.get(
+            GetAmbientContextParams(session_id="sess-9", role="architect", limit=5)
+        )
+
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/ambient-context"
+        assert call_args[1]["params"] == {
+            "sessionId": "sess-9",
+            "role": "architect",
+            "limit": "5",
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_get_omits_unset_optionals(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"ambientCrystals": []}},
+            request=httpx.Request("GET", "http://test:3100/v1/ambient-context"),
+        )
+
+        result = self.resource.get(GetAmbientContextParams(session_id="sess-x"))
+
+        assert result == []
+        # role/limit not provided -> only sessionId is sent.
+        assert mock_request.call_args[1]["params"] == {"sessionId": "sess-x"}
+
+
+class TestAsyncAmbientContextResource:
+    @pytest.mark.asyncio
+    async def test_async_get_parses_enveloped_list(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        resource = AmbientContextResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=ENVELOPE,
+                        request=httpx.Request("GET", "http://test:3100/v1/ambient-context"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await resource.get(
+                    GetAmbientContextParams(session_id="sess-123", role="reviewer")
+                )
+
+                assert len(result) == 2
+                assert isinstance(result[0], AmbientCrystal)
+                assert result[0].relevance_score == 0.87
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "GET"
+                assert call_args[0][1] == "/v1/ambient-context"
+                assert call_args[1]["params"] == {
+                    "sessionId": "sess-123",
+                    "role": "reviewer",
+                }
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_dedup_merge.py
+++ b/packages/sdk-python/tests/test_dedup_merge.py
@@ -1,0 +1,237 @@
+"""Tests for the P11 dedup / deferred-merge review surface.
+
+Covers ``crystals.pending_merges`` / ``review_merge`` / ``merge_history`` and
+``notes.dedup``. These routes return **bare** (non-enveloped) bodies, so the
+tests pin that the resources do NOT unwrap a ``data`` envelope and that a
+contract drift fails loudly.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.errors import EngramError
+from engram.types.dedup_merge import (
+    DedupNoteParams,
+    DedupNoteResult,
+    ListPendingMergesParams,
+    MergeRecord,
+    PendingMerge,
+    ReviewMergeParams,
+    ReviewMergeResult,
+)
+
+PENDING = {
+    "mergeId": "m-1",
+    "sourceId": "note-1",
+    "targetId": "kc-1",
+    "sourceType": "session_note",
+    "targetType": "knowledge_crystal",
+    "confidence": 0.91,
+    "mergeMethod": "semantic",
+    "mergeOutcomeStrategy": "oldest_wins",
+    "createdAt": "2026-01-01T00:00:00Z",
+}
+
+MERGE_RECORD = {
+    "id": "mr-1",
+    "sourceNoteId": "note-1",
+    "sourceCrystalId": None,
+    "targetCrystalId": "kc-1",
+    "mergeMethod": "semantic",
+    "mergeOutcomeStrategy": "oldest_wins",
+    "similarityScore": 0.9,
+    "mergeReason": "duplicate",
+    "mergedContentSnapshot": {"title": "x"},
+    "mergedBy": "agent-1",
+    "mergedAt": "2026-01-01T00:00:00Z",
+    "reversible": True,
+    "reverseRecordId": None,
+    "createdAt": "2026-01-01T00:00:00Z",
+}
+
+
+def _resp(json_data, status_code=200, method="GET", url="http://test:3100/x"):
+    return httpx.Response(status_code, json=json_data, request=httpx.Request(method, url))
+
+
+class TestSyncPendingMerges:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_pending_merges_bare_body(self, mock_request):
+        mock_request.return_value = _resp({"success": True, "pending": [PENDING], "total": 1})
+        result = self.client.crystals.pending_merges(ListPendingMergesParams(limit=50))
+        assert result["total"] == 1
+        assert isinstance(result["pending"][0], PendingMerge)
+        assert result["pending"][0].merge_id == "m-1"
+        call = mock_request.call_args
+        assert call[0][1] == "/v1/crystals/merges/pending"
+        assert call[1]["params"] == {"limit": "50"}
+
+    @patch.object(httpx.Client, "request")
+    def test_pending_merges_rejects_enveloped_body(self, mock_request):
+        mock_request.return_value = _resp({"data": {"pending": [PENDING], "total": 1}})
+        with pytest.raises(EngramError) as exc:
+            self.client.crystals.pending_merges()
+        assert exc.value.code == "INTERNAL_ERROR"
+
+    @patch.object(httpx.Client, "request")
+    def test_pending_merges_rejects_missing_total(self, mock_request):
+        mock_request.return_value = _resp({"success": True, "pending": [PENDING]})
+        with pytest.raises(EngramError):
+            self.client.crystals.pending_merges()
+
+    @patch.object(httpx.Client, "request")
+    def test_review_merge_approve(self, mock_request):
+        mock_request.return_value = _resp(
+            {"success": True, "decision": "approve", "targetCrystalId": "kc-1"},
+            method="POST",
+        )
+        result = self.client.crystals.review_merge(
+            "m-1", ReviewMergeParams(decision="approve")
+        )
+        assert isinstance(result, ReviewMergeResult)
+        assert result.decision == "approve"
+        assert result.target_crystal_id == "kc-1"
+        call = mock_request.call_args
+        assert call[0][1] == "/v1/crystals/merges/m-1/review"
+        assert call[1]["json"] == {"decision": "approve"}
+
+    @patch.object(httpx.Client, "request")
+    def test_review_merge_modify_sends_snake_case_content(self, mock_request):
+        mock_request.return_value = _resp(
+            {"success": True, "decision": "modify", "targetCrystalId": "kc-1"},
+            method="POST",
+        )
+        self.client.crystals.review_merge(
+            "m-1", ReviewMergeParams(decision="modify", merged_content="merged text")
+        )
+        assert mock_request.call_args[1]["json"] == {
+            "decision": "modify",
+            "merged_content": "merged text",
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_review_merge_reject_empty_target_normalized_to_none(self, mock_request):
+        # On reject the server returns targetCrystalId="" (or omits it); the SDK
+        # normalizes a falsy-but-present value to None.
+        mock_request.return_value = _resp(
+            {"success": True, "decision": "reject", "targetCrystalId": ""},
+            method="POST",
+        )
+        result = self.client.crystals.review_merge(
+            "m-1", ReviewMergeParams(decision="reject")
+        )
+        assert result.target_crystal_id is None
+
+    @patch.object(httpx.Client, "request")
+    def test_merge_history_bare_body(self, mock_request):
+        mock_request.return_value = _resp(
+            {"success": True, "id": "kc-1", "merge_chain": [MERGE_RECORD], "total": 1}
+        )
+        result = self.client.crystals.merge_history("kc-1")
+        assert result["id"] == "kc-1"
+        assert result["total"] == 1
+        assert isinstance(result["merge_chain"][0], MergeRecord)
+        assert result["merge_chain"][0].target_crystal_id == "kc-1"
+        assert mock_request.call_args[0][1] == "/v1/crystals/merges/history/kc-1"
+
+    @patch.object(httpx.Client, "request")
+    def test_merge_history_rejects_enveloped_body(self, mock_request):
+        mock_request.return_value = _resp({"data": {"id": "kc-1", "merge_chain": [], "total": 0}})
+        with pytest.raises(EngramError):
+            self.client.crystals.merge_history("kc-1")
+
+
+class TestSyncNotesDedup:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_dedup_merged(self, mock_request):
+        mock_request.return_value = _resp(
+            {"action": "merged", "merge_id": "m-1", "confidence": 0.9, "canonical_id": "kc-1"},
+            method="POST",
+        )
+        result = self.client.notes.dedup("note-1")
+        assert isinstance(result, DedupNoteResult)
+        assert result.action == "merged"
+        assert result.merge_id == "m-1"
+        assert result.canonical_id == "kc-1"
+        assert mock_request.call_args[0][1] == "/v1/notes/note-1/dedup"
+
+    @patch.object(httpx.Client, "request")
+    def test_dedup_no_match_all_none(self, mock_request):
+        mock_request.return_value = _resp(
+            {"action": "no_match", "merge_id": None, "confidence": None, "canonical_id": None},
+            method="POST",
+        )
+        result = self.client.notes.dedup("note-1")
+        assert result.action == "no_match"
+        assert result.merge_id is None
+        assert result.confidence is None
+
+    @patch.object(httpx.Client, "request")
+    def test_dedup_sends_snake_case_body(self, mock_request):
+        mock_request.return_value = _resp(
+            {"action": "deferred", "merge_id": "m-1", "confidence": 0.8, "canonical_id": None},
+            method="POST",
+        )
+        self.client.notes.dedup(
+            "note-1", DedupNoteParams(merge_method="semantic", threshold=0.85)
+        )
+        assert mock_request.call_args[1]["json"] == {
+            "merge_method": "semantic",
+            "threshold": 0.85,
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_dedup_rejects_enveloped_body(self, mock_request):
+        mock_request.return_value = _resp({"data": {"action": "merged"}}, method="POST")
+        with pytest.raises(EngramError) as exc:
+            self.client.notes.dedup("note-1")
+        assert exc.value.code == "INTERNAL_ERROR"
+
+
+class TestAsyncDedupMerge:
+    @pytest.mark.asyncio
+    async def test_async_pending_merges(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*a, **k):
+                    return _resp({"success": True, "pending": [PENDING], "total": 1})
+
+                mock_request.side_effect = _r
+                result = await client.crystals.pending_merges()
+                assert result["pending"][0].source_type == "session_note"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_notes_dedup(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*a, **k):
+                    return _resp(
+                        {"action": "merged", "merge_id": "m-1", "confidence": 0.9, "canonical_id": "kc-1"},
+                        method="POST",
+                    )
+
+                mock_request.side_effect = _r
+                result = await client.notes.dedup("note-1")
+                assert result.action == "merged"
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_errors.py
+++ b/packages/sdk-python/tests/test_errors.py
@@ -11,12 +11,15 @@ from engram.client import AsyncEngramClient, EngramClient
 import warnings
 
 from engram.errors import (
+    CrystalVersionConflictError,
     EngramError,
     EngramTimeoutError,
     InternalError,
     NetworkError,
     NotFoundError,
     SessionExistsError,
+    ShimmerCasConflictError,
+    ShimmerDisabledError,
     UnauthorizedError,
     ValidationError,
     parse_api_error,
@@ -640,3 +643,83 @@ class TestConcurrentAsync:
             return_exceptions=True,
         )
         assert all(isinstance(r, EngramTimeoutError) for r in results)
+
+
+class TestNestedEnvelopeStatusMapping:
+    """Issue #117 — the nested error envelope must route through the same
+    status->class mapping as the flat shape, not throw a base EngramError.
+
+    Mirrors the TS regression coverage added in PR #118.
+    """
+
+    def test_nested_404_maps_to_not_found_and_preserves_code(self):
+        body = {"error": {"code": "RES_NOT_FOUND", "message": "gone"}}
+        with pytest.raises(NotFoundError) as exc_info:
+            parse_api_error(404, body)
+        # Typed class by status, server code preserved (not flattened to NOT_FOUND).
+        assert exc_info.value.code == "RES_NOT_FOUND"
+        assert exc_info.value.status_code == 404
+
+    def test_nested_401_maps_to_unauthorized(self):
+        body = {"error": {"code": "AUTH_REQUIRED", "message": "no key"}}
+        with pytest.raises(UnauthorizedError) as exc_info:
+            parse_api_error(401, body)
+        assert exc_info.value.code == "AUTH_REQUIRED"
+
+    def test_nested_500_maps_to_internal(self):
+        body = {"error": {"code": "DB_DOWN", "message": "boom"}}
+        with pytest.raises(InternalError) as exc_info:
+            parse_api_error(500, body)
+        assert exc_info.value.code == "DB_DOWN"
+
+    def test_nested_409_cas_maps_to_version_conflict(self):
+        body = {
+            "error": {
+                "code": "OPERATION_VERSION_CONFLICT",
+                "message": "stale",
+                "details": {"currentVersion": 7},
+            }
+        }
+        with pytest.raises(CrystalVersionConflictError) as exc_info:
+            parse_api_error(409, body)
+        assert exc_info.value.current_version == 7
+
+    def test_nested_409_session_exists_maps_to_session_exists(self):
+        body = {"error": {"code": "SESSION_EXISTS", "message": "dup"}}
+        with pytest.raises(SessionExistsError):
+            parse_api_error(409, body)
+
+    def test_nested_generic_409_stays_base_engram_error(self):
+        # A 409 with a non-CAS, non-SESSION_EXISTS code must NOT be mangled into
+        # SessionExistsError — it stays a base EngramError carrying the code.
+        body = {"error": {"code": "SYNC_SCHEMA_VERSION_MISMATCH", "message": "v"}}
+        with pytest.raises(EngramError) as exc_info:
+            parse_api_error(409, body)
+        assert type(exc_info.value) is EngramError
+        assert exc_info.value.code == "SYNC_SCHEMA_VERSION_MISMATCH"
+
+    def test_nested_unmapped_status_stays_base_engram_error(self):
+        body = {"error": {"code": "TEAPOT", "message": "no coffee"}}
+        with pytest.raises(EngramError) as exc_info:
+            parse_api_error(418, body)
+        assert type(exc_info.value) is EngramError
+        assert exc_info.value.code == "TEAPOT"
+
+    def test_nested_shimmer_cas_still_typed(self):
+        body = {"error": {"code": "SHIMMER_CAS_CONFLICT", "message": "held"}}
+        with pytest.raises(ShimmerCasConflictError):
+            parse_api_error(409, body)
+
+    def test_nested_shimmer_disabled_still_typed(self):
+        body = {"error": {"code": "SHIMMER_DISABLED", "message": "off"}}
+        with pytest.raises(ShimmerDisabledError):
+            parse_api_error(503, body)
+
+    def test_flat_generic_409_now_base_error(self):
+        # Symmetry with the nested branch: a flat 409 with a non-CAS,
+        # non-SESSION_EXISTS code is a base EngramError, not SessionExistsError.
+        body = {"code": "SYNC_SCHEMA_VERSION_MISMATCH", "message": "v"}
+        with pytest.raises(EngramError) as exc_info:
+            parse_api_error(409, body)
+        assert type(exc_info.value) is EngramError
+        assert exc_info.value.code == "SYNC_SCHEMA_VERSION_MISMATCH"

--- a/packages/sdk-python/tests/test_facts.py
+++ b/packages/sdk-python/tests/test_facts.py
@@ -1,0 +1,321 @@
+"""Tests for the facts resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body/query and
+response unwrapping. Single-object facts come back in the standard ``{ data }``
+envelope; history is a paginated list with ``meta.pagination``.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.resources.facts import FactsResource, SyncFactsResource
+from engram.types.common import PaginatedResult
+from engram.types.facts import (
+    CreateFactParams,
+    Fact,
+    FactHistoryParams,
+    UpdateFactParams,
+)
+
+SAMPLE_FACT = {
+    "id": "fact-123",
+    "key": "user.preferences.theme",
+    "value": {"mode": "dark"},
+    "validFrom": "2026-01-01T00:00:00Z",
+    "validTo": None,
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+}
+
+SAMPLE_FACT_V2 = {
+    **SAMPLE_FACT,
+    "value": {"mode": "light"},
+    "validFrom": "2026-02-01T00:00:00Z",
+}
+
+
+def _envelope(data, total=None, has_more=False):
+    resp = {"data": data}
+    if total is not None:
+        resp["meta"] = {
+            "pagination": {
+                "total": total,
+                "limit": 20,
+                "offset": 0,
+                "hasMore": has_more,
+            }
+        }
+    return resp
+
+
+class TestSyncFactsResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        # The client does not (yet) expose a ``.facts`` accessor; construct the
+        # resource directly so these tests pin the wire contract regardless.
+        self.facts = SyncFactsResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_create(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT),
+            request=httpx.Request("POST", "http://test:3100/v1/facts"),
+        )
+
+        result = self.facts.create(
+            CreateFactParams(key="user.preferences.theme", value={"mode": "dark"})
+        )
+
+        assert isinstance(result, Fact)
+        assert result.id == "fact-123"
+        assert result.key == "user.preferences.theme"
+        assert result.value == {"mode": "dark"}
+        assert result.valid_to is None
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/facts"
+        assert call_args[1]["json"] == {
+            "key": "user.preferences.theme",
+            "value": {"mode": "dark"},
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_create_with_valid_at(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT),
+            request=httpx.Request("POST", "http://test:3100/v1/facts"),
+        )
+
+        self.facts.create(
+            CreateFactParams(
+                key="k", value={"a": 1}, valid_at="2026-01-01T00:00:00Z"
+            )
+        )
+
+        assert mock_request.call_args[1]["json"] == {
+            "key": "k",
+            "value": {"a": 1},
+            "validAt": "2026-01-01T00:00:00Z",
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_get(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT),
+            request=httpx.Request("GET", "http://test:3100/v1/facts/fact-123"),
+        )
+
+        result = self.facts.get("fact-123")
+
+        assert isinstance(result, Fact)
+        assert result.id == "fact-123"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/facts/fact-123"
+        # No asOf -> no query params sent.
+        assert "params" not in call_args[1] or call_args[1]["params"] is None
+
+    @patch.object(httpx.Client, "request")
+    def test_get_with_as_of(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT),
+            request=httpx.Request("GET", "http://test:3100/v1/facts/fact-123"),
+        )
+
+        self.facts.get("fact-123", as_of="2025-01-15T00:00:00Z")
+
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/facts/fact-123"
+        assert call_args[1]["params"] == {"asOf": "2025-01-15T00:00:00Z"}
+
+    @patch.object(httpx.Client, "request")
+    def test_get_url_encodes_id(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT),
+            request=httpx.Request("GET", "http://test:3100/v1/facts/a%2Fb"),
+        )
+
+        self.facts.get("a/b")
+
+        assert mock_request.call_args[0][1] == "/v1/facts/a%2Fb"
+
+    @patch.object(httpx.Client, "request")
+    def test_get_by_key(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT),
+            request=httpx.Request("GET", "http://test:3100/v1/facts"),
+        )
+
+        result = self.facts.get_by_key("user.preferences.theme")
+
+        assert isinstance(result, Fact)
+        assert result.key == "user.preferences.theme"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/facts"
+        assert call_args[1]["params"] == {"key": "user.preferences.theme"}
+
+    @patch.object(httpx.Client, "request")
+    def test_update(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope(SAMPLE_FACT_V2),
+            request=httpx.Request("PATCH", "http://test:3100/v1/facts/fact-123"),
+        )
+
+        result = self.facts.update(
+            "fact-123", UpdateFactParams(value={"mode": "light"})
+        )
+
+        assert isinstance(result, Fact)
+        assert result.value == {"mode": "light"}
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "PATCH"
+        assert call_args[0][1] == "/v1/facts/fact-123"
+        assert call_args[1]["json"] == {"value": {"mode": "light"}}
+
+    @patch.object(httpx.Client, "request")
+    def test_get_history(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope([SAMPLE_FACT, SAMPLE_FACT_V2], total=2, has_more=False),
+            request=httpx.Request(
+                "GET", "http://test:3100/v1/facts/fact-123/history"
+            ),
+        )
+
+        result = self.facts.get_history("fact-123")
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 2
+        assert all(isinstance(f, Fact) for f in result.items)
+        assert result.total == 2
+        assert result.has_more is False
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/facts/fact-123/history"
+        assert "params" not in call_args[1] or call_args[1]["params"] is None
+
+    @patch.object(httpx.Client, "request")
+    def test_get_history_with_params(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=_envelope([SAMPLE_FACT], total=5, has_more=True),
+            request=httpx.Request(
+                "GET", "http://test:3100/v1/facts/fact-123/history"
+            ),
+        )
+
+        result = self.facts.get_history(
+            "fact-123",
+            FactHistoryParams(
+                valid_from="2026-01-01T00:00:00Z",
+                valid_to="2026-03-01T00:00:00Z",
+                limit=10,
+                offset=2,
+            ),
+        )
+
+        assert result.total == 5
+        assert result.has_more is True
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/facts/fact-123/history"
+        assert call_args[1]["params"] == {
+            "validFrom": "2026-01-01T00:00:00Z",
+            "validTo": "2026-03-01T00:00:00Z",
+            "limit": "10",
+            "offset": "2",
+        }
+
+
+class TestAsyncFactsResource:
+    @pytest.mark.asyncio
+    async def test_async_create(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        facts = FactsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=_envelope(SAMPLE_FACT),
+                        request=httpx.Request("POST", "http://test:3100/v1/facts"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await facts.create(
+                    CreateFactParams(key="k", value={"mode": "dark"})
+                )
+                assert isinstance(result, Fact)
+                assert result.id == "fact-123"
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "POST"
+                assert call_args[0][1] == "/v1/facts"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get_with_as_of(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        facts = FactsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=_envelope(SAMPLE_FACT),
+                        request=httpx.Request(
+                            "GET", "http://test:3100/v1/facts/fact-123"
+                        ),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await facts.get(
+                    "fact-123", as_of="2025-01-15T00:00:00Z"
+                )
+                assert isinstance(result, Fact)
+                call_args = mock_request.call_args
+                assert call_args[0][1] == "/v1/facts/fact-123"
+                assert call_args[1]["params"] == {"asOf": "2025-01-15T00:00:00Z"}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get_history(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        facts = FactsResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=_envelope(
+                            [SAMPLE_FACT, SAMPLE_FACT_V2], total=2, has_more=False
+                        ),
+                        request=httpx.Request(
+                            "GET", "http://test:3100/v1/facts/fact-123/history"
+                        ),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await facts.get_history("fact-123")
+                assert isinstance(result, PaginatedResult)
+                assert len(result.items) == 2
+                assert result.total == 2
+                call_args = mock_request.call_args
+                assert call_args[0][1] == "/v1/facts/fact-123/history"
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_gc.py
+++ b/packages/sdk-python/tests/test_gc.py
@@ -1,0 +1,289 @@
+"""Tests for the GC (garbage collection) resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body/query and
+response parsing. The GC endpoints use the standard ``{ data, meta }`` envelope;
+``get_candidates``/``get_audit_log`` fold ``meta.pagination.hasMore`` into the
+returned result model, and ``run`` unwraps ``data``.
+
+The ``gc`` resource is not (yet) wired onto the client, so these tests
+instantiate the resource directly against a real client (whose transport is
+mocked), exactly mirroring how the resource is used in production.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.resources.gc import GcResource, SyncGcResource
+from engram.types.gc import (
+    GcAuditResult,
+    GcCandidatesResult,
+    GcRunOptions,
+    GcRunResult,
+    ListGcAuditParams,
+    ListGcCandidatesParams,
+)
+
+
+SAMPLE_CANDIDATE = {
+    "id": "kc-1",
+    "title": "Stale Crystal",
+    "nodeType": "pattern",
+    "relevanceScore": 0.12,
+    "accessCount": 3,
+    "lastAccessedAt": None,
+    "createdAt": "2026-01-01T00:00:00Z",
+    "verified": False,
+    "lifecycleStatus": "active",
+}
+
+SAMPLE_AUDIT_ENTRY = {
+    "id": "gc-run-1",
+    "runAt": "2026-01-02T00:00:00Z",
+    "decayCurve": "exponential",
+    "threshold": 0.2,
+    "scannedCrystals": 100,
+    "archivedCrystals": 5,
+    "scannedNotes": 200,
+    "archivedNotes": 10,
+    "dryRun": True,
+    "details": {"note": "preview only"},
+}
+
+SAMPLE_RUN_RESULT = {
+    "scannedCrystals": 100,
+    "archivedCrystals": 5,
+    "scannedNotes": 200,
+    "archivedNotes": 10,
+    "dryRun": False,
+}
+
+CANDIDATES_ENVELOPE = {
+    "data": {"candidates": [SAMPLE_CANDIDATE], "threshold": 0.2, "total": 1},
+    "meta": {"pagination": {"total": 1, "limit": 20, "offset": 0, "hasMore": True}},
+}
+
+AUDIT_ENVELOPE = {
+    "data": {"entries": [SAMPLE_AUDIT_ENTRY], "total": 1},
+    "meta": {"pagination": {"total": 1, "limit": 20, "offset": 0, "hasMore": False}},
+}
+
+RUN_ENVELOPE = {"data": SAMPLE_RUN_RESULT}
+
+
+class TestSyncGcResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.gc = SyncGcResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_candidates_parses_and_folds_has_more(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=CANDIDATES_ENVELOPE,
+            request=httpx.Request("GET", "http://test:3100/v1/gc/candidates"),
+        )
+
+        result = self.gc.get_candidates(
+            ListGcCandidatesParams(threshold=0.2, limit=50, offset=0)
+        )
+
+        assert isinstance(result, GcCandidatesResult)
+        assert result.threshold == 0.2
+        assert result.total == 1
+        assert result.has_more is True
+        assert len(result.candidates) == 1
+        assert result.candidates[0].id == "kc-1"
+        assert result.candidates[0].node_type == "pattern"
+        assert result.candidates[0].relevance_score == 0.12
+        assert result.candidates[0].last_accessed_at is None
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/gc/candidates"
+        assert call_args[1]["params"] == {
+            "threshold": "0.2",
+            "limit": "50",
+            "offset": "0",
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_get_candidates_default_sends_no_query_params(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=CANDIDATES_ENVELOPE,
+            request=httpx.Request("GET", "http://test:3100/v1/gc/candidates"),
+        )
+
+        self.gc.get_candidates()
+
+        # No params => the client omits the ``params`` kwarg entirely.
+        assert "params" not in mock_request.call_args[1]
+
+    @patch.object(httpx.Client, "request")
+    def test_get_candidates_defaults_has_more_false_without_meta(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"candidates": [], "threshold": 0.5, "total": 0}},
+            request=httpx.Request("GET", "http://test:3100/v1/gc/candidates"),
+        )
+
+        result = self.gc.get_candidates()
+
+        assert result.has_more is False
+        assert result.candidates == []
+
+    @patch.object(httpx.Client, "request")
+    def test_get_audit_log_parses_and_folds_has_more(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=AUDIT_ENVELOPE,
+            request=httpx.Request("GET", "http://test:3100/v1/gc/audit"),
+        )
+
+        result = self.gc.get_audit_log(ListGcAuditParams(limit=10, offset=5))
+
+        assert isinstance(result, GcAuditResult)
+        assert result.total == 1
+        assert result.has_more is False
+        assert len(result.entries) == 1
+        entry = result.entries[0]
+        assert entry.id == "gc-run-1"
+        assert entry.decay_curve == "exponential"
+        assert entry.scanned_crystals == 100
+        assert entry.dry_run is True
+        assert entry.details == {"note": "preview only"}
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/gc/audit"
+        assert call_args[1]["params"] == {"limit": "10", "offset": "5"}
+
+    @patch.object(httpx.Client, "request")
+    def test_get_audit_log_default_sends_no_query_params(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=AUDIT_ENVELOPE,
+            request=httpx.Request("GET", "http://test:3100/v1/gc/audit"),
+        )
+
+        self.gc.get_audit_log()
+
+        # No params => the client omits the ``params`` kwarg entirely.
+        assert "params" not in mock_request.call_args[1]
+
+    @patch.object(httpx.Client, "request")
+    def test_run_unwraps_data_and_sends_body(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=RUN_ENVELOPE,
+            request=httpx.Request("POST", "http://test:3100/v1/gc/run"),
+        )
+
+        result = self.gc.run(GcRunOptions(dry_run=True))
+
+        assert isinstance(result, GcRunResult)
+        assert result.scanned_crystals == 100
+        assert result.archived_notes == 10
+        assert result.dry_run is False
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/gc/run"
+        assert call_args[1]["json"] == {"dryRun": True}
+
+    @patch.object(httpx.Client, "request")
+    def test_run_without_options_sends_no_body(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json=RUN_ENVELOPE,
+            request=httpx.Request("POST", "http://test:3100/v1/gc/run"),
+        )
+
+        result = self.gc.run()
+
+        assert isinstance(result, GcRunResult)
+        # No options => the client omits the ``json`` kwarg entirely.
+        assert "json" not in mock_request.call_args[1]
+
+
+class TestAsyncGcResource:
+    @pytest.mark.asyncio
+    async def test_async_get_candidates(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        gc = GcResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=CANDIDATES_ENVELOPE,
+                        request=httpx.Request(
+                            "GET", "http://test:3100/v1/gc/candidates"
+                        ),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await gc.get_candidates(
+                    ListGcCandidatesParams(threshold=0.2)
+                )
+                assert isinstance(result, GcCandidatesResult)
+                assert result.has_more is True
+                assert result.candidates[0].id == "kc-1"
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "GET"
+                assert call_args[0][1] == "/v1/gc/candidates"
+                assert call_args[1]["params"] == {"threshold": "0.2"}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get_audit_log(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        gc = GcResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=AUDIT_ENVELOPE,
+                        request=httpx.Request("GET", "http://test:3100/v1/gc/audit"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await gc.get_audit_log()
+                assert isinstance(result, GcAuditResult)
+                assert result.entries[0].id == "gc-run-1"
+                assert result.has_more is False
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_run(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        gc = GcResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json=RUN_ENVELOPE,
+                        request=httpx.Request("POST", "http://test:3100/v1/gc/run"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await gc.run(GcRunOptions(dry_run=True))
+                assert isinstance(result, GcRunResult)
+                assert result.scanned_crystals == 100
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "POST"
+                assert call_args[0][1] == "/v1/gc/run"
+                assert call_args[1]["json"] == {"dryRun": True}
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_memory_spaces.py
+++ b/packages/sdk-python/tests/test_memory_spaces.py
@@ -1,0 +1,299 @@
+"""Tests for the memory-spaces resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body/query and
+response parsing for the standard ``{ data }`` envelope, whose inner payload is
+keyed by member name (``{ data: { space } }``, ``{ data: { spaces } }``,
+``{ data: { member } }``). The resource unwraps ``data`` then the named member;
+these tests pin that contract.
+
+The memory-spaces resource is not (yet) wired onto the client, so the tests
+instantiate the resource classes directly with the client.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.resources.memory_spaces import (
+    MemorySpacesResource,
+    SyncMemorySpacesResource,
+)
+from engram.types.memory_spaces import (
+    CreateMemorySpaceParams,
+    JoinMemorySpaceParams,
+    MemorySpace,
+    MemorySpaceInitialMember,
+    MemorySpaceMember,
+    MemorySpaceWithMembers,
+)
+
+
+SAMPLE_SPACE = {
+    "id": "space-1",
+    "title": "Shared Space",
+    "description": "A collaborative space",
+    "visibility": "shared",
+    "nodeType": "memory_space",
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+}
+
+SAMPLE_MEMBER = {
+    "agentId": "agent-1",
+    "permission": "write",
+    "joinedAt": "2026-01-02T00:00:00Z",
+}
+
+SAMPLE_SPACE_WITH_MEMBERS = {
+    **SAMPLE_SPACE,
+    "members": [SAMPLE_MEMBER],
+}
+
+
+def _resp(json_data, method="GET", url="http://test:3100"):
+    return httpx.Response(
+        200, json=json_data, request=httpx.Request(method, url)
+    )
+
+
+class TestSyncMemorySpacesResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.resource = SyncMemorySpacesResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_list(self, mock_request):
+        mock_request.return_value = _resp({"data": {"spaces": [SAMPLE_SPACE]}})
+
+        spaces = self.resource.list()
+
+        assert isinstance(spaces, list)
+        assert len(spaces) == 1
+        assert isinstance(spaces[0], MemorySpace)
+        assert spaces[0].id == "space-1"
+        assert spaces[0].node_type == "memory_space"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/memory-spaces"
+        # No agent filter => no query params reach httpx.
+        assert "params" not in call_args[1] or call_args[1].get("params") is None
+
+    @patch.object(httpx.Client, "request")
+    def test_list_with_agent_filter(self, mock_request):
+        mock_request.return_value = _resp({"data": {"spaces": []}})
+
+        spaces = self.resource.list(agent_id="agent-1")
+
+        assert spaces == []
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/memory-spaces"
+        assert call_args[1]["params"] == {"agentId": "agent-1"}
+
+    @patch.object(httpx.Client, "request")
+    def test_create(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"space": SAMPLE_SPACE}},
+            method="POST",
+            url="http://test:3100/v1/memory-spaces",
+        )
+
+        space = self.resource.create(
+            CreateMemorySpaceParams(
+                title="Shared Space",
+                description="A collaborative space",
+                visibility="shared",
+                initial_members=[
+                    MemorySpaceInitialMember(agent_id="agent-1", permission="admin")
+                ],
+            )
+        )
+
+        assert isinstance(space, MemorySpace)
+        assert space.id == "space-1"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/memory-spaces"
+        assert call_args[1]["json"] == {
+            "title": "Shared Space",
+            "description": "A collaborative space",
+            "visibility": "shared",
+            "initialMembers": [{"agentId": "agent-1", "permission": "admin"}],
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_create_minimal_drops_none(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"space": SAMPLE_SPACE}},
+            method="POST",
+            url="http://test:3100/v1/memory-spaces",
+        )
+
+        self.resource.create(CreateMemorySpaceParams(title="Only Title"))
+
+        assert mock_request.call_args[1]["json"] == {"title": "Only Title"}
+
+    @patch.object(httpx.Client, "request")
+    def test_get(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"space": SAMPLE_SPACE_WITH_MEMBERS}}
+        )
+
+        space = self.resource.get("space-1/with slash")
+
+        assert isinstance(space, MemorySpaceWithMembers)
+        assert len(space.members) == 1
+        assert space.members[0].agent_id == "agent-1"
+        assert space.members[0].permission == "write"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        # Path param is URL-encoded with quote(..., safe='').
+        assert call_args[0][1] == "/v1/memory-spaces/space-1%2Fwith%20slash"
+
+    @patch.object(httpx.Client, "request")
+    def test_join(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"member": SAMPLE_MEMBER}},
+            method="POST",
+            url="http://test:3100/v1/memory-spaces/space-1/join",
+        )
+
+        member = self.resource.join(
+            "space-1", JoinMemorySpaceParams(agent_id="agent-1", permission="write")
+        )
+
+        assert isinstance(member, MemorySpaceMember)
+        assert member.agent_id == "agent-1"
+        assert member.permission == "write"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/memory-spaces/space-1/join"
+        assert call_args[1]["json"] == {"agentId": "agent-1", "permission": "write"}
+
+    @patch.object(httpx.Client, "request")
+    def test_leave(self, mock_request):
+        mock_request.return_value = _resp(
+            {"data": {"removed": True}},
+            method="DELETE",
+            url="http://test:3100/v1/memory-spaces/space-1/leave",
+        )
+
+        result = self.resource.leave("space-1", "agent-1")
+
+        assert result == {"removed": True}
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert call_args[0][1] == "/v1/memory-spaces/space-1/leave"
+        assert call_args[1]["params"] == {"agentId": "agent-1"}
+
+
+class TestAsyncMemorySpacesResource:
+    @pytest.mark.asyncio
+    async def test_async_list(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        resource = MemorySpacesResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _side(*args, **kwargs):
+                    return _resp({"data": {"spaces": [SAMPLE_SPACE]}})
+
+                mock_request.side_effect = _side
+                spaces = await resource.list()
+                assert len(spaces) == 1
+                assert spaces[0].id == "space-1"
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "GET"
+                assert call_args[0][1] == "/v1/memory-spaces"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_create(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        resource = MemorySpacesResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _side(*args, **kwargs):
+                    return _resp(
+                        {"data": {"space": SAMPLE_SPACE}},
+                        method="POST",
+                        url="http://test:3100/v1/memory-spaces",
+                    )
+
+                mock_request.side_effect = _side
+                space = await resource.create(
+                    CreateMemorySpaceParams(title="Shared Space")
+                )
+                assert isinstance(space, MemorySpace)
+                assert space.id == "space-1"
+                assert mock_request.call_args[1]["json"] == {"title": "Shared Space"}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        resource = MemorySpacesResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _side(*args, **kwargs):
+                    return _resp({"data": {"space": SAMPLE_SPACE_WITH_MEMBERS}})
+
+                mock_request.side_effect = _side
+                space = await resource.get("space-1")
+                assert isinstance(space, MemorySpaceWithMembers)
+                assert len(space.members) == 1
+                assert mock_request.call_args[0][1] == "/v1/memory-spaces/space-1"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_join(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        resource = MemorySpacesResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _side(*args, **kwargs):
+                    return _resp(
+                        {"data": {"member": SAMPLE_MEMBER}},
+                        method="POST",
+                        url="http://test:3100/v1/memory-spaces/space-1/join",
+                    )
+
+                mock_request.side_effect = _side
+                member = await resource.join(
+                    "space-1",
+                    JoinMemorySpaceParams(agent_id="agent-1", permission="write"),
+                )
+                assert isinstance(member, MemorySpaceMember)
+                assert member.agent_id == "agent-1"
+                assert mock_request.call_args[0][1] == (
+                    "/v1/memory-spaces/space-1/join"
+                )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_leave(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        resource = MemorySpacesResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _side(*args, **kwargs):
+                    return _resp(
+                        {"data": {"removed": True}},
+                        method="DELETE",
+                        url="http://test:3100/v1/memory-spaces/space-1/leave",
+                    )
+
+                mock_request.side_effect = _side
+                result = await resource.leave("space-1", "agent-1")
+                assert result == {"removed": True}
+                assert mock_request.call_args[1]["params"] == {"agentId": "agent-1"}
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_shimmers.py
+++ b/packages/sdk-python/tests/test_shimmers.py
@@ -1,0 +1,339 @@
+"""Tests for the shimmers resource.
+
+Mirrors the TS resource-test pattern: assert request method/path/body/query
+params and response unwrapping for the standard ``{ data }`` envelope, plus the
+two typed shimmer errors (``ShimmerCasConflictError`` 409, ``ShimmerDisabledError``
+503) routed centrally by ``parse_api_error`` from the server error codes.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.errors import ShimmerCasConflictError, ShimmerDisabledError
+from engram.resources.shimmers import ShimmersResource, SyncShimmersResource
+from engram.types.shimmers import (
+    AcquireLockParams,
+    ReleaseLockParams,
+    RenewLockParams,
+    Shimmer,
+    ShimmerDeleteResult,
+    ShimmerRead,
+)
+
+
+SHIMMER_LOCK = {
+    "recordType": "lock",
+    "recordKey": "deploy",
+    "value": {"phase": "build"},
+    "ownerToken": "owner-1",
+    "revision": 1,
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+    "fadesAt": "2026-01-01T00:01:00Z",
+}
+
+SHIMMER_HEARTBEAT = {
+    **SHIMMER_LOCK,
+    "recordType": "heartbeat",
+    "recordKey": "worker-1",
+    "ownerToken": None,
+}
+
+SHIMMER_READ = {
+    "recordType": "lock",
+    "recordKey": "deploy",
+    "value": {"phase": "build"},
+    "ownerToken": None,
+    "revision": 1,
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+    "fadesAt": "2026-01-01T00:01:00Z",
+}
+
+
+def _ok(data, method="POST", url="http://test:3100/v1/shimmers"):
+    return httpx.Response(200, json={"data": data}, request=httpx.Request(method, url))
+
+
+class TestSyncShimmersResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.shimmers = SyncShimmersResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_heartbeat(self, mock_request):
+        mock_request.return_value = _ok(SHIMMER_HEARTBEAT)
+
+        result = self.shimmers.heartbeat(
+            "worker-1", {"phase": "build"}, ttl_seconds=30
+        )
+
+        assert isinstance(result, Shimmer)
+        assert result.record_type == "heartbeat"
+        assert result.owner_token is None
+        call = mock_request.call_args
+        assert call[0][0] == "POST"
+        assert call[0][1] == "/v1/shimmers"
+        assert call[1]["json"] == {
+            "recordType": "heartbeat",
+            "key": "worker-1",
+            "ttlSeconds": 30,
+            "value": {"phase": "build"},
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_heartbeat_omits_none_value(self, mock_request):
+        mock_request.return_value = _ok(SHIMMER_HEARTBEAT)
+        self.shimmers.heartbeat("worker-1", None, ttl_seconds=30)
+        assert mock_request.call_args[1]["json"] == {
+            "recordType": "heartbeat",
+            "key": "worker-1",
+            "ttlSeconds": 30,
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_acquire_lock(self, mock_request):
+        mock_request.return_value = _ok(SHIMMER_LOCK)
+
+        result = self.shimmers.acquire_lock(
+            "deploy",
+            AcquireLockParams(owner_token="owner-1", ttl_seconds=60, value={"phase": "build"}),
+        )
+
+        assert isinstance(result, Shimmer)
+        assert result.owner_token == "owner-1"
+        call = mock_request.call_args
+        assert call[0][0] == "POST"
+        assert call[0][1] == "/v1/shimmers"
+        assert call[1]["json"] == {
+            "recordType": "lock",
+            "key": "deploy",
+            "ownerToken": "owner-1",
+            "ttlSeconds": 60,
+            "value": {"phase": "build"},
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_renew_lock(self, mock_request):
+        mock_request.return_value = _ok(
+            SHIMMER_LOCK, method="PUT", url="http://test:3100/v1/shimmers/deploy"
+        )
+
+        result = self.shimmers.renew_lock(
+            "deploy",
+            RenewLockParams(owner_token="owner-1", expected_revision=1, ttl_seconds=60),
+        )
+
+        assert isinstance(result, Shimmer)
+        call = mock_request.call_args
+        assert call[0][0] == "PUT"
+        assert call[0][1] == "/v1/shimmers/deploy"
+        assert call[1]["json"] == {
+            "recordType": "lock",
+            "ownerToken": "owner-1",
+            "expectedRevision": 1,
+            "ttlSeconds": 60,
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_renew_lock_url_encodes_key(self, mock_request):
+        mock_request.return_value = _ok(
+            SHIMMER_LOCK, method="PUT", url="http://test:3100/v1/shimmers/a%2Fb"
+        )
+        self.shimmers.renew_lock(
+            "a/b", RenewLockParams(owner_token="o", expected_revision=1, ttl_seconds=60)
+        )
+        assert mock_request.call_args[0][1] == "/v1/shimmers/a%2Fb"
+
+    @patch.object(httpx.Client, "request")
+    def test_release_lock(self, mock_request):
+        mock_request.return_value = _ok(
+            {"released": True, "consumed": None},
+            method="DELETE",
+            url="http://test:3100/v1/shimmers/deploy",
+        )
+
+        result = self.shimmers.release_lock(
+            "deploy", ReleaseLockParams(owner_token="owner-1")
+        )
+
+        assert isinstance(result, ShimmerDeleteResult)
+        assert result.released is True
+        assert result.consumed is None
+        call = mock_request.call_args
+        assert call[0][0] == "DELETE"
+        assert call[0][1] == "/v1/shimmers/deploy"
+        assert call[1]["params"] == {"recordType": "lock", "ownerToken": "owner-1"}
+
+    @patch.object(httpx.Client, "request")
+    def test_emit_ipc(self, mock_request):
+        mock_request.return_value = _ok({**SHIMMER_LOCK, "recordType": "ipc", "ownerToken": None})
+
+        self.shimmers.emit_ipc("chan", {"msg": "hi"}, ttl_seconds=120)
+
+        call = mock_request.call_args
+        assert call[0][0] == "POST"
+        assert call[0][1] == "/v1/shimmers"
+        assert call[1]["json"] == {
+            "recordType": "ipc",
+            "key": "chan",
+            "ttlSeconds": 120,
+            "value": {"msg": "hi"},
+        }
+
+    @patch.object(httpx.Client, "request")
+    def test_consume_ipc_returns_record(self, mock_request):
+        consumed = {**SHIMMER_READ, "recordType": "ipc"}
+        mock_request.return_value = _ok(
+            {"released": True, "consumed": consumed},
+            method="DELETE",
+            url="http://test:3100/v1/shimmers/chan",
+        )
+
+        result = self.shimmers.consume_ipc("chan")
+
+        assert isinstance(result, ShimmerRead)
+        assert result.owner_token is None
+        call = mock_request.call_args
+        assert call[0][0] == "DELETE"
+        assert call[0][1] == "/v1/shimmers/chan"
+        assert call[1]["params"] == {"recordType": "ipc"}
+
+    @patch.object(httpx.Client, "request")
+    def test_consume_ipc_returns_none_when_empty(self, mock_request):
+        mock_request.return_value = _ok(
+            {"released": False, "consumed": None},
+            method="DELETE",
+            url="http://test:3100/v1/shimmers/chan",
+        )
+        result = self.shimmers.consume_ipc("chan")
+        assert result is None
+
+    @patch.object(httpx.Client, "request")
+    def test_get(self, mock_request):
+        mock_request.return_value = _ok(
+            SHIMMER_READ, method="GET", url="http://test:3100/v1/shimmers/deploy"
+        )
+
+        result = self.shimmers.get("deploy", "lock")
+
+        assert isinstance(result, ShimmerRead)
+        assert result.owner_token is None
+        call = mock_request.call_args
+        assert call[0][0] == "GET"
+        assert call[0][1] == "/v1/shimmers/deploy"
+        assert call[1]["params"] == {"recordType": "lock"}
+
+    @patch.object(httpx.Client, "request")
+    def test_acquire_lock_raises_cas_conflict_nested(self, mock_request):
+        # engram's Hono envelope: { error: { code, message } }
+        mock_request.return_value = httpx.Response(
+            409,
+            json={"error": {"code": "SHIMMER_CAS_CONFLICT", "message": "held"}},
+            request=httpx.Request("POST", "http://test:3100/v1/shimmers"),
+        )
+        with pytest.raises(ShimmerCasConflictError) as exc:
+            self.shimmers.acquire_lock(
+                "deploy", AcquireLockParams(owner_token="o", ttl_seconds=60)
+            )
+        assert exc.value.code == "SHIMMER_CAS_CONFLICT"
+        assert exc.value.status_code == 409
+
+    @patch.object(httpx.Client, "request")
+    def test_emit_ipc_raises_cas_conflict_flat(self, mock_request):
+        # Bare { code, message } body.
+        mock_request.return_value = httpx.Response(
+            409,
+            json={"code": "SHIMMER_CAS_CONFLICT", "message": "live message"},
+            request=httpx.Request("POST", "http://test:3100/v1/shimmers"),
+        )
+        with pytest.raises(ShimmerCasConflictError) as exc:
+            self.shimmers.emit_ipc("chan", {"m": 1}, ttl_seconds=60)
+        assert exc.value.details == {"code": "SHIMMER_CAS_CONFLICT", "message": "live message"}
+
+    def test_heartbeat_raises_disabled(self):
+        # 503 SHIMMER_DISABLED must surface as the typed error. Use retries=0 so
+        # the 5xx retry loop doesn't run (the resource port doesn't change the
+        # transport-level retry policy).
+        client = EngramClient(base_url="http://test:3100", retries=0)
+        try:
+            with patch.object(httpx.Client, "request") as mock_request:
+                mock_request.return_value = httpx.Response(
+                    503,
+                    json={"error": {"code": "SHIMMER_DISABLED", "message": "off"}},
+                    request=httpx.Request("POST", "http://test:3100/v1/shimmers"),
+                )
+                with pytest.raises(ShimmerDisabledError) as exc:
+                    SyncShimmersResource(client).heartbeat("w", {}, ttl_seconds=30)
+                assert exc.value.code == "SHIMMER_DISABLED"
+                assert exc.value.status_code == 503
+        finally:
+            client.close()
+
+
+class TestAsyncShimmersResource:
+    @pytest.mark.asyncio
+    async def test_async_acquire_lock(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return _ok(SHIMMER_LOCK)
+
+                mock_request.side_effect = _resp
+                result = await ShimmersResource(client).acquire_lock(
+                    "deploy", AcquireLockParams(owner_token="owner-1", ttl_seconds=60)
+                )
+                assert isinstance(result, Shimmer)
+                assert result.owner_token == "owner-1"
+                call = mock_request.call_args
+                assert call[0][0] == "POST"
+                assert call[0][1] == "/v1/shimmers"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return _ok(
+                        SHIMMER_READ, method="GET",
+                        url="http://test:3100/v1/shimmers/deploy",
+                    )
+
+                mock_request.side_effect = _resp
+                result = await ShimmersResource(client).get("deploy", "lock")
+                assert isinstance(result, ShimmerRead)
+                assert result.owner_token is None
+                assert mock_request.call_args[1]["params"] == {"recordType": "lock"}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_acquire_lock_raises_cas_conflict(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        409,
+                        json={"error": {"code": "SHIMMER_CAS_CONFLICT", "message": "held"}},
+                        request=httpx.Request("POST", "http://test:3100/v1/shimmers"),
+                    )
+
+                mock_request.side_effect = _resp
+                with pytest.raises(ShimmerCasConflictError):
+                    await ShimmersResource(client).acquire_lock(
+                        "deploy", AcquireLockParams(owner_token="o", ttl_seconds=60)
+                    )
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_sync.py
+++ b/packages/sdk-python/tests/test_sync.py
@@ -1,0 +1,317 @@
+"""Tests for the sync (multi-node replication) resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body and
+response parsing for the standard ``{ data }`` envelope, the BARE peer shapes,
+and the NDJSON push/pull wire format.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.errors import EngramError, NetworkError
+from engram.resources.sync import (
+    SyncResource,
+    SyncSyncResource,
+)
+from engram.types.sync import (
+    CreatePeerParams,
+    ListConflictsParams,
+    ResolveConflictParams,
+    SyncChange,
+    SyncConflict,
+    SyncPeer,
+    SyncPullParams,
+    SyncPullResult,
+    SyncPushResult,
+    SyncStatus,
+)
+
+
+def _counts(n: int = 0) -> dict:
+    entry = {"inserted": n, "updated": 0, "skipped": 0}
+    return {
+        "knowledge_crystals": entry,
+        "knowledge_crystal_edges": entry,
+        "sessions": entry,
+        "session_notes": entry,
+    }
+
+
+PUSH_RESULT = {"counts": _counts(2), "conflicts": 0, "duration": 12.5}
+
+PEER = {
+    "id": "peer-1",
+    "name": "node-b",
+    "url": "https://b.example",
+    "lastPushAt": None,
+    "lastPullAt": None,
+    "lastPushSeq": None,
+    "lastPullSeq": None,
+    "linkEnabled": False,
+    "linkIntervalSeconds": 300,
+    "linkLastSyncAt": None,
+    "linkLastError": None,
+    "linkPaused": False,
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z",
+}
+
+CONFLICT = {
+    "id": "conf-1",
+    "entityType": "knowledge_crystals",
+    "entityId": "kc-1",
+    "fieldName": "title",
+    "localValue": "a",
+    "remoteValue": "b",
+    "localUpdatedAt": None,
+    "remoteUpdatedAt": None,
+    "winner": "local",
+    "resolution": "auto_lww",
+    "resolvedAt": None,
+    "createdAt": "2026-01-01T00:00:00Z",
+}
+
+STATUS = {
+    "instanceId": "inst-1",
+    "schemaVersion": "1",
+    "peersCount": 2,
+    "activeLinksCount": 1,
+    "changelogSize": 42,
+}
+
+CHANGE = {
+    "seq": "10",
+    "entityType": "knowledge_crystals",
+    "entityId": "kc-1",
+    "operation": "insert",
+    "changedFields": {"title": "x"},
+    "previousValues": None,
+    "createdAt": "2026-01-01T00:00:00Z",
+}
+
+
+def _resp(status_code=200, json_data=None, text=None, method="POST", url="http://test:3100/x"):
+    if text is not None:
+        return httpx.Response(status_code, text=text, request=httpx.Request(method, url))
+    return httpx.Response(status_code, json=json_data, request=httpx.Request(method, url))
+
+
+class TestSyncSyncResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.sync = SyncSyncResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_push_serializes_ndjson(self, mock_request):
+        mock_request.return_value = _resp(json_data={"data": PUSH_RESULT})
+        change = SyncChange.model_validate(CHANGE)
+
+        result = self.sync.push([change])
+
+        assert isinstance(result, SyncPushResult)
+        assert result.counts.knowledge_crystals.inserted == 2
+        assert result.conflicts == 0
+        call = mock_request.call_args
+        assert call[0][0] == "POST"
+        assert call[0][1] == "/v1/sync/push"
+        assert call[1]["headers"]["Content-Type"] == "application/x-ndjson"
+        body = call[1]["content"].decode("utf-8")
+        assert body.endswith("\n")
+        line = json.loads(body.strip())
+        # Serialized back to camelCase wire keys.
+        assert line["entityType"] == "knowledge_crystals"
+        assert line["entityId"] == "kc-1"
+
+    @patch.object(httpx.Client, "request")
+    def test_push_empty_sends_empty_body(self, mock_request):
+        mock_request.return_value = _resp(json_data={"data": PUSH_RESULT})
+        self.sync.push([])
+        assert mock_request.call_args[1]["content"] == b""
+
+    @patch.object(httpx.Client, "request")
+    def test_push_rejects_unenveloped_body(self, mock_request):
+        mock_request.return_value = _resp(json_data=PUSH_RESULT)  # missing { data }
+        with pytest.raises(EngramError) as exc:
+            self.sync.push([])
+        assert exc.value.code == "INTERNAL_ERROR"
+
+    @patch.object(httpx.Client, "request")
+    def test_pull_parses_ndjson(self, mock_request):
+        ndjson = json.dumps(CHANGE) + "\n" + json.dumps({**CHANGE, "seq": "11"}) + "\n"
+        mock_request.return_value = _resp(text=ndjson)
+
+        changes = self.sync.pull(SyncPullParams(since_seq=None))
+
+        assert len(changes) == 2
+        assert changes[0].seq == "10"
+        assert changes[1].seq == "11"
+        call = mock_request.call_args
+        assert call[0][1] == "/v1/sync/pull"
+        sent = json.loads(call[1]["content"].decode("utf-8"))
+        assert sent["sinceSeq"] is None
+
+    @patch.object(httpx.Client, "request")
+    def test_pull_malformed_line_raises_network_error(self, mock_request):
+        mock_request.return_value = _resp(text="{not json}\n")
+        with pytest.raises(NetworkError):
+            self.sync.pull(SyncPullParams(since_seq="5"))
+
+    @patch.object(httpx.Client, "request")
+    def test_pull_unknown_entity_type_raises(self, mock_request):
+        bad = json.dumps({**CHANGE, "entityType": "bogus"}) + "\n"
+        mock_request.return_value = _resp(text=bad)
+        with pytest.raises(NetworkError):
+            self.sync.pull(SyncPullParams(since_seq="5"))
+
+    @patch.object(httpx.Client, "request")
+    def test_get_status(self, mock_request):
+        mock_request.return_value = _resp(json_data={"data": STATUS}, method="GET")
+        status = self.sync.get_status()
+        assert isinstance(status, SyncStatus)
+        assert status.instance_id == "inst-1"
+        assert status.peers_count == 2
+        assert mock_request.call_args[0][1] == "/v1/sync/status"
+
+    @patch.object(httpx.Client, "request")
+    def test_push_to_sets_peer_query(self, mock_request):
+        mock_request.return_value = _resp(json_data={"data": PUSH_RESULT})
+        self.sync.push_to("node-b")
+        call = mock_request.call_args
+        assert call[0][1] == "/v1/sync/push-to"
+        assert call[1]["params"] == {"peer": "node-b"}
+
+    @patch.object(httpx.Client, "request")
+    def test_pull_from_normalizes_max_seq(self, mock_request):
+        mock_request.return_value = _resp(
+            json_data={"data": {"entriesStreamed": 3, "maxSeq": None, "duration": 1.0}}
+        )
+        result = self.sync.pull_from("node-b")
+        assert isinstance(result, SyncPullResult)
+        assert result.entries_streamed == 3
+        assert result.max_seq is None
+
+    @patch.object(httpx.Client, "request")
+    def test_list_conflicts(self, mock_request):
+        mock_request.return_value = _resp(
+            json_data={"data": {"conflicts": [CONFLICT], "total": 1}}, method="GET"
+        )
+        result = self.sync.list_conflicts(ListConflictsParams(unresolved=True))
+        assert result["total"] == 1
+        assert isinstance(result["conflicts"][0], SyncConflict)
+        assert mock_request.call_args[1]["params"] == {"unresolved": "true"}
+
+    @patch.object(httpx.Client, "request")
+    def test_resolve_conflict(self, mock_request):
+        mock_request.return_value = _resp(json_data={"data": CONFLICT})
+        result = self.sync.resolve_conflict(
+            "conf-1", ResolveConflictParams(resolution="local")
+        )
+        assert isinstance(result, SyncConflict)
+        call = mock_request.call_args
+        assert call[0][1] == "/v1/sync/conflicts/conf-1/resolve"
+        assert call[1]["json"] == {"resolution": "local"}
+
+
+class TestSyncSyncPeersResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.sync = SyncSyncResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_create_peer_bare_shape(self, mock_request):
+        mock_request.return_value = _resp(json_data={"peer": PEER})
+        peer = self.sync.peers.create(
+            CreatePeerParams(name="node-b", url="https://b.example")
+        )
+        assert isinstance(peer, SyncPeer)
+        assert peer.name == "node-b"
+        assert mock_request.call_args[0][1] == "/v1/sync/peers"
+
+    @patch.object(httpx.Client, "request")
+    def test_list_peers_bare_shape(self, mock_request):
+        mock_request.return_value = _resp(json_data={"peers": [PEER]}, method="GET")
+        peers = self.sync.peers.list()
+        assert len(peers) == 1
+        assert peers[0].id == "peer-1"
+
+    @patch.object(httpx.Client, "request")
+    def test_list_peers_rejects_wrong_shape(self, mock_request):
+        mock_request.return_value = _resp(json_data={"data": [PEER]}, method="GET")
+        with pytest.raises(EngramError) as exc:
+            self.sync.peers.list()
+        assert exc.value.code == "INTERNAL_ERROR"
+
+    @patch.object(httpx.Client, "request")
+    def test_delete_peer_returns_bare(self, mock_request):
+        mock_request.return_value = _resp(
+            json_data={"removed": True, "name": "node-b"}, method="DELETE"
+        )
+        result = self.sync.peers.delete("node-b")
+        assert result == {"removed": True, "name": "node-b"}
+
+    @patch.object(httpx.Client, "request")
+    def test_link_toggles(self, mock_request):
+        mock_request.return_value = _resp(json_data={"peer": PEER})
+        assert self.sync.peers.link("node-b") is None
+        assert mock_request.call_args[0][1] == "/v1/sync/peers/node-b/link"
+        self.sync.peers.pause("node-b")
+        assert mock_request.call_args[0][1] == "/v1/sync/peers/node-b/link/pause"
+
+
+class TestAsyncSyncResource:
+    @pytest.mark.asyncio
+    async def test_async_push(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*a, **k):
+                    return _resp(json_data={"data": PUSH_RESULT})
+
+                mock_request.side_effect = _r
+                result = await SyncResource(client).push([SyncChange.model_validate(CHANGE)])
+                assert isinstance(result, SyncPushResult)
+                assert result.counts.sessions.skipped == 0
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_pull(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*a, **k):
+                    return _resp(text=json.dumps(CHANGE) + "\n")
+
+                mock_request.side_effect = _r
+                changes = await SyncResource(client).pull(SyncPullParams(since_seq=None))
+                assert len(changes) == 1
+                assert changes[0].entity_id == "kc-1"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_peers_create(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _r(*a, **k):
+                    return _resp(json_data={"peer": PEER})
+
+                mock_request.side_effect = _r
+                peer = await SyncResource(client).peers.create(
+                    CreatePeerParams(name="node-b", url="https://b.example")
+                )
+                assert peer.name == "node-b"
+        finally:
+            await client.close()

--- a/packages/sdk-python/tests/test_sync.py
+++ b/packages/sdk-python/tests/test_sync.py
@@ -160,9 +160,24 @@ class TestSyncSyncResource:
 
     @patch.object(httpx.Client, "request")
     def test_pull_malformed_line_raises_network_error(self, mock_request):
-        mock_request.return_value = _resp(text="{not json}\n")
-        with pytest.raises(NetworkError):
+        # A good line 0 then a malformed line 1 — the error must name the
+        # offending line index and the route so the failure is debuggable.
+        mock_request.return_value = _resp(text=json.dumps(CHANGE) + "\n{not json}\n")
+        with pytest.raises(NetworkError) as exc_info:
             self.sync.pull(SyncPullParams(since_seq="5"))
+        msg = str(exc_info.value)
+        assert "line 1" in msg
+        assert "/v1/sync/pull" in msg
+
+    @patch.object(httpx.Client, "request")
+    def test_pull_wrong_field_type_raises_network_error(self, mock_request):
+        # A field with the wrong type (changedFields as a list) must surface as a
+        # structured NetworkError with the line index, not a raw pydantic error.
+        bad = json.dumps({**CHANGE, "changedFields": ["not", "a", "dict"]}) + "\n"
+        mock_request.return_value = _resp(text=bad)
+        with pytest.raises(NetworkError) as exc_info:
+            self.sync.pull(SyncPullParams(since_seq="5"))
+        assert "line 0" in str(exc_info.value)
 
     @patch.object(httpx.Client, "request")
     def test_pull_unknown_entity_type_raises(self, mock_request):

--- a/packages/sdk-python/tests/test_users.py
+++ b/packages/sdk-python/tests/test_users.py
@@ -1,0 +1,268 @@
+"""Tests for the users resource.
+
+Mirrors the TS resource-test pattern: assert request path/method/body/query
+and response unwrapping for the users endpoints. The users endpoints use the
+standard ``{ data }`` envelope; the single-object routes nest their payload one
+level deeper (``{ data: { user } }`` / ``{ data: { user, key } }`` /
+``{ data: { users: [...] } }``), so these tests pin that unwrapping.
+
+The users resource is not wired onto the client, so the resources are
+instantiated directly against a real client (with httpx patched).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engram.client import AsyncEngramClient, EngramClient
+from engram.resources.users import SyncUsersResource, UsersResource
+from engram.types.users import (
+    ApiKey,
+    CreateUserParams,
+    CreateUserResult,
+    DeleteUserResult,
+    User,
+)
+
+
+SAMPLE_USER = {
+    "id": "user-1",
+    "name": "alice",
+    "displayName": "Alice",
+    "createdAt": "2026-01-01T00:00:00Z",
+}
+
+SAMPLE_USER_NO_DISPLAY = {
+    "id": "user-2",
+    "name": "bob",
+    "displayName": None,
+    "createdAt": "2026-01-02T00:00:00Z",
+}
+
+SAMPLE_API_KEY = {
+    "id": "key-1",
+    "name": "default",
+    "prefix": "ek_abc",
+    "value": "ek_abc_secret_value",
+}
+
+
+class TestSyncUsersResource:
+    def setup_method(self):
+        self.client = EngramClient(base_url="http://test:3100")
+        self.users = SyncUsersResource(self.client)
+
+    def teardown_method(self):
+        self.client.close()
+
+    @patch.object(httpx.Client, "request")
+    def test_create_unwraps_user_and_key(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"user": SAMPLE_USER, "key": SAMPLE_API_KEY}},
+            request=httpx.Request("POST", "http://test:3100/v1/users"),
+        )
+
+        result = self.users.create(
+            CreateUserParams(name="alice", display_name="Alice")
+        )
+
+        assert isinstance(result, CreateUserResult)
+        assert isinstance(result.user, User)
+        assert isinstance(result.key, ApiKey)
+        assert result.user.id == "user-1"
+        assert result.user.name == "alice"
+        assert result.user.display_name == "Alice"
+        assert result.key.value == "ek_abc_secret_value"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/v1/users"
+        # camelCase body, with no display name sent when omitted is covered below.
+        assert call_args[1]["json"] == {"name": "alice", "displayName": "Alice"}
+
+    @patch.object(httpx.Client, "request")
+    def test_create_omits_display_name_when_absent(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"user": SAMPLE_USER_NO_DISPLAY, "key": SAMPLE_API_KEY}},
+            request=httpx.Request("POST", "http://test:3100/v1/users"),
+        )
+
+        self.users.create(CreateUserParams(name="bob"))
+
+        assert mock_request.call_args[1]["json"] == {"name": "bob"}
+
+    @patch.object(httpx.Client, "request")
+    def test_list_unwraps_users_array(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"users": [SAMPLE_USER, SAMPLE_USER_NO_DISPLAY]}},
+            request=httpx.Request("GET", "http://test:3100/v1/users"),
+        )
+
+        users = self.users.list()
+
+        assert isinstance(users, list)
+        assert len(users) == 2
+        assert all(isinstance(u, User) for u in users)
+        assert users[0].name == "alice"
+        assert users[1].display_name is None
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/users"
+        # No pagination params -> no query params reach httpx at all.
+        assert "params" not in call_args[1]
+
+    @patch.object(httpx.Client, "request")
+    def test_list_sends_limit_and_offset(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"users": []}},
+            request=httpx.Request("GET", "http://test:3100/v1/users"),
+        )
+
+        users = self.users.list(limit=10, offset=5)
+
+        assert users == []
+        assert mock_request.call_args[1]["params"] == {"limit": "10", "offset": "5"}
+
+    @patch.object(httpx.Client, "request")
+    def test_get_unwraps_user(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"user": SAMPLE_USER}},
+            request=httpx.Request("GET", "http://test:3100/v1/users/alice"),
+        )
+
+        user = self.users.get("alice")
+
+        assert isinstance(user, User)
+        assert user.id == "user-1"
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/v1/users/alice"
+
+    @patch.object(httpx.Client, "request")
+    def test_get_url_encodes_id(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"user": SAMPLE_USER}},
+            request=httpx.Request("GET", "http://test:3100/v1/users/a%2Fb"),
+        )
+
+        self.users.get("a/b")
+
+        assert mock_request.call_args[0][1] == "/v1/users/a%2Fb"
+
+    @patch.object(httpx.Client, "request")
+    def test_delete_default_sends_no_query(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"deleted": True, "revokedKeys": 0}},
+            request=httpx.Request("DELETE", "http://test:3100/v1/users/alice"),
+        )
+
+        result = self.users.delete("alice")
+
+        assert isinstance(result, DeleteUserResult)
+        assert result.deleted is True
+        assert result.revoked_keys == 0
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "DELETE"
+        assert call_args[0][1] == "/v1/users/alice"
+        assert "params" not in call_args[1]
+
+    @patch.object(httpx.Client, "request")
+    def test_delete_revoke_keys_sets_query(self, mock_request):
+        mock_request.return_value = httpx.Response(
+            200,
+            json={"data": {"deleted": True, "revokedKeys": 3}},
+            request=httpx.Request("DELETE", "http://test:3100/v1/users/alice?revokeKeys=true"),
+        )
+
+        result = self.users.delete("alice", revoke_keys=True)
+
+        assert result.revoked_keys == 3
+        call_args = mock_request.call_args
+        assert call_args[0][1] == "/v1/users/alice"
+        assert call_args[1]["params"] == {"revokeKeys": "true"}
+
+
+class TestAsyncUsersResource:
+    @pytest.mark.asyncio
+    async def test_async_create_unwraps_user_and_key(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        users = UsersResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json={"data": {"user": SAMPLE_USER, "key": SAMPLE_API_KEY}},
+                        request=httpx.Request("POST", "http://test:3100/v1/users"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await users.create(CreateUserParams(name="alice"))
+                assert isinstance(result, CreateUserResult)
+                assert result.user.name == "alice"
+                assert result.key.prefix == "ek_abc"
+                call_args = mock_request.call_args
+                assert call_args[0][0] == "POST"
+                assert call_args[0][1] == "/v1/users"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_list_unwraps_users_array(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        users = UsersResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    return httpx.Response(
+                        200,
+                        json={"data": {"users": [SAMPLE_USER]}},
+                        request=httpx.Request("GET", "http://test:3100/v1/users"),
+                    )
+
+                mock_request.side_effect = _resp
+                result = await users.list()
+                assert isinstance(result, list)
+                assert result[0].name == "alice"
+                assert mock_request.call_args[0][1] == "/v1/users"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_get_and_delete(self):
+        client = AsyncEngramClient(base_url="http://test:3100")
+        users = UsersResource(client)
+        try:
+            with patch.object(httpx.AsyncClient, "request") as mock_request:
+                async def _resp(*args, **kwargs):
+                    if args[0] == "DELETE":
+                        return httpx.Response(
+                            200,
+                            json={"data": {"deleted": True, "revokedKeys": 1}},
+                            request=httpx.Request("DELETE", "http://test:3100/v1/users/alice"),
+                        )
+                    return httpx.Response(
+                        200,
+                        json={"data": {"user": SAMPLE_USER}},
+                        request=httpx.Request("GET", "http://test:3100/v1/users/alice"),
+                    )
+
+                mock_request.side_effect = _resp
+                user = await users.get("alice")
+                assert isinstance(user, User)
+                assert user.id == "user-1"
+
+                result = await users.delete("alice", revoke_keys=True)
+                assert isinstance(result, DeleteUserResult)
+                assert result.revoked_keys == 1
+                assert mock_request.call_args[1]["params"] == {"revokeKeys": "true"}
+        finally:
+            await client.close()


### PR DESCRIPTION
## Summary

Completes **sdk-python Phase C**: brings `engram-py` to full `@centient/sdk` 2.1.0 **resource parity** and aligns the version `1.0.0 → 2.1.0`. Also fixes the Python sibling of issue #117 (nested-envelope error mapping), folded in per request.

### Phase C — new resources (async + synchronous-client variants, wired into both clients)

- **`sync`** (`client.sync`): NDJSON `push`/`pull`, `push_to`/`pull_from`, `get_status`, `list_conflicts`/`resolve_conflict`, and a `.peers` sub-resource. Standard `{data}` envelopes + bare `{peer}` peer shapes; malformed NDJSON → `NetworkError`, contract drift → `EngramError`.
- **`agents`, `ambient_context`, `facts`, `gc`, `memory_spaces`, `users`** — the six plan resources.
- **`shimmers`** (`client.shimmers`): lock / heartbeat / ipc, with typed `ShimmerCasConflictError` / `ShimmerDisabledError` (post-plan surface, #112).
- **Crystal dedup / deferred-merge review** (post-plan, #114): `notes.dedup`, `crystals.pending_merges` / `review_merge` / `merge_history` — bare (non-enveloped) bodies.

### Supporting changes

- `EngramError.retryable` property (default `True`; `False` on `ShimmerDisabledError`) now honored across the client retry loop, so the 503 deployment gate is not retried (mirrors TS).
- Version `1.0.0 → 2.1.0`; CHANGELOG support matrix + README updated to 2.1.0 (every TS resource surface now has a Python counterpart; flat client methods remain out of scope by design).
- `types/__init__` imports `sync` before `terrafirma` so terrafirma keeps the flat-namespace `SyncStatus`; the replication one stays at `engram.types.sync.SyncStatus`.

### #117 sibling fix (`parse_api_error`)

The nested `{ error: { code, message } }` branch threw a base `EngramError` for every non-CAS/non-shimmer code, never reaching the status→class mapping (404→`NotFoundError`, etc.) — exactly the TS bug fixed in #118. Extracted a shared `_status_mapped_error` helper routed through by **both** envelope branches; server code/details preserved; generic 409 (non-`SESSION_EXISTS`) now stays a base `EngramError` in both branches.

## Testing

`make python-test` (`scripts/run-python-tests.sh`): **668 passed, 10 deselected**. ~120 new tests (every new resource + `TestNestedEnvelopeStatusMapping`). The 10 deselected integration tests (autogen/crewai/langchain) are pre-existing and excluded from the gate.

## Notes

- `engram-py` is a PyPI package, not in the npm Changesets flow — version bumped in `pyproject.toml` per the Python release procedure (no changeset).
- Relates to TS #117 / #118 (the TS-side fix of the same error-mapping bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)