### PR TITLE
chore(.agent): sync canonical docs from standards (ADR-005)

### DIFF
--- a/.agent/DESIGN-PHILOSOPHY.md
+++ b/.agent/DESIGN-PHILOSOPHY.md
@@ -1,6 +1,7 @@
+<!-- cl-sync src=f0142478 -->
 # Design Philosophy
 
-This document defines the design philosophy for this project. These principles guide architectural decisions, tool implementations, and integration patterns. They exist to produce systems that are **efficient, honest, observable, and resilient**.
+This document defines the design philosophy for this project. These principles guide architectural decisions, tool implementations, and integration patterns. They exist to produce systems that are **efficient, accurate, observable, and resilient**.
 
 The principles are organized into three tiers:
 
@@ -24,7 +25,7 @@ Fix underlying problems, not symptoms. Central solutions over per-handler workar
 
 Errors must be explicit, visible, and actionable at the point they occur. Never silently swallow failures or return empty results that could mean either "nothing found" or "search failed."
 
-This does not mean the system should crash on every edge case. It means: when something goes wrong or falls back to a lower-confidence path, the caller must know. A function that returns `null` when the database is unreachable is lying. A function that returns `{ ok: false, error: { code: "DB_TIMEOUT" } }` is honest.
+This does not mean the system should crash on every edge case. It means: when something goes wrong or falls back to a lower-confidence path, the caller must know. A function that returns `null` when the database is unreachable is lying. A function that returns `{ ok: false, error: { code: "DB_TIMEOUT" } }` is truthful.
 
 **Clarification — "silent" is the key word.** This principle prohibits *hiding* degradation, not degradation itself. A system that falls back to a simpler algorithm when the primary fails is fine — as long as the response indicates the fallback path was used (`method: "fallback"`, `confidence: 0.60`). The violation is returning results without indicating they came from a fallback path. See also: P14 (Resilient Under Load) addresses *performance* degradation separately from *accuracy/completeness* degradation governed here.
 
@@ -60,7 +61,7 @@ Functions and APIs should behave predictably. Same inputs produce same outputs. 
 
 Every fact should live in exactly one place. When two systems disagree, surface the conflict — don't pick a winner silently. Validation happens at system boundaries, not deep inside internal logic. Internal code trusts its own data structures. Trust is established at ingestion, then carried forward.
 
-**Clarification — relationship to P11 (Honest Uncertainty).** "Single source of truth" defines *where* authoritative data lives, not that the data is infallible. The authoritative store may contain data with varying confidence levels. P6 says "don't duplicate the data elsewhere"; P11 says "surface how confident the single source is." One source, with calibrated confidence.
+**Clarification — relationship to P11 (Explicit Uncertainty).** "Single source of truth" defines *where* authoritative data lives, not that the data is infallible. The authoritative store may contain data with varying confidence levels. P6 says "don't duplicate the data elsewhere"; P11 says "surface how confident the single source is." One source, with calibrated confidence.
 
 **Litmus test:** Is there a second place where this data is stored or derived independently?
 
@@ -98,7 +99,7 @@ This is the proactive complement to P1 (Root Cause Over Bandaid). P1 says "when 
 
 **Litmus test:** When building a capability for concept X, can you name the category X belongs to? Have you confirmed the capability applies to every other member of that category?
 
-### 11. Honest Uncertainty
+### 11. Explicit Uncertainty
 
 When the system doesn't know something, it should say so. Every response should allow the caller to distinguish between confirmed absence and uncertain absence. Surface confidence when applicable.
 
@@ -152,7 +153,7 @@ When principles conflict, use these resolution rules:
 | "Errors visible" vs "idempotent writes" | P2 vs P8 | Idempotent no-ops are not errors. Return success with `already_exists` — don't disguise as new work, don't treat as failure. |
 | "Surface everything" vs "progressive disclosure" | P2 vs P7 | Structural transparency is mandatory (error codes always present). Verbose detail is proportional to complexity. |
 | "Composable tools" vs "minimize cost" | P9 vs P12 | Never merge different responsibilities to save calls. Always allow batching of the same responsibility. |
-| "Single source" vs "honest uncertainty" | P6 vs P11 | One authoritative store with calibrated confidence. "Single source" means "don't duplicate," not "infallible." |
+| "Single source" vs "explicit uncertainty" | P6 vs P11 | One authoritative store with calibrated confidence. "Single source" means "don't duplicate," not "infallible." |
 | "Predictable" vs "evolving" | P5 vs P3 | Evolve capabilities, preserve contracts. Existing inputs produce equivalent outputs; new capabilities are additive. |
 | "Build for all members" vs "composable tools" | P10 vs P9 | Categorical Symmetry requires uniform *infrastructure* (same pipeline, same data contract, same observability). Composability governs *boundaries* (separate responsibilities). Symmetric treatment doesn't mean one mega-function — it means shared underlying abstractions composed through appropriate interfaces. |
 | "Secure posture" vs "authority placement" | P15 vs P16 | P15 governs *provisioning posture* (read-only default, intentional provisioning). P16 governs *placement* — which side of the isolation boundary a credential/action runs on. Intentionally provisioning a secret into the untrusted-code sandbox still violates P16; "provisioned intentionally" must also mean "provisioned to the protected side." |

--- a/.agent/constraints/communication.md
+++ b/.agent/constraints/communication.md
@@ -1,3 +1,4 @@
+<!-- cl-sync src=b0d82f20 -->
 # Communication Constraints
 
 Style and tone directives that apply to every agent operating in
@@ -29,8 +30,4 @@ based on the file structure, not the runtime behavior") rather than
 claiming honesty. Specific uncertainty is informative; generic hedging is
 not.
 
-## Repo-specific
-
-<!-- Append repo-specific communication conventions here: domain
-     terminology rules, customer-facing tone guidelines, audience-specific
-     constraints, etc. -->
+Repo-specific additions: see `communication-local.md` (loaded alongside this file).

--- a/.agent/constraints/observability.md
+++ b/.agent/constraints/observability.md
@@ -1,20 +1,24 @@
+<!-- cl-sync src=81f5f8dc -->
 # Observability Constraints
 
-Principles: P4 (Observable Architecture), P11 (Cost-Aware), P12 (Auditability), P13 (Resilient Under Load)
+Principles: P4 (Observable Architecture), P12 (Cost-Aware), P13 (Auditability), P14 (Resilient Under Load)
 
 ## Mutation Audit Trail
 
 Every write operation must be traceable:
+
 - **Who** requested it (user, agent, system)
 - **When** it occurred (ISO 8601 timestamp)
 - **What** changed (before/after or diff)
 - **Why** it happened (context, trigger, reason)
 
-Audit trails are not a compliance afterthought — they enable the system to observe and improve itself.
+Audit trails are not a compliance afterthought — they enable the system to
+observe and improve itself.
 
 ## Cost Tracking
 
 External API calls must be tracked:
+
 - Count calls per operation type
 - Track latency per external service
 - Monitor batch sizes and cache hit rates
@@ -25,6 +29,7 @@ Caching and deduplication are requirements, not optimizations.
 ## Performance Envelopes
 
 The system should know and communicate its limits:
+
 - Define batch size caps with clear error messages
 - Set timeout budgets for external calls
 - Pre-warm expensive resources at startup (not on first request)
@@ -32,15 +37,22 @@ The system should know and communicate its limits:
 
 ## Structured Logging
 
-- Use structured logger (not console.log/print)
+- Use a structured logger (not `console.log` or `print`)
 - Include correlation IDs for request tracing
