### PR TITLE
fix(secrets): audit policy-rejected ops + surface libsecret D-Bus fallback (#120, #121)

### DIFF
--- a/.changeset/secrets-audit-rejected-ops-and-dbus-warning.md
+++ b/.changeset/secrets-audit-rejected-ops-and-dbus-warning.md
@@ -1,0 +1,36 @@
+---
+"@centient/secrets": minor
+---
+
+Close two ADR-002 P0 audit gaps surfaced by the scoped `cl-adr-audit` re-run:
+policy-rejected operations are now audited, and a security-relevant libsecret
+enumeration fallback is no longer silent.
+
+**#120 — denied operations are audited (ADR-002 §1.0.0).** Previously, when a
+`before` policy hook rejected an operation by throwing, the error propagated to
+the caller but **no `after` event fired** — a denied credential operation left
+no audit trace, the exact gap ADR-002 line 158 warns against (the `policy.ts`
+docstring even contradicted the ADR). `runBeforeHooks` now implements the
+documented behavior: on a before-hook throw at policy `i`, the `after` hooks of
+the already-entered policies (`0..i-1`, bottom-to-top) fire with a new
+`*_rejected` event, then the original error is re-thrown. The rejecting policy's
+own `after` hook does not fire (its `before` did not complete). Wired through
+both the cascade vault (`storeCredential`/`getCredential`/`deleteCredential`/
+`listCredentials`) and the session vault's `withAudit` helper.
+
+**Minor (not patch) — additive public surface.** `SecretsEventType` gains four
+members: `credential_read_rejected`, `credential_write_rejected`,
+`credential_delete_rejected`, `credential_enumerate_rejected`. A new
+`rejectedEventType(op)` helper (operation → rejected-event-type) is exported as
+the single source of truth for the mapping. Existing event types and emission
+are unchanged, so consumers that only `switch` on the prior types keep working.
+
+**#121 — libsecret D-Bus→secret-tool fallback is no longer silent.** The
+`secret-tool search` fallback briefly materializes secret values on stdout, so
+reverting to it from the secure D-Bus enumeration path is a security-relevant
+degradation. The bare `catch {}` that swallowed all D-Bus errors now emits a
+one-time stderr warning **when a session bus is advertised
+(`DBUS_SESSION_BUS_ADDRESS` set) yet the D-Bus path still fails** — i.e. the
+path that should have worked didn't. A genuinely bus-less host (SSH session,
+headless server) stays quiet, since the fallback is the documented, expected
+behavior there.

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -54,7 +54,7 @@ export type { ResolveKeyProviderOptions } from "./key-providers/resolve.js";
 export { isValidKey } from "./vault/vault-utils.js";
 
 // Policy
-export { setSecretsPolicies, getActivePolicies, auditTrail } from "./vault/policy.js";
+export { setSecretsPolicies, getActivePolicies, auditTrail, rejectedEventType } from "./vault/policy.js";
 export type { SecretsPolicy, SecretsEvent, SecretsEventType, SecretsOperation, AuditTrailOptions } from "./vault/policy.js";
 
 // Session-backed vault (envelope encryption, single unlock per session)

--- a/packages/secrets/src/vault/policy.ts
+++ b/packages/secrets/src/vault/policy.ts
@@ -79,6 +79,12 @@ export function rejectedEventType(op: SecretsOperation): SecretsEventType {
       return "credential_delete_rejected";
     case "enumerate":
       return "credential_enumerate_rejected";
+    default: {
+      // Exhaustiveness guard: if a new SecretsOperation["type"] is added
+      // without a case here, this assignment fails to compile.
+      const unreachable: never = op.type;
+      throw new Error(`unhandled operation type: ${String(unreachable)}`);
+    }
   }
 }
 