-- Log at appropriate levels: error (broken), warn (degraded), info (lifecycle), debug (diagnostic)
+- Log at appropriate levels:
+  - `error` — broken
+  - `warn` — degraded
+  - `info` — lifecycle events
+  - `debug` — diagnostic detail
 - Never log secrets, tokens, PII, or credentials
-- Log errors with context: what failed, what was attempted, what the caller should do
+- Log errors with context: what failed, what was attempted, what the caller
+  should do
 
 ## Health Signals
 
-- Expose health check endpoints
+- Expose health check endpoints for services
 - Report dependency status (database, external APIs)
 - Distinguish between "healthy", "degraded", and "unhealthy"
 - Include uptime, last successful operation, error counts
+
+Repo-specific additions: see `observability-local.md` (loaded alongside this file).

--- a/.agent/constraints/security-local.md
+++ b/.agent/constraints/security-local.md
@@ -1,0 +1,92 @@
+<!-- migrated from .agent/constraints/security.md repo-specific region (ADR-005) -->
+## Repo-specific (migrated — review)
+
+<!-- Migrated from the repo's prior (older-template) security.md during the
+     P16 sync. The generic sections below are superseded by the canonical
+     content above and kept only for the npm-publishing rules specific to
+     this package; trim the redundant parts on review. -->
+
+# Security Constraints
+
+Principles: P14 (Secure by Default), P12 (Auditability)
+
+## Default Posture: Read-Only (P14)
+
+External integrations are read-only unless explicitly configured for writes. Write operations require intentional approval flows — never escalate access implicitly.
+
+## Secrets
+
+### Never commit secrets
+- API keys, tokens, passwords
+- Private keys, certificates
+- Database connection strings with credentials
+
+### Use environment variables
+```bash
+# Good - reference from environment
+DATABASE_URL=${DATABASE_URL}
+
+# Bad - hardcoded
+DATABASE_URL=postgres://user:password@host/db
+```
+
+### Required files
+- `.env.example` - Template with placeholder values
+- `.env` - Actual values (gitignored)
+
+## Input Validation
+
+### Validate at system boundaries (P14)
+- API request handlers
+- CLI argument parsing
+- File uploads
+- User-provided URLs
+
+Internal code trusts its own data structures. Trust is established at ingestion, then carried forward.
+
+### Sanitize paths
+```typescript
+// Good - resolve and verify
+const resolved = path.resolve(userPath);
+if (!resolved.startsWith(allowedBase)) {
+  throw new Error('Invalid path');
+}
+
+// Bad - direct use
+fs.readFile(userPath);
+```
+
+## Mutation Traceability (P12)
+
+Every write operation must be auditable:
+- Who requested the change
+- What was changed (before/after)
+- When it occurred
+- Why (context, trigger)
+
+This is a security requirement, not just compliance. Audit trails detect unauthorized changes and enable incident response.
+
+## Cloud CLI Safety
+
+### Blocked commands (without explicit permission)
+- `fly deploy`, `fly secrets`
+- `aws`, `gcloud`, `az`
+- `vercel`, `netlify`
+- `terraform apply`, `pulumi up`
+
+### Allowed read-only operations
+- `fly status`, `fly logs`
+- Status checks and log viewing
+
+## Dependency Security
+
+- Review new dependencies before adding
+- Keep dependencies updated
+- Use lockfiles (package-lock.json, yarn.lock, etc.)
+- Check for known vulnerabilities (`npm audit`)
+
+## npm Publishing Security
+
+- Never publish with embedded secrets
+- Use npm provenance for supply chain integrity
+- Changesets action handles publishing (not manual `npm publish`)

--- a/.agent/constraints/security.md
+++ b/.agent/constraints/security.md
@@ -1,3 +1,4 @@
+<!-- cl-sync src=cc938958 -->
 # Security Constraints
 
 Principles: P15 (Secure by Default), P16 (Authority Outside the Sandbox)
@@ -78,13 +79,13 @@ config.local.json
 # Good
 DATABASE_URL=${DATABASE_URL}
 
-# Bad
-DATABASE_URL=postgres://user:password@host/db
+# Bad — real credentials inlined (placeholders shown; never commit actual ones)
+DATABASE_URL=postgres://<credentials>@<host>/<db>
 ```
 
 ```typescript
-// Bad — hardcoded
-const API_KEY = "sk-abc123...";
+// Bad — hardcoded (placeholder shown; never commit a real key)
+const API_KEY = "<key>";
 
 // Bad — logging secrets
 console.error(`Using API key: ${apiKey}`);
@@ -120,8 +121,13 @@ git diff --staged | grep -iE "(api_key|password|secret|token|credential)" && ech
 import path from "path";
 
 function validatePath(userPath: string, allowedBase: string): boolean {
-  const resolved = path.resolve(allowedBase, userPath);
-  return resolved.startsWith(allowedBase);
+  const base = path.resolve(allowedBase);
+  const resolved = path.resolve(base, userPath);
+  // Compare by path segment, not string prefix: `/project` must NOT accept
+  // `/project-sibling/secret`. Allow the base itself or anything under base/.
+  // Note: an empty/"." userPath resolves to base (allowed). If "no path" should
+  // be an error in your context, reject empty input before calling this.
+  return resolved === base || resolved.startsWith(base + path.sep);
 }
 
 // Usage