@@ -88,7 +94,17 @@ export function rejectedEventType(op: SecretsOperation): SecretsEventType {
 
 export interface SecretsPolicy {
   readonly name: string;
+  /** `before` hooks may be async; they are awaited before the operation runs. */
   before?(op: SecretsOperation): void | Promise<void>;
+  /**
+   * `after` hooks MUST be synchronous (return type is `void`, not
+   * `Promise<void>`). The runner invokes them synchronously and catches
+   * only synchronous throws — a `Promise` returned from an `after` hook
+   * is not awaited, so its rejection would escape as an unhandled
+   * rejection rather than being swallowed with the one-time warning. Do
+   * audit I/O via a fire-and-forget sink the hook itself owns, or buffer
+   * and flush outside the hook.
+   */
   after?(event: SecretsEvent): void;
 }
 
@@ -141,9 +157,12 @@ export function runAfterHooks(event: SecretsEvent): void {
 
 /**
  * Run `after` hooks for policies `fromIndex..0` (bottom-to-top). A
- * negative `fromIndex` is a no-op (no policy was entered). Hook
- * exceptions are swallowed best-effort with a one-time stderr warning —
- * audit-infrastructure failures must never break credential operations.
+ * negative `fromIndex` is a no-op (no policy was entered). Synchronous
+ * hook exceptions are swallowed best-effort with a one-time stderr
+ * warning — audit-infrastructure failures must never break credential
+ * operations. `after` hooks are synchronous by contract (see
+ * `SecretsPolicy.after`); a hook that returns a rejected `Promise` is
+ * not awaited here, so it would surface as an unhandled rejection.
  */
 function runAfterHooksForRange(event: SecretsEvent, fromIndex: number): void {
   for (let i = fromIndex; i >= 0; i--) {

--- a/packages/secrets/src/vault/policy.ts
+++ b/packages/secrets/src/vault/policy.ts
@@ -8,8 +8,13 @@
  * stack described in ADR-002.
  *
  * Execution model:
- *   1. `before` hooks run top-to-bottom. If any throws, the operation
- *      is aborted and the error propagates to the caller.
+ *   1. `before` hooks run top-to-bottom. If one throws, the operation
+ *      is aborted and the error propagates to the caller — but the
+ *      `after` hooks of already-entered policies (those whose `before`
+ *      hook already completed) still fire with a `*_rejected` event, so
+ *      a policy-denied operation is audited rather than vanishing
+ *      (ADR-002 §1.0.0). The rejecting policy's own `after` hook does
+ *      not fire — its `before` hook did not complete.
  *   2. The backend operation executes.
  *   3. `after` hooks run bottom-to-top with a structured event
  *      describing the outcome. Exceptions in `after` hooks are
@@ -27,12 +32,16 @@ export type SecretsEventType =
   | "credential_read"
   | "credential_read_missing"
   | "credential_read_failed"
+  | "credential_read_rejected"
   | "credential_written"
   | "credential_write_failed"
+  | "credential_write_rejected"
   | "credential_deleted"
   | "credential_delete_failed"
+  | "credential_delete_rejected"
   | "credential_enumerated"
-  | "credential_enumerate_failed";
+  | "credential_enumerate_failed"
+  | "credential_enumerate_rejected";
 
 export interface SecretsEvent {
   type: SecretsEventType;
@@ -53,6 +62,24 @@ export interface SecretsOperation {
   type: "read" | "write" | "delete" | "enumerate";
   key?: string;
   prefix?: string;
+}
+
+/**
+ * The audit event type emitted when a `before` hook rejects an
+ * operation. Single source of truth for the operation→`*_rejected`
+ * mapping, shared by the cascade vault and the session vault.
+ */
+export function rejectedEventType(op: SecretsOperation): SecretsEventType {
+  switch (op.type) {
+    case "read":
+      return "credential_read_rejected";
+    case "write":
+      return "credential_write_rejected";
+    case "delete":
+      return "credential_delete_rejected";
+    case "enumerate":
+      return "credential_enumerate_rejected";
+  }
 }
 
 // =============================================================================
@@ -81,14 +108,45 @@ export function getActivePolicies(): readonly SecretsPolicy[] {
   return activePolicies;
 }
 
-export async function runBeforeHooks(op: SecretsOperation): Promise<void> {
-  for (const policy of activePolicies) {
-    if (policy.before) await policy.before(op);
+/**
+ * Run `before` hooks top-to-bottom. If a hook throws, the operation is
+ * rejected: the `after` hooks of the already-entered policies (indices
+ * `0..i-1`, bottom-to-top) fire with the event built by
+ * `makeRejectionEvent` so the denied operation is still audited, then the
+ * original error is re-thrown to abort the operation. The rejecting
+ * policy's own `after` hook is intentionally skipped — its `before` hook
+ * did not complete, so the policy was not fully entered. See ADR-002
+ * §1.0.0.
+ */
+export async function runBeforeHooks(
+  op: SecretsOperation,
+  makeRejectionEvent: (error: string) => SecretsEvent,
+): Promise<void> {
+  for (let i = 0; i < activePolicies.length; i++) {
+    const policy = activePolicies[i]!;
+    if (!policy.before) continue;
+    try {
+      await policy.before(op);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      runAfterHooksForRange(makeRejectionEvent(msg), i - 1);
+      throw err;
+    }
   }
 }
 
 export function runAfterHooks(event: SecretsEvent): void {
-  for (let i = activePolicies.length - 1; i >= 0; i--) {
+  runAfterHooksForRange(event, activePolicies.length - 1);
+}
+
+/**
+ * Run `after` hooks for policies `fromIndex..0` (bottom-to-top). A
+ * negative `fromIndex` is a no-op (no policy was entered). Hook
+ * exceptions are swallowed best-effort with a one-time stderr warning —
+ * audit-infrastructure failures must never break credential operations.
+ */
+function runAfterHooksForRange(event: SecretsEvent, fromIndex: number): void {
+  for (let i = fromIndex; i >= 0; i--) {
     const policy = activePolicies[i]!;
     if (policy.after) {
       try {

--- a/packages/secrets/src/vault/session-vault.ts
+++ b/packages/secrets/src/vault/session-vault.ts
@@ -59,6 +59,7 @@ import type { KeyProvider, KeyProviderType } from "../key-providers/types.js";
 import {
   runBeforeHooks,
   runAfterHooks,
+  rejectedEventType,
   type SecretsEventType,
   type SecretsOperation,
 } from "./policy.js";
@@ -720,7 +721,16 @@ function buildVault(args: BuildVaultArgs): SessionVault {
     extras?: (value: T) => Partial<{ keyCount: number }>,
   ): Promise<T> => {
     assertOpen();
-    await runBeforeHooks(op);
+    const beforeStart = Date.now();
+    await runBeforeHooks(op, (error) => ({
+      type: rejectedEventType(op),
+      timestamp: new Date(beforeStart).toISOString(),
+      backend: "session-vault",
+      key: op.key,
+      prefix: op.prefix,
+      error,
+      durationMs: Date.now() - beforeStart,
+    }));
     // Re-check after the await — TTL or sibling close() could have fired
     // while before-hooks awaited (H2).
     assertOpen();

--- a/packages/secrets/src/vault/vault-libsecret.ts
+++ b/packages/secrets/src/vault/vault-libsecret.ts
@@ -20,6 +20,14 @@ import { isValidKey } from "./vault-utils.js";
 const SERVICE_ATTR = "centient";
 const LABEL = "centient-auth";
 
+/**
+ * One-time guard so a "secure D-Bus enumeration degraded to secret-tool"
+ * warning is emitted at most once per process (mirrors the audit-policy
+ * warning idiom in policy.ts), avoiding a log flood when enumeration is
+ * called in a loop.
+ */
+let dbusFallbackWarned = false;
+
 // =============================================================================
 // LibsecretVault
 // =============================================================================
@@ -138,7 +146,11 @@ export class LibsecretVault implements VaultBackend {
    * `secret-tool search --all` and parses `attribute.key` lines.
    * The fallback still briefly materializes secret values on stdout;
    * the JSDoc on the `secret-tool` path in the fallback documents
-   * this trade-off.
+   * this trade-off. Because that fallback is a security-relevant
+   * degradation, a host that advertises a session bus yet still fails
+   * the D-Bus path emits a one-time stderr warning
+   * (`warnOnDbusDegradation`); a genuinely bus-less host stays quiet
+   * since the fallback is the documented, expected behavior there.
    *
    * No results -> empty list. A transient failure from both paths is
    * propagated per the VaultBackend contract so the caller can retry.
@@ -146,9 +158,36 @@ export class LibsecretVault implements VaultBackend {
   async listKeys(prefix?: string): Promise<string[]> {
     try {
       return await this.listKeysViaDbus(prefix);
-    } catch {
+    } catch (err) {
+      this.warnOnDbusDegradation(err);
       return this.listKeysViaSecretTool(prefix);
     }
+  }
+
+  /**
+   * The secret-tool fallback briefly materializes secret values on
+   * stdout (see `listKeysViaSecretTool`), so reverting to it from the
+   * secure D-Bus path is a security-relevant degradation that must not
+   * be silent (DESIGN-PHILOSOPHY: no silent degradation).
+   *
+   * But a host with no session bus at all — an SSH session or headless
+   * server with no `DBUS_SESSION_BUS_ADDRESS` — is the *documented,
+   * expected* fallback case, not a degradation, so warning there would
+   * be noise. We therefore warn (once per process) only when a session
+   * bus is advertised yet the D-Bus enumeration still failed: that is an
+   * unexpected failure of the path that was supposed to work.
+   */
+  private warnOnDbusDegradation(err: unknown): void {
+    if (dbusFallbackWarned) return;
+    const sessionBus = process.env.DBUS_SESSION_BUS_ADDRESS;
+    if (sessionBus === undefined || sessionBus.length === 0) return;
+    dbusFallbackWarned = true;
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[secrets] libsecret D-Bus enumeration failed despite an active session ` +
+        `bus; falling back to \`secret-tool search\`, which briefly materializes ` +
+        `secret values on stdout. Cause: ${msg}\n`,
+    );
   }
 
   /**

--- a/packages/secrets/src/vault/vault-libsecret.ts
+++ b/packages/secrets/src/vault/vault-libsecret.ts
@@ -159,6 +159,12 @@ export class LibsecretVault implements VaultBackend {
     try {
       return await this.listKeysViaDbus(prefix);
     } catch (err) {
+      // Intentionally broad: the contract is "if the secure D-Bus path
+      // cannot enumerate for ANY reason, degrade to secret-tool" — the
+      // dominant cause is a bus-less host, but a protocol/variant error
+      // should fall back too rather than fail the read. The degradation
+      // is never silent (warnOnDbusDegradation surfaces an unexpected
+      // failure once), so a swallowed cause is still observable.
       this.warnOnDbusDegradation(err);
       return this.listKeysViaSecretTool(prefix);
     }

--- a/packages/secrets/src/vault/vault.ts
+++ b/packages/secrets/src/vault/vault.ts
@@ -108,12 +108,11 @@ function touchSession(): void {
 // =============================================================================
 // Public API
 //
-// Known limitation (0.5.0): when a `before` policy hook rejects an
-// operation by throwing, the rejection propagates to the caller but no
-// `after` event is emitted. This means policy-rejected operations are
-// invisible to the audit trail. The full onion model — where `after`
-// hooks on already-entered policies still fire on abort — ships in 1.0
-// as part of `createSecretsClient`. See ADR-002 §1.0.0.
+// Policy-rejected operations are audited: when a `before` hook throws,
+// the rejection propagates to the caller AND the `after` hooks of the
+// already-entered policies fire with a `*_rejected` event (see
+// `runBeforeHooks` in policy.ts), so a denied operation is never
+// invisible to the audit trail. ADR-002 §1.0.0.
 // =============================================================================
 
 /**
@@ -138,7 +137,14 @@ export async function storeCredential(
   value: string,
 ): Promise<boolean> {
   const start = performance.now();
-  await runBeforeHooks({ type: "write", key });
+  await runBeforeHooks({ type: "write", key }, (error) => ({
+    type: "credential_write_rejected",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    key,
+    error,
+    durationMs: performance.now() - start,
+  }));
   const success = activeBackend.store(key, value);
   if (success) touchSession();
   runAfterHooks({
@@ -159,7 +165,14 @@ export async function storeCredential(
  */
 export async function getCredential(key: string): Promise<string | null> {
   const start = performance.now();
-  await runBeforeHooks({ type: "read", key });
+  await runBeforeHooks({ type: "read", key }, (error) => ({
+    type: "credential_read_rejected",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    key,
+    error,
+    durationMs: performance.now() - start,
+  }));
   let value: string | null;
   try {
     value = activeBackend.retrieve(key);
@@ -193,7 +206,14 @@ export async function getCredential(key: string): Promise<string | null> {
  */
 export async function deleteCredential(key: string): Promise<boolean> {
   const start = performance.now();
-  await runBeforeHooks({ type: "delete", key });
+  await runBeforeHooks({ type: "delete", key }, (error) => ({
+    type: "credential_delete_rejected",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    key,
+    error,
+    durationMs: performance.now() - start,
+  }));
   const success = activeBackend.delete(key);
   runAfterHooks({
     type: success ? "credential_deleted" : "credential_delete_failed",
@@ -231,7 +251,14 @@ export async function deleteCredential(key: string): Promise<boolean> {
  */
 export async function listCredentials(prefix?: string): Promise<string[]> {
   const start = performance.now();
-  await runBeforeHooks({ type: "enumerate", prefix });
+  await runBeforeHooks({ type: "enumerate", prefix }, (error) => ({
+    type: "credential_enumerate_rejected",
+    timestamp: new Date().toISOString(),
+    backend: activeVaultType,
+    prefix,
+    error,
+    durationMs: performance.now() - start,
+  }));
   let keys: string[];
   try {
     keys = await activeBackend.listKeys(prefix);

--- a/packages/secrets/tests/policy.test.ts
+++ b/packages/secrets/tests/policy.test.ts
@@ -254,6 +254,95 @@ describe("policy before hooks", () => {
 });
 
 // =============================================================================
+// before hook rejection — denied operations are still audited (ADR-002 §1.0.0)
+// =============================================================================
+
+describe("policy before-hook rejection auditing", () => {
+  it("fires after hooks of already-entered policies with a *_rejected event when a later before hook throws", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([
+      { name: "auditor", after: (e) => events.push(e) },
+      { name: "acl", before: () => { throw new Error("denied by acl"); } },
+    ]);
+
+    await expect(storeCredential("auth-token", "value")).rejects.toThrow("denied by acl");
+
+    // backend never ran, but the denial was audited
+    expect(mockStoreString).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("credential_write_rejected");
+    expect(events[0]!.key).toBe("auth-token");
+    expect(events[0]!.error).toBe("denied by acl");
+  });
+
+  it("does NOT fire the rejecting policy's own after hook (its before did not complete)", async () => {
+    const fired: string[] = [];
+    setSecretsPolicies([
+      { name: "outer", after: () => { fired.push("outer-after"); } },
+      {
+        name: "acl",
+        before: () => { throw new Error("denied"); },
+        after: () => { fired.push("acl-after"); },
+      },
+    ]);
+
+    await expect(getCredential("auth-token")).rejects.toThrow("denied");
+
+    // only the already-entered "outer" policy's after fires
+    expect(fired).toEqual(["outer-after"]);
+  });
+
+  it("fires no after hooks when the FIRST policy's before throws (nothing entered)", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([
+      { name: "acl", before: () => { throw new Error("denied first"); }, after: (e) => events.push(e) },
+    ]);
+
+    await expect(getCredential("auth-token")).rejects.toThrow("denied first");
+    expect(events).toHaveLength(0);
+  });
+
+  it("emits the per-operation rejected event type", async () => {
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([
+      { name: "auditor", after: (e) => events.push(e) },
+      { name: "acl", before: () => { throw new Error("nope"); } },
+    ]);
+
+    await expect(storeCredential("k", "v")).rejects.toThrow();
+    await expect(getCredential("k")).rejects.toThrow();
+    await expect(deleteCredential("k")).rejects.toThrow();
+    await expect(listCredentials("p.")).rejects.toThrow();
+
+    expect(events.map((e) => e.type)).toEqual([
+      "credential_write_rejected",
+      "credential_read_rejected",
+      "credential_delete_rejected",
+      "credential_enumerate_rejected",
+    ]);
+    // enumerate rejection carries the prefix, not a key
+    expect(events[3]!.prefix).toBe("p.");
+  });
+
+  it("routes a denial through the auditTrail built-in policy", async () => {
+    const sink = vi.fn();
+    setSecretsPolicies([
+      auditTrail({ sink }),
+      { name: "acl", before: () => { throw new Error("blocked"); } },
+    ]);
+
+    await expect(storeCredential("auth-token", "value")).rejects.toThrow("blocked");
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0]![0]).toMatchObject({
+      type: "credential_write_rejected",
+      key: "auth-token",
+      error: "blocked",
+    });
+  });
+});
+
+// =============================================================================
 // Multiple policies compose
 // =============================================================================
 

--- a/packages/secrets/tests/policy.test.ts
+++ b/packages/secrets/tests/policy.test.ts
@@ -270,9 +270,17 @@ describe("policy before-hook rejection auditing", () => {
     // backend never ran, but the denial was audited
     expect(mockStoreString).not.toHaveBeenCalled();
     expect(events).toHaveLength(1);
-    expect(events[0]!.type).toBe("credential_write_rejected");
-    expect(events[0]!.key).toBe("auth-token");
-    expect(events[0]!.error).toBe("denied by acl");
+    const event = events[0]!;
+    expect(event.type).toBe("credential_write_rejected");
+    expect(event.key).toBe("auth-token");
+    expect(event.error).toBe("denied by acl");
+    // the rejection event is fully populated, not a partial stub
+    expect(event.backend).toBe("keychain");
+    expect(typeof event.durationMs).toBe("number");
+    expect(event.durationMs).toBeGreaterThanOrEqual(0);
+    // timestamp is a valid ISO-8601 instant
+    expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+    expect(Number.isNaN(Date.parse(event.timestamp))).toBe(false);
   });
 
   it("does NOT fire the rejecting policy's own after hook (its before did not complete)", async () => {

--- a/packages/secrets/tests/session-vault.test.ts
+++ b/packages/secrets/tests/session-vault.test.ts
@@ -752,6 +752,33 @@ describe("SessionVault — policy integration", () => {
     vault.close();
   });
 
+  it("audits a policy-rejected write via an already-entered policy (#120)", async () => {
+    seedVault(vaultPath, { existing: "v" }, 1);
+    seedSidecar(sidecarPath, 1);
+    const events: SecretsEvent[] = [];
+    setSecretsPolicies([
+      { name: "auditor", after: (e) => { events.push(e); } },
+      {
+        name: "no-writes",
+        before: (op: SecretsOperation): void => {
+          if (op.type === "write") throw new Error("writes blocked by policy");
+        },
+      },
+    ]);
+
+    const vault = await openVault({ path: vaultPath, sidecarPath });
+    await expect(vault.set("k", "v")).rejects.toThrow(/writes blocked by policy/);
+    vault.close();
+
+    // The denial is audited, not silent: the entered "auditor" policy's
+    // after-hook fires with a rejection event scoped to the session vault.
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("credential_write_rejected");
+    expect(events[0]!.backend).toBe("session-vault");
+    expect(events[0]!.key).toBe("k");
+    expect(events[0]!.error).toBe("writes blocked by policy");
+  });
+
   it("emits credential_read_missing for a non-existent key", async () => {
     seedVault(vaultPath, {}, 1);
     seedSidecar(sidecarPath, 1);

--- a/packages/secrets/tests/vault-libsecret.test.ts
+++ b/packages/secrets/tests/vault-libsecret.test.ts
@@ -14,7 +14,7 @@
  * exercises the secret-tool CLI parser — same as the pre-0.5.0 code.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockExecSync = vi.hoisted(() => vi.fn());
 const mockSessionBus = vi.hoisted(() => vi.fn());
@@ -106,6 +106,10 @@ beforeEach(() => {
   mockSessionBus.mockReset();
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 // ---------------------------------------------------------------------------
 // D-Bus primary path
 // ---------------------------------------------------------------------------
@@ -161,6 +165,10 @@ describe("LibsecretVault.listKeys — D-Bus path", () => {
 
 describe("LibsecretVault.listKeys — secret-tool fallback", () => {
   beforeEach(() => {
+    // Pin these to the bus-less (expected-fallback) case so they neither
+    // emit the degradation warning nor consume its one-time-per-process
+    // guard, keeping the warning tests below deterministic.
+    vi.stubEnv("DBUS_SESSION_BUS_ADDRESS", "");
     mockSessionBus.mockImplementation(() => {
       throw new Error("no session bus available");
     });
@@ -215,5 +223,51 @@ describe("LibsecretVault.listKeys — secret-tool fallback", () => {
       expect(key).not.toContain("secret");
       expect(key).not.toContain("super-secret-value");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D-Bus → secret-tool degradation warning (#121)
+//
+// Reverting from the secure D-Bus path to secret-tool (which briefly
+// materializes secret values on stdout) is a security-relevant
+// degradation that must not be silent — UNLESS the host simply has no
+// session bus, which is the documented, expected fallback case.
+// ---------------------------------------------------------------------------
+
+describe("LibsecretVault.listKeys — D-Bus degradation warning", () => {
+  beforeEach(() => {
+    mockSessionBus.mockImplementation(() => {
+      throw new Error("dbus connection refused");
+    });
+    mockExecSync.mockReturnValue(SAMPLE_SECRET_TOOL_OUTPUT);
+  });
+
+  it("warns once when a session bus is advertised but the D-Bus path fails", async () => {
+    vi.stubEnv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/1000/bus");
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const vault = new LibsecretVault();
+
+    const first = await vault.listKeys();
+    await vault.listKeys(); // second call must not warn again (one-shot)
+
+    expect(first).toContain("auth-token"); // fallback still returns keys
+    expect(stderr).toHaveBeenCalledTimes(1);
+    expect(String(stderr.mock.calls[0]![0])).toMatch(/D-Bus enumeration failed/);
+
+    stderr.mockRestore();
+  });
+
+  it("stays quiet on a bus-less host (no DBUS_SESSION_BUS_ADDRESS)", async () => {
+    vi.stubEnv("DBUS_SESSION_BUS_ADDRESS", "");
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const vault = new LibsecretVault();
+
+    const result = await vault.listKeys();
+
+    expect(result).toContain("auth-token");
+    expect(stderr).not.toHaveBeenCalled();
+
+    stderr.mockRestore();
   });
 });


### PR DESCRIPTION
Closes **#120** and **#121** — the two ADR-002 P0 gaps surfaced by the scoped `cl-adr-audit` re-run (both survived adversarial refutation).

## #120 — policy-rejected operations are now audited (ADR-002 §1.0.0)

Before: a `before` policy hook that rejected an operation by throwing propagated to the caller but fired **no `after` event** — a denied credential op left no audit trace, the exact gap ADR-002 line 158 warns against. The `policy.ts` docstring even contradicted the ADR.

After: `runBeforeHooks` implements the documented behavior — on a before-hook throw at policy `i`, the `after` hooks of the **already-entered** policies (`0..i-1`, bottom-to-top) fire with a new `*_rejected` event, then the original error re-throws. The rejecting policy's own `after` hook is skipped (its `before` did not complete). Wired through both the cascade vault (`store`/`get`/`delete`/`listCredential`) and the session vault's `withAudit` helper.

- `SecretsEventType` gains `credential_{read,write,delete,enumerate}_rejected`.
- New exported `rejectedEventType(op)` is the single source of truth for the op→event mapping.

## #121 — libsecret D-Bus→secret-tool fallback is no longer silent

The `secret-tool search` fallback briefly materializes secret values on stdout, so reverting to it from the secure D-Bus enumeration path is a security-relevant degradation. The bare `catch {}` now emits a **one-time stderr warning when a session bus is advertised (`DBUS_SESSION_BUS_ADDRESS` set) yet the D-Bus path still fails** — the path that should have worked didn't. A genuinely bus-less host (SSH/headless) stays quiet, since the fallback is the documented, expected behavior there.

## Tests

- `policy.test.ts` — rejection fires entered-only after-hooks; first-policy throw is a no-op; per-operation rejected event type; routing through the `auditTrail` built-in.
- `session-vault.test.ts` — a policy-denied write is audited via `withAudit` (`credential_write_rejected`, `backend: session-vault`).
- `vault-libsecret.test.ts` — warns once when bus advertised + D-Bus fails; stays quiet on a bus-less host. Existing fallback tests pinned bus-less for determinism.

234 secrets tests pass; `tsc --noEmit` clean. Changeset: `@centient/secrets` minor (additive event types + exported helper).

## Notes
- No ADR-002 doc change: the code now **conforms** to its line-158 commitment (the audit flagged code↛ADR divergence, not an ADR error). The contradicting `policy.ts`/`vault.ts` docstrings were reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)