@@ -133,9 +139,13 @@ if (!validatePath(requestedFile, projectRoot)) {
 ### Sanitize home-directory paths in output
 
 ```typescript
+import path from "path";
+
 function sanitizePath(p: string): string {
   const home = process.env.HOME || process.env.USERPROFILE || "";
-  if (home && p.startsWith(home)) return "~" + p.slice(home.length);
+  // Segment-aware AND cross-platform: `/home/john` must NOT rewrite
+  // `/home/johnson/...`; use path.sep so it works on Windows (`\`) too.
+  if (home && (p === home || p.startsWith(home + path.sep))) return "~" + p.slice(home.length);
   return p;
 }
 
@@ -154,7 +164,9 @@ Never expose stack traces, queries, or internal paths in error responses:
 // Bad
 return { error: { message: error.stack } };
 
-// Good
+// Good — sanitizeError maps an internal error to a safe, generic message
+// (no stack/query/path); define it once per project, e.g.:
+//   const sanitizeError = (e: unknown) => "An internal error occurred";
 return {
   error: {
     code: "INTERNAL_ERROR",
@@ -172,6 +184,7 @@ human-initiated only. Blocked unless the human explicitly invokes:
 |-----|---------|
 | `fly`, `flyctl` | Fly.io |
 | `vercel` | Vercel |
+| `netlify` | Netlify |
 | `aws` | Amazon Web Services |
 | `gcloud` | Google Cloud |
 | `az` | Microsoft Azure |
@@ -216,94 +229,4 @@ If you discover a security vulnerability:
 2. Contact maintainers directly
 3. Allow reasonable time for fix before disclosure
 
-## Repo-specific (migrated — review)
-
-<!-- Migrated from the repo's prior (older-template) security.md during the
-     P16 sync. The generic sections below are superseded by the canonical
-     content above and kept only for the npm-publishing rules specific to
-     this package; trim the redundant parts on review. -->
-
-# Security Constraints
-
-Principles: P14 (Secure by Default), P12 (Auditability)
-
-## Default Posture: Read-Only (P14)
-
-External integrations are read-only unless explicitly configured for writes. Write operations require intentional approval flows — never escalate access implicitly.
-
-## Secrets
-
-### Never commit secrets
-- API keys, tokens, passwords
-- Private keys, certificates
-- Database connection strings with credentials
-
-### Use environment variables
-```bash
-# Good - reference from environment
-DATABASE_URL=${DATABASE_URL}
-
-# Bad - hardcoded
-DATABASE_URL=postgres://user:password@host/db
-```
-
-### Required files
-- `.env.example` - Template with placeholder values
-- `.env` - Actual values (gitignored)
-
-## Input Validation
-
-### Validate at system boundaries (P14)
-- API request handlers
-- CLI argument parsing
-- File uploads
-- User-provided URLs
-
-Internal code trusts its own data structures. Trust is established at ingestion, then carried forward.
-
-### Sanitize paths
-```typescript
-// Good - resolve and verify
-const resolved = path.resolve(userPath);
-if (!resolved.startsWith(allowedBase)) {
-  throw new Error('Invalid path');
-}
-
-// Bad - direct use
-fs.readFile(userPath);
-```
-
-## Mutation Traceability (P12)
-
-Every write operation must be auditable:
-- Who requested the change
-- What was changed (before/after)
-- When it occurred
-- Why (context, trigger)
-
-This is a security requirement, not just compliance. Audit trails detect unauthorized changes and enable incident response.
-
-## Cloud CLI Safety
-
-### Blocked commands (without explicit permission)
-- `fly deploy`, `fly secrets`
-- `aws`, `gcloud`, `az`
-- `vercel`, `netlify`
-- `terraform apply`, `pulumi up`
-
-### Allowed read-only operations
-- `fly status`, `fly logs`
-- Status checks and log viewing
-
-## Dependency Security
-
-- Review new dependencies before adding
-- Keep dependencies updated
-- Use lockfiles (package-lock.json, yarn.lock, etc.)
-- Check for known vulnerabilities (`npm audit`)
-
-## npm Publishing Security
-
-- Never publish with embedded secrets
-- Use npm provenance for supply chain integrity
-- Changesets action handles publishing (not manual `npm publish`)
+Repo-specific additions: see `security-local.md` (loaded alongside this file).

--- a/.agent/patterns/api-design.md
+++ b/.agent/patterns/api-design.md
@@ -1,10 +1,11 @@
+<!-- cl-sync src=45e004cb -->
 # API Design Pattern
 
-Principles: P5 (Least Surprise), P6 (Single Source of Truth), P7 (Progressive Disclosure), P8 (Idempotency)
+Principles: P5 (Least Surprise), P6 (Single Source of Truth), P7 (Progressive Disclosure), P8 (Idempotency), P9 (Composability)
 
 ## Response Contract
 
-Every API response should allow the caller to understand what happened:
+Every API response should let the caller understand what happened:
 
 ```typescript
 // Good — caller knows what happened
@@ -32,8 +33,7 @@ async function createUser(email: string): Result<User> {
 
 // Bad — throws on duplicate, forcing caller to handle non-exceptional condition
 async function createUser(email: string): User {
-  // throws "duplicate key" on retry
-  return db.create({ email });
+  return db.create({ email }); // throws "duplicate key" on retry
 }
 ```
 
@@ -55,7 +55,7 @@ The simple case should be simple. Scale detail with complexity:
 ## Single Source of Truth
 
 - One authoritative store per data type
-- Validate at system boundaries, trust internal data structures
+- Validate at system boundaries; trust internal data structures
 - When sources disagree, surface the conflict — don't pick a winner silently
 - Echo interpreted parameters so callers see what the system understood
 
@@ -65,3 +65,5 @@ The simple case should be simple. Scale detail with complexity:
 - Different responsibilities stay separate (search vs transform vs format)
 - Same responsibility can be batched (search 20 items in one call)
 - Callers compose workflows; functions don't assume context
+
+Repo-specific additions: see `api-design-local.md` (loaded alongside this file).

--- a/.agent/patterns/error-handling.md
+++ b/.agent/patterns/error-handling.md
@@ -1,12 +1,14 @@
+<!-- cl-sync src=f14cdcfb -->
 # Error Handling Pattern
 
-Principles: P2 (No Silent Degradation), P8 (Idempotency), P10 (Honest Uncertainty)
+Principles: P2 (No Silent Degradation), P8 (Idempotency), P11 (Explicit Uncertainty)
 
 ## Core Rule
 
 **Return errors, don't throw them** (where language allows).
 
-Explicit error handling makes control flow visible and forces callers to handle failures.
+Explicit error handling makes control flow visible and forces callers to
+handle failures.
 
 ## No Silent Degradation (P2)
 
@@ -15,25 +17,28 @@ Every error path must be distinguishable from a success path:
 ```typescript
 // Good — caller can tell what happened
 { ok: false, error: { code: "DB_TIMEOUT", message: "Database unreachable" } }
-{ ok: true, value: [], method: "fallback_cache" }  // degraded but honest
+{ ok: true, value: [], method: "fallback_cache" }  // degraded but truthful
 
 // Bad — "no results" is ambiguous
 { results: [] }  // is this empty or broken?
 ```
 
-**Rule:** Never return empty results when the operation failed. Surface the failure mode.
+**Rule:** Never return empty results when the operation failed. Surface the
+failure mode.
 
 ## Structured Error Format
 
 Errors should include:
-- **code**: Machine-readable identifier (e.g., `USER_NOT_FOUND`)
-- **message**: Human-readable description
-- **component**: Where the error originated (optional)
-- **recovery**: What the caller should do (optional)
+
+- **code** — machine-readable identifier (e.g., `USER_NOT_FOUND`)
+- **message** — human-readable description
+- **component** — where the error originated (optional)
+- **recovery** — what the caller should do (optional)
 
 ## Result Type Pattern
 
-### TypeScript/JavaScript
+### TypeScript / JavaScript
+
 ```typescript
 type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
 
@@ -47,6 +52,7 @@ function findUser(id: string): Result<User, AppError> {
 ```
 
 ### Go
+
 ```go
 func FindUser(id string) (*User, error) {
     user, err := db.Find(id)
@@ -55,6 +61,28 @@ func FindUser(id string) (*User, error) {
     }
     return user, nil
 }
+```
+
+### Python
+
+```python
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+@dataclass
+class Ok(Generic[T]):
+    value: T
+    ok: bool = True
+
+@dataclass
+class Err:
+    code: str
+    message: str
+    ok: bool = False
+
+Result = Ok[T] | Err
 ```
 
 ## Idempotent Error Handling (P8)
@@ -69,7 +97,7 @@ Write operations that encounter duplicates are **not errors**:
 throw new Error("duplicate key");
 ```
 
-## Honest Uncertainty (P10)
+## Explicit Uncertainty (P11)
 
 Distinguish between confirmed absence and uncertain absence:
 
@@ -89,3 +117,5 @@ Distinguish between confirmed absence and uncertain absence:
 4. Use typed errors for expected failure cases
 5. Surface fallback paths: if using a cache instead of live data, say so
 6. Distinguish "not found" from "couldn't look"
+
+Repo-specific additions: see `error-handling-local.md` (loaded alongside this file).

--- a/.agent/patterns/known-pitfalls.md
+++ b/.agent/patterns/known-pitfalls.md
@@ -1,3 +1,4 @@
+<!-- cl-sync src=a50f30c5 -->
 # Known Pitfalls
 
 Org-wide ecosystem traps that have bitten multiple repos and are worth
@@ -125,10 +126,4 @@ where developer agents have no merge rights. `.agent/procedures/pr-response.md`
 (when a repo has it) and the user-level `pr-shepherd` skill must be
 consistent with this behavior; if there's a conflict, the classifier wins.
 
-## Repo-specific
-
-<!-- Append repo-specific pitfalls here. Examples:
-     - Daemon process gotchas (port conflicts, log file paths)
-     - Domain-specific data quirks (timezone artifacts, encoding edge cases)
-     - Build-system traps (cache invalidation conditions, lockfile drift)
-     - Project-specific CLI footguns -->
+Repo-specific additions: see `known-pitfalls-local.md` (loaded alongside this file).

--- a/.agent/procedures/commits.md
+++ b/.agent/procedures/commits.md
@@ -1,3 +1,4 @@
+<!-- cl-sync src=969b8c8b -->
 # Commit Procedures
 
 ## Commit Format
@@ -9,88 +10,90 @@ Use conventional commits:
 
 [optional body]
 
-[optional footer]
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
+**Subject line is all lowercase.** Acronyms like UI/UX, API, ADR must be
+written lowercase (`ui/ux`, `api`, `adr`). Commitlint rejects uppercase
+subjects.
+
 ### Types
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation only
-- `style`: Formatting, no code change
-- `refactor`: Code change that neither fixes nor adds
-- `test`: Adding or updating tests
-- `chore`: Build process, dependencies
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or functionality |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `test` | Adding or updating tests |
+| `refactor` | Code change that neither fixes nor adds |
+| `chore` | Build, CI, dependencies, configs |
 
 ### Scopes
-- `sdk`: @centient/sdk package
-- `logger`: @centient/logger package
-- `wal`: @centient/wal package
-- `python`: sdk-python package
-- `monorepo`: Root-level changes
 
-### Examples
-```
-feat(sdk): add ambient context resource
-
-fix(logger): handle null transport gracefully
-
-docs(wal): update replay API documentation
-
-chore(monorepo): upgrade turbo to 2.9.0
-```
-
-## Changesets Workflow
-
-This project uses [Changesets](https://github.com/changesets/changesets) for versioning:
-
-1. After making changes, add a changeset:
-   ```bash
-   pnpm changeset
-   ```
-2. Select affected packages and semver bump type
-3. Commit the changeset file with your changes
-4. On merge to main, CI creates a "Version Packages" PR
-5. Merging that PR publishes to npm
-
-**Never bump versions manually in package.json.**
-
-**Never run `pnpm changeset publish` directly** — `make publish` is the
-only publish path; it gates on a clean `origin/main` tree, runs the full
-check both before and after the version bump, and syncs the CLAUDE.md
-package table. The sole exception is the recovery flow in RELEASING.md,
-immediately after a `make publish` run in which `check` already passed.
-For the same reason, version bumps go through `pnpm run version-packages`
-(invoked by `make publish`), never bare `pnpm changeset version` — the
-bare command skips the CLAUDE.md sync.
-
-## Branch Workflow
-
-1. Create feature branch from main
-   ```bash
-   git checkout -b feat/description
-   ```
-
-2. Make atomic commits (one logical change per commit)
-
-3. Push and create pull request
-   ```bash
-   git push -u origin feat/description
-   ```
-
-4. After review, merge via PR (squash or merge commit)
+Define in `.agent/procedures/commits.md` under `## Repo-specific`. Common
+patterns: monorepo package names, module names, or omit the scope for
+single-package repos.
 
 ## Pre-commit Checklist
 
-- [ ] Tests pass locally (`pnpm test`)
-- [ ] Types check (`pnpm build` succeeds)
-- [ ] No secrets in diff
+- [ ] Files staged (`git add <files>`)
+- [ ] Lint passes (`make lint` or toolchain equivalent)
+- [ ] Tests pass (`make test`)
+- [ ] No secrets in diff (`git diff --staged | grep -iE "api_key|password|secret|token"`)
 - [ ] Commit message follows format
-- [ ] Changeset added if user-facing change
+- [ ] Co-Author line included
+
+## Branch Workflow
+
+1. Create feature branch from main:
+   ```bash
+   git checkout -b feat/description
+   ```
+2. Make atomic commits (one logical change per commit)
+3. Push and open a PR:
+   ```bash
+   git push -u origin feat/description
+   gh pr create --base main
+   ```
+4. The maintainer bot (or a human reviewer) approves and merges via squash.
+
+**Never push directly to `main`.** Branch protection enforces PR-only workflow
+on Tier A repos; even where it doesn't, treat direct-to-main as prohibited.
+
+**Prefer independent PRs — do not stack.** Branch **every** PR off `main`. If a PR
+references another unmerged PR, still branch off `main` and note the dependency in
+the PR body — doc cross-references resolve once both land; do not branch one PR off
+another. Stack **only** for a true *content* dependency (your code cannot build or
+test without the other PR's code). When you must stack: the base merges first, then
+**rebase the child onto `main`** before merging it, and **never squash-merge or
+force-push a PR whose head is the base of an open child** — it rewrites the base's
+SHAs and strands the child, which is how a "merged" stacked PR can land its content
+on a dead branch instead of `main`.
+
+## Anti-patterns
+
+```bash
+# BAD — vague message
+git commit -m "updates"
+
+# BAD — uppercase subject
+git commit -m "Fix: resolve bug"
+
+# BAD — mixed changes
+git commit -m "feat: add feature and fix bug and update docs"
+
+# GOOD — specific, lowercase, single concern
+git commit -m "feat(search): add semantic ranking to query results"
+```
 
 ## Attribution
 
 When Claude assists with code:
+
 ```
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
+
+Never commit under a real person's identity for AI-assisted work.
+
+Repo-specific additions: see `commits-local.md` (loaded alongside this file).

--- a/.agent/procedures/handoff-creation.md
+++ b/.agent/procedures/handoff-creation.md
@@ -1,3 +1,4 @@
+<!-- cl-sync src=65dcaf5d -->
 # Handoff Creation Procedure
 
 When and how to write a session handoff. A handoff is a single file that lets
@@ -27,8 +28,16 @@ Skip when:
 
 ## Where it goes
 
-`docs/handoffs/HANDOFF-YYYY-MM-DD-topic.md` (e.g.,
-`docs/handoffs/HANDOFF-2026-05-09-shepherd-system.md`).
+`docs/handoffs/YYYY-MM-DD-HANDOFF-topic.md` (e.g.,
+`docs/handoffs/2026-05-09-HANDOFF-shepherd-system.md`).
+
+**Date-first, then the uppercase type token, then the kebab descriptor**
+(`<date>-<TYPE>-<descriptor>.md`). Date-first makes a directory of mixed
+dated docs (handoffs, audits, retros) sort chronologically in one listing;
+a type-first name only sorts within its own prefix. Legacy
+`HANDOFF-YYYY-MM-DD-topic.md` files remain readable (the kickoff procedure
+normalizes both forms when sorting) — `git mv` them to date-first when you
+next touch them.
 
 For workspace-meta repos without a `docs/` directory, a top-level `HANDOFF.md`
 is acceptable as a current-snapshot file — but rotate to `docs/handoffs/`
@@ -61,22 +70,28 @@ Minimum sections (see `handoff-template.md` for the fillable structure):
    fi
    mkdir -p docs/handoffs && \
      cp -n .agent/procedures/handoff-template.md \
-           "docs/handoffs/HANDOFF-$(date +%Y-%m-%d)-${topic}.md"
+           "docs/handoffs/$(date +%Y-%m-%d)-HANDOFF-${topic}.md"
    ```
    `cp -n` exits non-zero without overwrite if the destination already
    exists; re-run with a different `topic` if you hit that case.
-2. Fill in sections top-to-bottom. The template marks each section
+2. **Fill the YAML frontmatter completely.** It is the machine-readable
+   contract: session-start hooks and `/cl-resume-session` parse it instead
+   of the prose. `engram_session` is the exact `sessionId` this session
+   passed to `start_session_coordination` (so the next session can
+   `load_session` deterministically); `handoff_issue` is back-filled after
+   the handoff issue is created; use `null` — never a blank — for fields
+   that don't apply.
+3. Fill in sections top-to-bottom. The template marks each section
    **(required)** or **(optional)**:
    - **Required sections** (the minimum-section set above) must remain
      in the file. If a required section has nothing real to say, write
      a one-line `n/a — <reason>` rather than deleting the heading.
    - **Optional sections** can be deleted cleanly when they don't apply.
      Empty optional sections rot; either fill them or remove them.
-3. Cite specific PRs / issues / commits with **full URLs**. Handoffs are
+4. Cite specific PRs / issues / commits with **full URLs**. Handoffs are
    read in fresh contexts where short refs are ambiguous.
-4. **Convert relative dates to absolute.** "Thursday" → "2026-05-15."
+5. **Convert relative dates to absolute.** "Thursday" → "2026-05-15."
    Handoffs outlive their relative time references.
-5. Date the file in its frontmatter or H1 subtitle.
 
 ## Anti-patterns
 
@@ -90,8 +105,4 @@ Minimum sections (see `handoff-template.md` for the fillable structure):
 - **Burying decisions.** Open questions and pending decisions go in their
   own section, not inline in narrative prose.
 
-## Repo-specific
-
-<!-- Append repo-specific handoff conventions here: storage location overrides,
-     naming conventions, required cross-references (e.g., ADR links),
-     cadence (every release, every incident, weekly). -->
+Repo-specific additions: see `handoff-creation-local.md` (loaded alongside this file).

--- a/.agent/procedures/handoff-template.md
+++ b/.agent/procedures/handoff-template.md
@@ -1,10 +1,22 @@
+<!-- cl-sync src=14125a82 -->
+---
+topic: <kebab-case-slug>
+date: YYYY-MM-DD
+author: <agent or operator name>
+engram_session: <sessionId passed to start_session_coordination, e.g. 2026-06-09-topic; null if MCP was unavailable>
+handoff_issue: <GitHub issue number for the handoff baton; null if --no-issue>
+predecessor: <previous handoff filename (repo-relative path) or null>
+---
+
 # Handoff: <one-line topic>
 
-**Date:** YYYY-MM-DD
-**Author:** <agent or operator name>
-**Predecessor:** <previous handoff filename, if any — repo-relative path or full GitHub URL>
-
-<!-- Copy this file to docs/handoffs/HANDOFF-YYYY-MM-DD-topic.md and fill in.
+<!-- Copy this file to docs/handoffs/YYYY-MM-DD-HANDOFF-topic.md and fill in.
+     (Date-first filename: dated docs sort chronologically in a directory
+     listing regardless of type.)
+     The YAML frontmatter above is machine-read by session-start hooks and
+     /cl-resume-session — fill every field; use null, not blank, when a
+     field doesn't apply. handoff_issue is filled in AFTER the issue is
+     created (the issue creation step edits it back in).
      Sections labelled (required) below are the minimum-section set
      enforced by procedures/handoff-creation.md — do not delete them. If
      a required section has nothing to say, write a one-line "n/a —

--- a/.agent/procedures/plan-gate.md
+++ b/.agent/procedures/plan-gate.md
@@ -1,0 +1,108 @@
+<!-- cl-sync src=1547b050 -->
+# Plan-Gate Procedure
+
+**Non-trivial work requires a committed, approved plan before a code PR opens.**
+This is the cheapest place to catch the costliest failure — an agent confidently
+building the wrong thing, caught only at diff review. The plan-gate moves
+correction to the **lowest-cost stage**: the plan is reviewed *before* any code is
+written (ADR-004 §4, the compound-engineering loop).
+
+Pairs with `procedures/session-kickoff.md` (step 4 grounds the plan in prior
+lessons — recall *feeds* the plan) and `procedures/commits.md` / handoff
+procedures (the work that follows an approved plan).
+
+## When the gate applies
+
+The gate applies to **non-trivial work** — anything beyond the trivial skip set.
+The boundary is the **same one** session-kickoff uses, kept single-source there:
+
+- **Exempt (trivial):** the trivial set defined in `session-kickoff.md` "When
+  to skip steps" — that file is the **single source** for the boundary (typo
+  fixes, single-line changes); this gate *inherits* it rather than re-defining
+  it, so the two never drift. Trivial work goes straight to a code PR; no plan
+  required.
+- **Gated (non-trivial):** new behavior, a new module or surface, a schema or
+  contract change, anything touching multiple files or with a non-obvious
+  architecture. If you would have to *decide* how to build it, the decision is
+  what the plan captures.
+
+When you are unsure which side a task falls on, it is gated. The plan is cheap;
+an unwound wrong-direction build is not.
+
+## What the plan must contain
+
+The plan carries the **crucible-plan shape** (the `/crucible-plan` skill already
+produces this; for smaller work, write the four fields by hand):
+
+1. **Objective** — what changes and why, in outcome terms. The success this
+   delivers, not the diff.
+2. **Proposed architecture** — where it lives, the components/interfaces
+   touched, the approach chosen and the alternatives rejected.
+3. **Research sources** — the grounding from `session-kickoff.md` step 4: prior
+   lessons, past PRs, existing patterns/constraints, ADRs, and any external
+   sources. Cite them; "have we solved this before?" answered, not skipped.
+4. **Success criteria** — how anyone confirms it works: the tests, the
+   acceptance checks, the `make check` gate. Concrete and verifiable.
+
+## Where the plan lives and who approves it
+
+The plan is **committed and reviewable before code** — pick the lightest vehicle
+that fits the work:
+
+| Work size | Plan vehicle | Approver |
+|-----------|-------------|----------|
+| Substantial / multi-wave | `docs/plans/PLAN-<topic>.md` (or a `/crucible-plan` artifact), or a dedicated plan issue | operator, or mbot on the plan issue/doc |
+| Moderate non-trivial | the tracking issue's description, carrying the four fields | operator, or mbot on the issue |
+
+Approval happens **at the plan stage**, before the code PR opens — that is the
+whole point of the gate. The code PR then **references the approved plan** (link
+the issue/doc), so the diff reviewer checks the code against an agreed target
+rather than re-deriving intent from the diff.
+
+(*mbot* = the centient-labs maintainer review bot — the same bot that reviews
+code PRs reviews the plan issue/doc here; see the maintainer-agent docs in
+`support/standards`.)
+
+## Strictness — the default and the open operator call
+
+**Default (this procedure): a convention-level gate.** Non-trivial work is
+*expected* to carry an approved plan before its code PR; the reviewer (mbot or
+operator) enforces it by norm — a code PR with no referenced, approved plan for
+clearly non-trivial work should be sent back to plan first.
+
+It is **not yet machine-enforced**: mbot reviews the output *diff*, and nothing
+mechanically blocks a code PR that lacks an approved plan. Hard enforcement
+(e.g. mbot or a `make check`-adjacent check that refuses a non-trivial code PR
+with no linked approved plan) is a **separate operator decision** — it trades
+up-front latency for a guarantee, and it needs a reliable trivial/non-trivial
+classifier to avoid taxing genuinely small changes. Treat the convention-level
+gate as the default until the operator opts into machine enforcement; the
+enforcement timeline lives in the ADR-004 rollout (§Rollout), not here.
+
+**Handling a violation.** Under the convention-level default, the reviewer
+bounce *is* the enforcement: a non-trivial code PR with no referenced, approved
+plan is sent back to write the plan first, not reviewed on its diff. A repeated
+pattern of bypass is the signal to escalate to the operator for hard
+enforcement — don't quietly let it become the norm.
+
+## Relationship to the rest of the loop
+
+- **Grounding (ADR-004 §3 / `session-kickoff.md` step 4) feeds the plan** — the
+  recall is the plan's "research sources" field, not a separate ritual.
+- **The codifier (ADR-004 §2) feeds future grounding** — recurring review
+  findings become standing rules the next plan inherits automatically, so the
+  plan-gate catches less over time.
+
+## Anti-patterns
+
+- **Opening the code PR first, plan after.** The gate is *before* code by
+  definition; a plan written to match an already-built diff has skipped the
+  cheap-correction stage entirely.
+- **A plan with no success criteria.** Without field 4 there is nothing to
+  approve against and nothing to verify the build against — it is a description,
+  not a plan.
+- **Gating trivial work.** Forcing a four-field plan onto a typo is the noise the
+  exemption exists to prevent. Respect the trivial skip set.
+- **Ungrounded plans.** A plan whose "research sources" are empty when prior
+  lessons exist re-creates the recall-on-demand failure ADR-004 §3 fixes. Ground
+  first (`session-kickoff.md` step 4), then plan.

--- a/.agent/procedures/session-kickoff.md
+++ b/.agent/procedures/session-kickoff.md
@@ -1,3 +1,4 @@
+<!-- cl-sync src=62d87ba6 -->
 # Session Kickoff Procedure
 
 What a fresh session does first, before any task-specific work. Pairs with
@@ -11,7 +12,8 @@ In order:
 
 1. **Read `CLAUDE.md`** (auto-loaded). Verify it has the design-philosophy
    pointer and the Session & Knowledge Management block.
-2. **Check for recent handoffs** at `docs/handoffs/HANDOFF-*.md`. The
+2. **Check for recent handoffs** at `docs/handoffs/YYYY-MM-DD-HANDOFF-*.md`
+   (legacy files may still be named `HANDOFF-YYYY-MM-DD-*.md`). The
    most recent one tells you what's in flight. Gate on the directory
    first so missing-dir is a clean no-op without globally silencing
    stderr (which would hide real I/O errors like permission denials
@@ -19,25 +21,47 @@ In order:
    ```bash
    latest=
    if [ -d docs/handoffs ]; then
-     latest=$(find docs/handoffs -maxdepth 1 -type f -name 'HANDOFF-*.md' | sort | tail -1)
+     latest=$(find docs/handoffs -maxdepth 1 -type f -name '*HANDOFF*.md' \
+       | awk -F/ '{key=$NF; sub(/^HANDOFF-/, "", key); print key "\t" $0}' \
+       | sort | tail -1 | cut -f2-)
    fi
    if [ -n "$latest" ]; then
      cat "$latest"
    fi
    # empty $latest = no handoff yet (safe under set -e)
    ```
-   The `YYYY-MM-DD` filename prefix makes lexicographic sort
-   chronological. Do NOT use mtime — it is affected by checkout order.
-   `-type f` filters out any directory that happens to match the glob.
-   Test the **value of `$latest`**, not the pipeline's `$?`: `find ...
-   | sort | tail` exits 0 whether or not anything matched, so `$?`
-   cannot distinguish "no handoff" from "I/O error" — only the value
-   of `$latest` can.
+   The date-first `YYYY-MM-DD` filename prefix makes lexicographic sort
+   chronological; the `awk` step normalizes legacy `HANDOFF-YYYY-MM-DD-*`
+   names to the same date-first key so old and new files sort together
+   (without it, every legacy name would sort after every date-first name,
+   since letters compare greater than digits). Do NOT use mtime — it is
+   affected by checkout order. `-type f` filters out any directory that
+   happens to match the glob. Test the **value of `$latest`**, not the
+   pipeline's `$?`: `find ... | sort | tail` exits 0 whether or not
+   anything matched, so `$?` cannot distinguish "no handoff" from "I/O
+   error" — only the value of `$latest` can.
 3. **Initialize the MCP session.** Call `mcp__centient__start_session_coordination`
    with `sessionId="YYYY-MM-DD-<keyword>"` and the absolute `projectPath`.
    See `procedures/session-management.md` for parameters.
-4. **Search memory for the task topic.** Call `mcp__centient__search_crystals`
-   with the keyword. Skim the top results for prior decisions.
+4. **Ground in prior lessons before planning** (required for non-trivial work —
+   ADR-004 §3). For anything beyond the trivial-task skip set below, loading
+   relevant prior lessons is a **non-skippable** step, not optional on-demand
+   recall. Two sources combine:
+   - the repo's **auto-loaded `.agent/` rules** are already in context (no
+     action needed) — the distilled standing rules every session inherits;
+   - **plus a mandatory engram recall**: call `mcp__centient__search_crystals`
+     with the task's keywords and read the top hits as **grounding, surfaced
+     before you plan** — phrase what you find as priming questions and
+     past-mistake examples, e.g.:
+     - *Where does this belong — have we solved this (or something close)
+       before, even in another repo?*
+     - *What did past PRs on this surface get wrong? What did a reviewer flag
+       last time?*
+     - *What standing rule or constraint already governs this area?*
+
+   Carry the answers into the plan (see `procedures/plan-gate.md`); do not start
+   writing code with the recall still unread. An empty recall is a result —
+   say so — not a reason to skip the step.
 5. **Check repo state** (fetch first — `git status -sb` only reports
    ahead/behind against locally-cached remote refs, which can be stale):
    ```bash
@@ -52,9 +76,16 @@ In order:
 
 ## When to skip steps
 
-- **Trivial tasks** (typo fixes, single-line changes): skip steps 3-5.
-- **MCP unavailable**: skip steps 3-4. Note in your first response so the
-  operator knows the knowledge layer is offline.
+- **Trivial tasks** (typo fixes, single-line changes): skip steps 3-5. The
+  grounding recall (step 4) is exempt **only** here — for all non-trivial work
+  it is required, not optional. This is the same trivial-task boundary the
+  plan-gate uses (`procedures/plan-gate.md`).
+- **MCP unavailable**: skip steps 3-4, but **do not skip grounding entirely** —
+  the engram recall is gone, not the grounding requirement. Fall back to the
+  always-in-context auto-loaded `.agent/` rules, plus a manual sweep of
+  `docs/handoffs/` and `git log` for prior lessons on this surface. Note in your
+  first response that the knowledge layer is offline so the operator knows the
+  engram recall didn't run and the grounding is degraded.
 - **No `docs/handoffs/`**: skip step 2 silently.
 - **No prior PRs by the agent**: step 5's `gh pr list` returns empty, which
   is fine.
@@ -67,6 +98,9 @@ By the end of the kickoff sequence, you should be able to answer:
 2. What PRs are open and at what review state?
 3. What did the previous session leave for this one?
 4. Are there active branches I should switch to, or stay off of?
+5. **If the work is non-trivial:** what prior lessons ground this task — past
+   mistakes, reviewer findings, or standing rules that already govern this area?
+   (Trivial tasks skip this — see "When to skip steps".)
 
 If you can't answer these, keep digging before starting the user's task.
 The kickoff is cheap; an uninformed first action is expensive.
@@ -80,14 +114,13 @@ The kickoff is cheap; an uninformed first action is expensive.
 - **Treating kickoff as ceremony.** If a step gives you nothing useful,
   that's a signal — note it, don't fail. But don't skip steps because
   "they probably won't help."
+- **Planning before grounding.** Starting to plan (or write code) on
+  non-trivial work with the step-4 recall still unread re-creates the
+  recall-on-demand failure ADR-004 §3 exists to fix — the lesson arrives
+  too late to change the plan. Recall first, plan with it in hand.
 - **Branching from a stale local `main`.** `git status -sb` reads
   locally-cached remote-tracking refs; without a preceding `git fetch`,
   ahead/behind counts may be hours or days out of date. Always fetch
   first (step 5 does this) before deciding whether to rebase or branch.
 
-## Repo-specific
-
-<!-- Append repo-specific kickoff steps here: daemon health checks,
-     cluster connectivity probes, project-specific status commands
-     (e.g., "maintainer status" before working on the maintainer repo),
-     credential verification. -->
+Repo-specific additions: see `session-kickoff-local.md` (loaded alongside this file).

--- a/.agent/procedures/session-management.md
+++ b/.agent/procedures/session-management.md
@@ -1,6 +1,10 @@
+<!-- cl-sync src=f2a557ef -->
 # Session & Knowledge Management
 
-Protocol for using the centient knowledge management system. The centient MCP server (`mcp__centient__*`) provides session memory and a cross-project knowledge graph. Consistent use prevents duplicate work, preserves context, and enables cross-project learning.
+Protocol for using the centient knowledge management system. The centient MCP
+server (`mcp__centient__*`) provides session memory and a cross-project
+knowledge graph. Consistent use prevents duplicate work, preserves context,
+and enables cross-project learning.
 
 ## Tool Reference
 
@@ -55,6 +59,8 @@ limit:  Number of results (default: 10)
 
 ## When NOT to Use
 
-- **Trivial tasks**: Quick typo fixes, single-line changes — no session needed
-- **Tools unavailable**: If `mcp__centient__*` tools aren't in the tool list, skip silently
-- **Read-only exploration**: Browsing code without making changes — search is still useful, but session lifecycle is optional
+- **Trivial tasks** — typo fixes, single-line changes. No session needed.
+- **Tools unavailable** — if `mcp__centient__*` is not in the tool list, skip
+  silently.
+- **Read-only exploration** — browsing code without making changes. Search is
+  still useful; the session lifecycle is optional.

--- a/.agent/tools/cl.md
+++ b/.agent/tools/cl.md
@@ -1,0 +1,67 @@
+<!-- cl-sync src=0cfc6826 -->
+# Tool: `cl` (the centient-labs workspace CLI)
+
+The `cl` binary is the agent's primary command surface for workspace, PR, engram,
+and cmux operations. Tool-neutral: applies to any agent (Claude, Codex, …).
+
+Authoritative live surface: `cl --help` and `cl <command> --help`. This file is
+the stable orientation + the conventions that do not change; it is **not** a flag
+reference (the command set grows — always confirm with `--help`).
+
+## Command families
+
+| Command | What it does |
+|---|---|
+| `cl tidy [branch] [--yes]` | Post-merge branch cleanup + repo sync. |
+| `cl repo <create\|move\|sync\|gitignore> [--execute]` | Workspace repo lifecycle (manifest-driven, band-prefixed managed repos). |
+| `cl pr <status\|watch> [--mine]` | **Read-only** PR query/watch over your open PRs. |
+| `cl merge-drain [--execute] [--watch[=s]] [--exclude/--only <repos>]` | **BREAK-GLASS** fallback merger — only when the mbot merge queue is down and merges are operator-authorized. Merges only PRs mbot APPROVED on their current head. |
+| `cl note <type> <title> <content>` | Write a knowledge crystal to engram. |
+| `cl recall <query>` | Search the engram knowledge store. |
+| `cl cmux-snapshot <save\|list\|show\|launch> [--execute]` | Save/relaunch a cmux working set (panes + commands + cwd). Must run inside a cmux pane. See [cmux.md](cmux.md). |
+
+(The set grows — e.g. a `cl init` to bootstrap the session/handoff convention into
+an arbitrary repo is planned. Always check `cl --help`.)
+
+## Conventions that hold across `cl`
+
+- **Dry-run by default; `--execute` to mutate.** `cl repo`, `cl merge-drain`, and
+  `cl cmux-snapshot launch` print the plan and change nothing without `--execute`.
+  Read the dry-run before executing.
+- **Read vs. write.** `cl pr`, `cl recall`, and the dry-run of any command are
+  read-only and always safe to run. The mutating `--execute` paths are not.
+
+## Operator-only (do not run these as an agent)
+
+Some `cl` paths perform **privileged / irreversible** actions that are reserved
+for an operator on a trusted workstation — an agent must not invoke them:
+
+- `cl repo create --execute` — creates a GitHub repo and applies a ruleset (a
+  `gh api` POST an agent's token is not authorized for).
+- `cl merge-drain --execute` — admin-merges PRs; run only under explicit
+  operator authorization (it is the break-glass path, not the normal one — the
+  mbot merge queue is the primary merger).
+- Anything that publishes (`make publish`), unlocks a vault, or rotates
+  credentials.
+
+When a task needs one of these, **stop and surface it to the operator** rather
+than attempting it.
+
+**The primary control is this documented policy plus agent compliance** — treat
+the list as a hard boundary and **do not rely on a technical block existing**.
+Some paths *do* have technical backstops (an agent's GitHub token cannot perform
+the `gh api` POST behind `cl repo create --execute`; admin-merge and the
+break-glass `merge-drain --execute` are gated by the harness's auto-mode
+classifier), but that coverage is **partial** — a new privileged path can ship
+before any control guards it. So the rule is compliance-first: when a task seems
+to need a privileged path, stop and ask the operator rather than testing whether
+it happens to be blocked.
+
+## Notes
+
+- `cl` is a **private** binary, installed from the private homebrew tap. Never
+  publish it (or `maintainer`) to a public tap.
+- Engram commands (`cl note`/`cl recall`) degrade cleanly when no engram daemon
+  is present — they are not required for `cl` to function.
+
+Repo-specific additions: see `cl-local.md` (loaded alongside this file).

--- a/.agent/tools/cmux.md
+++ b/.agent/tools/cmux.md
@@ -1,0 +1,80 @@
+<!-- cl-sync src=6aad84c8 -->
+# Tool: cmux (terminal multiplexer + built-in browser)
+
+How an agent **drives** cmux while working. cmux is a Ghostty-based terminal
+multiplexer that runs agents, terminals, and a **built-in browser** side by side
+in "workspaces," all scriptable from a bundled `cmux` CLI over a Unix socket.
+Tool-neutral: applies to any agent (Claude, Codex, …) running inside cmux.
+
+Authoritative live surface: `cmux --help` and `cmux docs <topic>`
+(`settings|api|browser|agents|dock|sidebars`). This file is the stable orientation
++ the non-obvious gotchas; it is not a flag reference.
+
+## Am I in cmux? Where is the CLI?
+
+- `env | grep CMUX_` — if `CMUX_WORKSPACE_ID` / `CMUX_SURFACE_ID` are set, you are
+  inside cmux. If not, every cmux capability below simply does not apply.
+- CLI: `cmux` (on PATH) or `$CMUX_BUNDLED_CLI_PATH`
+  (e.g. `/Applications/cmux.app/Contents/Resources/bin/cmux`).
+
+## Model
+
+`window` → `workspaces` (tabs) → `panes` (splits) → `surfaces`. A `surface` is a
+terminal, a browser, or an agent session. Target things by short ref
+(`workspace:1`, `pane:2`, `surface:3`), index, or UUID; `CMUX_WORKSPACE_ID` /
+`CMUX_SURFACE_ID` are the default targets, so most commands need no `--workspace`
+/ `--surface`.
+
+Orient: `cmux tree --all` (full map), `cmux list-workspaces`, `cmux list-panes`,
+`cmux current-workspace`.
+
+## Two capabilities worth reaching for
+
+1. **Read another pane's output yourself** — `cmux read-screen --surface
+   surface:5 --lines 30` (add `--scrollback` for history). Read a dev-server log
+   or a stack trace directly instead of asking the operator to paste it.
+
+2. **Drive the built-in browser** (no Chrome extension / MCP needed) — open one
+   with `cmux new-pane --type browser --url http://localhost:3000`, then:
+   - navigate/read: `cmux browser navigate <url>`, `reload`,
+     `wait --load-state complete`, `get url|title|text|html`
+   - interact: `cmux browser click|fill|type|select|press <…>`
+   - inspect: `cmux browser snapshot`, `screenshot --out <path>`, `eval <js>`,
+     `console list`
+
+   So you can load the app, fill a form, read the DOM, screenshot it, and check
+   console errors end-to-end — a first-class path for verifying UI changes.
+
+## Drive terminals
+
+- New pane: `cmux new-pane --type terminal --direction down`
+- Run a command: `cmux send --surface surface:5 "cd <path> && bin/dev"` then
+  `cmux send-key --surface surface:5 Enter`
+
+## Gotchas
+
+- **New panes open at `~`, not the project dir — `cd` first.**
+- **Refs renumber across an app restart** — re-run `cmux tree` after a reopen
+  before targeting anything by ref.
+- **`respawn-pane --command` is destructive** — it replaces the surface and runs
+  the command *as the pane's process*; if the command exits, the pane closes. Use
+  `send` + `send-key` to start a process instead.
+- **`resize-pane`** is relative pixels only, needs the pane focused AND its
+  workspace visible, and a full-edge pane must be resized from a neighbor.
+- **Persistence:** on relaunch cmux restores layout, browser URLs, and agent
+  sessions — but a plain terminal reopens as a **fresh login shell at `~`**: no
+  prior `cd`, and nothing exported in the old session survives. Re-establish the
+  working dir, any env vars / activated virtualenvs / `nvm`-style shell state, and
+  restart long-running processes (dev servers) — none of it auto-restores.
+- **Config:** `~/.config/cmux/cmux.json` (JSONC) — back it up, edit, then
+  `cmux reload-config` (no restart). Terminal font/theme/keybinds live in
+  `~/.config/ghostty/config`.
+
+## Related
+
+- `cl cmux-snapshot` (see [cl.md](cl.md)) saves/relaunches a cmux working set,
+  capturing per-pane command + cwd that `cmux tree` omits.
+- Operator-facing setup (install, socket access mode, Claude integration, auth)
+  is the cmux operator-onboarding runbook in the workspace repo.
+
+Repo-specific additions: see `cmux-local.md` (loaded alongside this file).

--- a/.agent/tools/packages.md
+++ b/.agent/tools/packages.md
@@ -1,0 +1,50 @@
+<!-- cl-sync src=095a9b8e -->
+# Tool: shared packages (`@centient/*` public + `@centient-labs/*` private)
+
+The org ships reusable libraries so common infrastructure is solved **once**.
+**Before hand-rolling logging, retries, subprocess handling, path sanitization,
+config loading, DAG scheduling, secrets, etc. — check whether a published package
+already does it, and depend on that.** Reimplementing what a package provides is a
+DRY/single-source violation (see DESIGN-PHILOSOPHY) and skips the package's
+hardening, tests, and security review. Tool-neutral: applies to any agent.
+
+This is an orientation registry; for the live API of any package read its README /
+types. Public packages are on the npm `@centient/*` scope; private ones are on the
+`@centient-labs/*` scope (GitHub Packages, private tap).
+
+## Public `@centient/*` (centient-sdk)
+
+| Package | Use it instead of hand-rolling… |
+|---|---|
+| `@centient/logger` | a logger; also home-dir / username **redaction** in log output. |
+| `@centient/resilience` | retry/backoff-with-jitter, circuit breaker, token-bucket rate limiter, LRU/TTL/SWR cache, bounded-concurrency pool. |
+| `@centient/proc` | raw `execFile`/`spawn` — a hardened subprocess runner with timeouts, SIGTERM→SIGKILL escalation, buffer caps, and unified typed errors. |
+| `@centient/path-security` | path-traversal validation + path-component sanitization (Result-typed). |
+| `@centient/config-loader` | layered config resolution (env > project > user > defaults) with caching, write-back, and project-root discovery. |
+| `@centient/secrets` | a secret store — cross-platform AES-256-GCM vault with platform-native key storage. |
+| `@centient/wal` | a write-ahead log / crash-recovery store, and `atomicWrite` / `atomicAppendLine`. |
+| `@centient/dag` | DAG scheduling — adjacency, cycle detection, topological sort, parallel waves, failure-cascade propagation. |
+| `@centient/events` | an ad-hoc event bus — typed event streaming with backpressure. |
+| `@centient/cli-utils` | terminal capability detection, ANSI color helpers, and semver-lite (parse/compare/satisfies). |
+| `@centient/sdk` | a hand-rolled engram/Centient client — the TypeScript SDK for agent memory + context engineering. |
+| `@centient/sdk-python` | the same, for Python consumers. |
+
+## Private `@centient-labs/*`
+
+| Package | Purpose |
+|---|---|
+| `@centient-labs/daemon` | The Centient daemon client/runtime (WebSocket delivery, PATH lookup, spawn). |
+
+> **Planned, not yet published** (workspace#85): `git-ops` (injection-safe git/GitHub
+> automation), `llm-cost` (pricing tables + usage→cost), `credential-pool`
+> (vault-backed rotating provider credentials + the `sk-ant-oat01` vs `sk-ant-api03`
+> mapper), `crystal-kit` (schema-validated crystal I/O + distributed lease lock).
+> Add each here as it lands.
+
+## Adopting a package
+
+- Add it to the consumer's `package.json` (public from npm; private from the
+  GitHub Packages registry — the repo's `.npmrc` already wires `${GITHUB_TOKEN}`).
+- Prefer replacing a hand-rolled equivalent over adding a parallel one.
+
+Repo-specific additions: see `packages-local.md` (loaded alongside this file).


### PR DESCRIPTION
Automated content-hash sync of .agent/ canonical globals from standards/templates/.agent/ per ADR-005. Where a global still held inline repo-specific content, that content is extracted VERBATIM into its `<name>-local.md` sibling in this same commit (atomic — no clobber window); pre-existing siblings are untouched. mbot review; do not force-push (this branch may base other PRs).